### PR TITLE
Replace instances of ubuntudesign with vanilla-framework

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -24,7 +24,7 @@ f99b11
 0f8420
 007aa6
 Sass
-ubuntudesign
+vanilla-framework
 LGPLv3
 Easings
 mixin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@ So, you'd like to contribute to Vanilla framework? Great!
 
 ## Bugs and issues
 
-We use the [GitHub issues](https://github.com/ubuntudesign/vanilla-framework/issues) to track all our bugs and feature requests.
+We use the [GitHub issues](https://github.com/vanilla-framework/vanilla-framework/issues) to track all our bugs and feature requests.
 
-When [submitting a new issue](https://github.com/ubuntudesign/vanilla-framework/issues/new), please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.
+When [submitting a new issue](https://github.com/vanilla-framework/vanilla-framework/issues/new), please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.
 
 Please provide as much information possible detailing what you're currently experiencing and what you'd expect to experience. 
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # Vanilla Framework
 
-[![Build Status](https://travis-ci.org/ubuntudesign/vanilla-framework.svg?branch=master)](https://travis-ci.org/ubuntudesign/vanilla-framework)
+[![Build Status](https://travis-ci.org/vanilla-framework/vanilla-framework.svg?branch=master)](https://travis-ci.org/vanilla-framework/vanilla-framework)
 [![npm version](https://badge.fury.io/js/vanilla-framework.svg)](http://badge.fury.io/js/vanilla-framework)
 [![Downloads](http://img.shields.io/npm/dm/vanilla-framework.svg)](https://www.npmjs.com/package/vanilla-framework)
-[![devDependency Status](https://david-dm.org/ubuntudesign/vanilla-framework/dev-status.svg)](https://david-dm.org/ubuntudesign/vanilla-framework#info=devDependencies)
+[![devDependency Status](https://david-dm.org/vanilla-framework/vanilla-framework/dev-status.svg)](https://david-dm.org/vanilla-framework/vanilla-framework#info=devDependencies)
 [![Chat in #vanilla-framework on Freenode](https://img.shields.io/badge/chat-%23vanilla--framework-blue.svg)](http://webchat.freenode.net/?channels=vanilla-framework)
 
 Vanilla Framework is a simple extensible CSS framework, built using [Sass](http://sass-lang.com/) and is designed to be used either directly or by using themes to extend or supplement its patterns.
 
 [Documentation](https://docs.vanillaframework.io) |
-[Project Task Board](https://waffle.io/ubuntudesign/vanilla-framework) | [Join the mailing list](https://lists.ubuntu.com/mailman/listinfo/vanilla-framework)
+[Project Task Board](https://waffle.io/vanilla-framework/vanilla-framework) | [Join the mailing list](https://lists.ubuntu.com/mailman/listinfo/vanilla-framework)
 
 ## Hotlinking
 
-On [the project homepage](http://ubuntudesign.github.io/vanilla-framework), find the link to the latest build to add directly into your markup:
+On [the project homepage](http://vanilla-framework.github.io/vanilla-framework), find the link to the latest build to add directly into your markup:
 
 ``` html
 <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-x.x.x.min.css" />

--- a/_jekyll/assets/example.js
+++ b/_jekyll/assets/example.js
@@ -12,7 +12,7 @@ x.onreadystatechange = function() {
 
 x.open(
     'GET',
-    'http://ubuntudesign.github.io/vanilla-framework/examples/base/code/',
+    'http://vanilla-framework.github.io/vanilla-framework/examples/base/code/',
     true
 );
 x.send(null);

--- a/docs/en/base/code.md
+++ b/docs/en/base/code.md
@@ -14,7 +14,7 @@ When you refer to code inline with other text, use the <code>&lt;code&gt;</code>
 
 If you want to refer to a larger piece of code, use <code>&lt;pre&gt;</code> together with the <code>&lt;code&gt;</code> tag.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/base/code/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/code/"
     class="js-example">
     View example of the base code block
 </a>

--- a/docs/en/base/forms.md
+++ b/docs/en/base/forms.md
@@ -6,7 +6,7 @@ title: Forms
 
 Vanilla form controls have global styling defined at the HTML element level. Labels and most input types are set to 100% width of the ```<form>``` parent element.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/base/forms/form"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/form"
     class="js-example">
     View example of a base form
 </a>
@@ -55,7 +55,7 @@ The attribute ```readonly``` disables the input but it still retains a default c
 
 Checkboxes and radio buttons are used for selecting one or multiple options, respectively.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/base/forms/checkboxes"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/checkboxes"
     class="js-example">
     View example of the base checkboxes
 </a>
@@ -69,7 +69,7 @@ Checkboxes and radio buttons are used for selecting one or multiple options, res
     <label for="Radio4">Radio option 3 - disabled</label>
 </form>
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/base/forms/radio-buttons"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/radio-buttons"
     class="js-example">
     View example of the base radio buttons
 </a>
@@ -78,14 +78,14 @@ Checkboxes and radio buttons are used for selecting one or multiple options, res
 
 The ```<select>``` element is used to create a drop-down list.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/base/forms/selects"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/selects"
     class="js-example">
     View example of the base selects
 </a>
 
 You can use the ```multiple``` attribute  to create a multiple select control.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/base/forms/select-multiple"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/select-multiple"
     class="js-example">
     View example of the base multiple selects
 </a>
@@ -103,7 +103,7 @@ Adding the ```[disabled="disabled"]``` attribute to an input will prevent user i
 
 Applying the classes ```.has-error```, ```.has-success``` or ```.has-warning``` to an input or label will style that element differently to provide visual feedback in case there is an error, success or warning notification related to the element.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/base/forms/feedback"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/feedback"
     class="js-example">
     View example of the base form feedback
 </a>
@@ -112,7 +112,7 @@ Applying the classes ```.has-error```, ```.has-success``` or ```.has-warning``` 
 
 You can use the ```<fieldset>``` element to divide the form into different logical sections.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/base/forms/fieldset"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/fieldset"
     class="js-example">
     View example of the base form fieldset
 </a>

--- a/docs/en/base/lists.md
+++ b/docs/en/base/lists.md
@@ -8,7 +8,7 @@ title: Lists
 
 Use an ordered list when the order of the items is important.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/base/lists/ordered-list/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/lists/ordered-list/"
     class="js-example">
     View example of the base ordered list
 </a>
@@ -17,7 +17,7 @@ Use an ordered list when the order of the items is important.
 
 Use an unordered list when the order of the items isn't important.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/base/lists/unordered-list/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/lists/unordered-list/"
     class="js-example">
     View example of the base unordered list
 </a>
@@ -26,7 +26,7 @@ Use an unordered list when the order of the items isn't important.
 
 Use a description list when you want to list a group of one or more terms and descriptions.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/base/lists/definition-list/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/lists/definition-list/"
     class="js-example">
     View example of the base definition list
 </a>

--- a/docs/en/base/table.md
+++ b/docs/en/base/table.md
@@ -4,7 +4,7 @@ title: Table
 
 # Table
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/base/table/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/table/"
     class="js-example">
     View example of the base table
 </a>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -4,17 +4,17 @@ title: Home
 
 ## A simple extensible CSS framework, written in Sass.
 
-[![Build Status](https://travis-ci.org/ubuntudesign/vanilla-framework.svg?branch=master)](https://travis-ci.org/ubuntudesign/vanilla-framework)
+[![Build Status](https://travis-ci.org/vanilla-framework/vanilla-framework.svg?branch=master)](https://travis-ci.org/vanilla-framework/vanilla-framework)
 [![npm version](https://badge.fury.io/js/vanilla-framework.svg)](http://badge.fury.io/js/vanilla-framework)
 [![Downloads](https://img.shields.io/npm/dm/vanilla-framework.svg)](https://www.npmjs.com/package/vanilla-framework)
-[![devDependency Status](https://david-dm.org/ubuntudesign/vanilla-framework/dev-status.svg)](https://david-dm.org/ubuntudesign/vanilla-framework#info=devDependencies)
+[![devDependency Status](https://david-dm.org/vanilla-framework/vanilla-framework/dev-status.svg)](https://david-dm.org/vanilla-framework/vanilla-framework#info=devDependencies)
 [![Chat in #vanilla-framework on Freenode](https://img.shields.io/badge/chat-%23vanilla--framework-blue.svg)](http://webchat.freenode.net/?channels=vanilla-framework)
 
 Vanilla Framework contains a basic CSS grid and pattern classes, and is designed to be extended either directly or by creating extension themes.
 
 Sites created within Canonical should follow this style guide closely, whereas external sites are free to adapt and expand the existing components to their needs.
 
-For ways to use Vanilla framework, see [ubuntudesign/vanilla-framework on GitHub](https://github.com/ubuntudesign/vanilla-framework).
+For ways to use Vanilla framework, see [vanilla-framework/vanilla-framework on GitHub](https://github.com/vanilla-framework/vanilla-framework).
 
 Code licensed [LGPLv3](http://opensource.org/licenses/lgpl-3.0.html) by [Canonical Ltd.](http://www.canonical.com/).
 

--- a/docs/en/patterns/breadcrumbs.md
+++ b/docs/en/patterns/breadcrumbs.md
@@ -4,7 +4,7 @@ title: Breadcrumbs
 
 # Breadcrumbs
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/breadcrumbs/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/breadcrumbs/"
     class="js-example">
     View example of the breadcrumbs pattern
 </a>

--- a/docs/en/patterns/card.md
+++ b/docs/en/patterns/card.md
@@ -14,7 +14,7 @@ All card styles, but in particular the highlighted card, should be used sparingl
 
 The purpose of the basic card is to display information, without user interaction.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/card/card/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/card/card/"
     class="js-example">
     View example of the default card pattern
 </a>
@@ -24,7 +24,7 @@ The purpose of the basic card is to display information, without user interactio
 
 The highlighted card should be used when you can interact with the content.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/card/highlighted/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/card/highlighted/"
     class="js-example">
     View example of the base definition list
 </a>

--- a/docs/en/patterns/code-numbered.md
+++ b/docs/en/patterns/code-numbered.md
@@ -10,7 +10,7 @@ Code numbered extends the [base styling of code](/base/code/).
 
 See also: [code snippet](/patterns/code-snippet/).
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/code-numbered/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/code-numbered/"
     class="js-example">
     View example of the code numbered pattern
 </a>

--- a/docs/en/patterns/code-snippet.md
+++ b/docs/en/patterns/code-snippet.md
@@ -8,7 +8,7 @@ title: Code snippet
 
 Code snippet should be used when presenting the user with a small snippet of code that they will likely want to copy and paste.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/code-snippets/code-snippet/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/code-snippets/code-snippet/"
     class="js-example">
     View example of the code snippet pattern
 </a>
@@ -16,7 +16,7 @@ Code snippet should be used when presenting the user with a small snippet of cod
 
 ## Dark
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/code-snippets/code-snippet-dark/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/code-snippets/code-snippet-dark/"
     class="js-example">
     View example of the dark code snippet pattern
 </a>

--- a/docs/en/patterns/footer.md
+++ b/docs/en/patterns/footer.md
@@ -4,7 +4,7 @@ title: Footer
 
 # Footer
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/footer/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/footer/"
     class="js-example">
     View example of the footer pattern
 </a>

--- a/docs/en/patterns/inline-images.md
+++ b/docs/en/patterns/inline-images.md
@@ -6,7 +6,7 @@ title: Inline images
 
 The Inline images pattern can be used to showcase a group of related images, such as a group of customer or partner logos.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/inline-images/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/inline-images/"
     class="js-example">
     View example of the inline images pattern
 </a>

--- a/docs/en/patterns/links.md
+++ b/docs/en/patterns/links.md
@@ -8,7 +8,7 @@ title: Links
 
 The `.p-link--external` class should be used on hyperlinks that go to a different domain than the current one. E.g.:
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/links/links-external/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/links/links-external/"
     class="js-example">
     View example of the external link pattern
 </a>
@@ -31,7 +31,7 @@ The `.p-link--no-underline` class should be used on hyperlinks where an underlin
 
 The `.p-top` link can be used to make it easier to go back to the top on long pages. If the page is divided into different sections, you can use more than one per page.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/links/links-back-to-top/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/links/links-back-to-top/"
     class="js-example">
     View example of the back to top pattern
 </a>

--- a/docs/en/patterns/lists.md
+++ b/docs/en/patterns/lists.md
@@ -6,42 +6,42 @@ title: Lists
 
 ## List
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/lists/list/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/lists/list/"
     class="js-example">
     View example of the list pattern
 </a>
 
 ## List with icon
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/lists/lists-ticked/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/lists/lists-ticked/"
     class="js-example">
     View example of the ticked list pattern
 </a>
 
 ## List with dividers
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/lists/lists-dividers/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/lists/lists-dividers/"
     class="js-example">
     View example of the divided list pattern
 </a>
 
 ## List with icons and dividers
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/lists/lists-dividers-ticked/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/lists/lists-dividers-ticked/"
     class="js-example">
     View example of the ticked divided list pattern
 </a>
 
 ## Inline list
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/lists/lists-inline/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/lists/lists-inline/"
     class="js-example">
     View example of the inline list pattern
 </a>
 
 ## Middot separated inline list
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/lists/lists-mid-dot/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/lists/lists-mid-dot/"
     class="js-example">
     View example of the middot list pattern
 </a>
@@ -49,7 +49,7 @@ title: Lists
 
 ## Stepped List
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/lists/lists-stepped/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/lists/lists-stepped/"
     class="js-example">
     View example of the stepped list pattern
 </a>

--- a/docs/en/patterns/matrix.md
+++ b/docs/en/patterns/matrix.md
@@ -6,7 +6,7 @@ title: Matrix
 
 Matrix items will display in one column on small screens. At resolutions above `$breakpoint-medium`, the matrix switches to three items per row.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/matrix/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/matrix/"
     class="js-example">
     View example of the matrix pattern
 </a>

--- a/docs/en/patterns/navigation.md
+++ b/docs/en/patterns/navigation.md
@@ -4,7 +4,7 @@ title: Navigation
 
 Note: You can constrain the width of the navigation to match the `$grid-max-width` by placing everything inside the header element within a `.row` wrapper.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/navigation/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/navigation/"
     class="js-example">
     View example of the navigation pattern
 </a>

--- a/docs/en/patterns/notification.md
+++ b/docs/en/patterns/notification.md
@@ -8,7 +8,7 @@ title: Notification
 
 Notifications are used to display global information. A notification will display at the top and fill the full width of the page. A notification can be a default, warning, negative or position.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/notifications/notifications"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/notifications/notifications"
     class="js-example">
     View example of the default notification pattern
 </a>
@@ -18,7 +18,7 @@ Notifications are used to display global information. A notification will displa
 
 This warning variant should be used to convey information that is not critical but the user should be aware of.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/notifications/warning/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/notifications/warning/"
     class="js-example">
     View example of the warning notification pattern
 </a>
@@ -27,7 +27,7 @@ This warning variant should be used to convey information that is not critical b
 
 This negative variant should be used to convey information that is critical and the user should take action.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/notifications/negative/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/notifications/negative/"
     class="js-example">
     View example of the negative notification pattern
 </a>
@@ -36,7 +36,7 @@ This negative variant should be used to convey information that is critical and 
 
 This positive variant should be used to convey information of success or completion.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/notifications/positive/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/notifications/positive/"
     class="js-example">
     View example of the positive notification pattern
 </a>
@@ -47,7 +47,7 @@ Notifications have the ability to add an action link to them. These should appea
 
 Note: All functionality must be developed in independently.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/notifications/action/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/notifications/action/"
     class="js-example">
     View example of the warning notification pattern
 </a>

--- a/docs/en/patterns/pull-quote.md
+++ b/docs/en/patterns/pull-quote.md
@@ -4,7 +4,7 @@ title: Pull quote
 
 # Pull quote
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/pull-quotes"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/pull-quotes"
     class="js-example">
     View example of the pull quote pattern
 </a>

--- a/docs/en/patterns/strip.md
+++ b/docs/en/patterns/strip.md
@@ -8,12 +8,12 @@ The strip pattern provides a full width strip container in which to wrap a row. 
 
 A `.p-strip` container should always be the parent of a `.row` and never the other way around.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/strips/strips-light/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/strips/strips-light/"
     class="js-example">
     View example of the strip light pattern
 </a>
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/strips/strips-dark/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/strips/strips-dark/"
     class="js-example">
     View example of the strip dark pattern
 </a>

--- a/docs/en/utilities/align.md
+++ b/docs/en/utilities/align.md
@@ -6,7 +6,7 @@ title: Align
 
 You can use these utilities to force the content inside an element to align center, left or right.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/utilities/content-align/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/content-align/"
     class="js-example">
     View example of the content align utility
 </a>

--- a/docs/en/utilities/clearfix.md
+++ b/docs/en/utilities/clearfix.md
@@ -10,7 +10,7 @@ The clearfix is a way to combat the zero-height container problem for floated el
 
 In the example below, the parent wrapping container does not collapse even though it's only two children are floated.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/utilities/clearfix/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/clearfix/"
     class="js-example">
     View example of the clearfix utility
 </a>

--- a/docs/en/utilities/embedded-media.md
+++ b/docs/en/utilities/embedded-media.md
@@ -6,7 +6,7 @@ title: Embedded media
 
 Embed media objects such as videos, maps and calendars.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/utilities/embedded-media/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/embedded-media/"
     class="js-example">
     View example of the embedded media utility
 </a>

--- a/docs/en/utilities/equal-height.md
+++ b/docs/en/utilities/equal-height.md
@@ -6,7 +6,7 @@ title: Equal height
 
 To ensure two or more elements have an equal height regardless of their content, add the class `.u-equal-height` to their wrapping parent element.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/utilities/equal-height/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/equal-height/"
     class="js-example">
     View example of the equal height utility
 </a>

--- a/docs/en/utilities/floats.md
+++ b/docs/en/utilities/floats.md
@@ -6,7 +6,7 @@ title: Floats
 
 The float utilities allow you to float an element left or right.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/utilities/floats/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/floats/"
     class="js-example">
     View example of the floats utility
 </a>

--- a/docs/en/utilities/margin-collapse.md
+++ b/docs/en/utilities/margin-collapse.md
@@ -6,7 +6,7 @@ title: Margin collapse
 
 Remove one or more margins of an element.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/utilities/margin-collapse/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/margin-collapse/"
     class="js-example">
     View example of the margin collapse utility
 </a>

--- a/docs/en/utilities/off-screen.md
+++ b/docs/en/utilities/off-screen.md
@@ -6,7 +6,7 @@ title: Off screen
 
 The `.u-off-screen` class will position an element out of the page flow and off-screen, while still making it available to screen readers.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/utilities/off-screen/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/off-screen/"
     class="js-example">
     View example of the off-screen utility
 </a>

--- a/docs/en/utilities/padding-collapse.md
+++ b/docs/en/utilities/padding-collapse.md
@@ -6,7 +6,7 @@ title: Padding collapse
 
 Remove one or more paddings on an element.
 
-<a href="https://ubuntudesign.github.io/vanilla-framework/examples/utilities/padding-collapse/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/padding-collapse/"
     class="js-example">
     View example of the padding collapse utility
 </a>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "bugs": {
     "email": "webteam@canonical.com",
-    "url": "http://github.com/ubuntudesign/vanilla-framework/issues"
+    "url": "http://github.com/vanilla-framework/vanilla-framework/issues"
   },
   "description": "A simple, extendable CSS framework.",
   "devDependencies": {
@@ -22,7 +22,7 @@
     "markdown-spellcheck": "^0.11.0",
     "wrench": "^1.5.9"
   },
-  "homepage": "http://ubuntudesign.github.io/vanilla-framework/",
+  "homepage": "http://vanilla-framework.github.io/vanilla-framework/",
   "keywords": [
     "ubuntu",
     "vanilla",
@@ -37,7 +37,7 @@
   "name": "vanilla-framework",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ubuntudesign/vanilla-framework"
+    "url": "https://github.com/vanilla-framework/vanilla-framework"
   },
   "scripts": {
     "clean": "rm -r build; rm -r node_modules"


### PR DESCRIPTION
Vanilla-framework has moved GitHub organisations to
vanilla-framework/vanilla-framework.

Therefore we should update all reference to ubuntudesign/vanilla-framework
with vanilla-framework/vanilla-framework.

This is especially important for the links to ubuntudesign.github.io, but
is useful everywhere.

QA
---

Check the README makes sense. Run the jekyll site and check it still works as expected. Check the links inside the docs pages work fine. Generally sanity check everything.