### PR TITLE
Switch bottom border on links to text-decoration

### DIFF
--- a/scss/_base_links.scss
+++ b/scss/_base_links.scss
@@ -9,7 +9,7 @@
     }
 
     &:hover {
-      border-bottom: 1px solid $color-link;
+      text-decoration: underline;
       cursor: pointer;
     }
 

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -20,8 +20,8 @@
       }
 
       &:visited {
-        border-bottom: 0;
         color: $color-dark;
+        text-decoration: none;
       }
 
       &.is-selected {
@@ -30,7 +30,6 @@
     }
 
     &--strong {
-      border-bottom-color: $color-link;
       color: $color-dark;
       font-weight: 400;
 
@@ -39,23 +38,20 @@
       }
 
       &:hover {
-        border-bottom-color: $color-link;
         color: $color-link;
+        text-decoration: underline;
       }
     }
 
     &--inverted {
-      border-bottom-color: $color-light;
       color: $color-light;
       font-weight: 400;
 
       &:hover {
-        border-bottom-color: $color-light;
         color: $color-light;
       }
 
       &:visited {
-        border-bottom-color: darken($color-light, 10%);
         color: darken($color-light, 10%);
       }
     }
@@ -68,11 +64,11 @@
 
     &__link {
       background: $color-x-light;
-      border-bottom: 0;
       float: right;
       margin-right: 5px;
       padding: 0 5px;
       position: relative;
+      text-decoration: none;
       top: -.725rem;
     }
   }


### PR DESCRIPTION
## Done

- Switch bottom border on links to text-decoration

## QA

- Pull code
- Run `jekyll gulp`
- Go to:
  - http://127.0.0.1:4000/vanilla-framework/examples/patterns/links/links-back-to-top/
  - http://127.0.0.1:4000/vanilla-framework/examples/patterns/links/links-external/
  - http://127.0.0.1:4000/vanilla-framework/examples/patterns/links/links-inverted/
  - http://127.0.0.1:4000/vanilla-framework/examples/patterns/links/links-soft/
  - http://127.0.0.1:4000/vanilla-framework/examples/patterns/links/links-strong/
- Check they all display in accordance with the [design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Links)


## Details

Fixes #840 