### PR TITLE
Give inline button margin-top on small screens

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -5,9 +5,13 @@
   button {
     @include button-pattern;
     line-height: 1rem;
-    @media (min-width: $breakpoint-medium) {
 
-      span + & {
+    span + & {
+
+      @media (max-width: $breakpoint-medium) {
+        margin-top: 1.2rem;
+      }
+      @media (min-width: $breakpoint-medium) {
         margin-left: .5rem;
       }
     }


### PR DESCRIPTION
## Done

Give inline button margin-top on small screens

## QA

- Test the following markup on small screens in the button example page

```html
<span>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</span>
<button>Button</button>
```

The space between the button and inline text should be `1.2rem`, just as it would be if the `<span>` was a `<p>`

## Details

Fixes #855 
