### PR TITLE
Add viewport zoom to example template

### DIFF
--- a/_jekyll/_layouts/default.html
+++ b/_jekyll/_layouts/default.html
@@ -3,6 +3,7 @@
 <html>
     <head>
         <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{% if page.title %} {{ page.title }} | {% endif %} {{ site.name }}</title>
         {% if site.env == 'development' %}
         <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/build/css/build.css" />


### PR DESCRIPTION
## Done

This means that mobile views can now be tested correctly.

## QA

- Pull code
- Run `gulp jekyll`
- Go to a specific pattern, e.g. http://127.0.0.1:4000/vanilla-framework/
- Use a tool like Viewport Resizer to test that when on small screens, the patterns responds correctly.

## Details

Fixes #847

