### PR TITLE
Remove tablet snapshot from Percy command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
 script:
   - jekyll build
   - node_modules/gulp/bin/gulp.js test
-  - percy snapshot --widths "375,768,1280" _jekyll/_site/ --baseurl "/vanilla-framework"
+  - percy snapshot --widths "375,1280" _jekyll/_site/ --baseurl "/vanilla-framework"
 notifications:
   irc:
     channels:


### PR DESCRIPTION
## Done

Remove tablet snapshot from Percy command

## QA

Sanity check code, no QA required as we're currently over Percy quota so cannot be tested