### PR TITLE
Prevent text-decoration:underline leaking into :after

### DIFF
--- a/scss/_patterns_footer.scss
+++ b/scss/_patterns_footer.scss
@@ -64,6 +64,10 @@
           top: .2rem;
         }
       }
+
+      &:hover::after {
+        color: $color-dark;
+      }
     }
   }
 }

--- a/scss/_patterns_footer.scss
+++ b/scss/_patterns_footer.scss
@@ -57,6 +57,7 @@
 
         &::after {
           content: '\00b7'; // Adds a middle dot
+          display: inline-block;
           font-size: 1.5rem;
           left: .5rem;
           position: relative;

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -85,6 +85,10 @@
         top: .55rem;
       }
 
+      &:hover::after {
+        color: $color-mid-dark;
+      }
+
       &:last-of-type,
       .last-item {
         &::after {


### PR DESCRIPTION
## Done

Prevent text-decoration:underline leaking into :after pseudo element

## QA

- Run `gulp jekyll`
- Navigate to [http://127.0.0.1:3002/vanilla-framework/examples/patterns/footer/](http://127.0.0.1:3002/vanilla-framework/examples/patterns/footer/)
- Roll over liks in footer and ensure no borders appear below the dots

## Details

Before: https://cl.ly/3J3f102f1f2b
After: https://cl.ly/2p473V1A1L0e

## Screenshots

Fixes #799
