### PR TITLE
Update breadcrumb pattern to work with lists

### DIFF
--- a/examples/patterns/breadcrumbs.html
+++ b/examples/patterns/breadcrumbs.html
@@ -3,9 +3,9 @@ layout: default
 title: Breadcrumbs
 category: _patterns
 ---
-<nav class="p-breadcrumbs">
-  <a class="p-breadcrumbs__link" href="#">Breadcrumb1</a>
-  <a class="p-breadcrumbs__link" href="#">Breadcrumb2</a>
-  <a class="p-breadcrumbs__link" href="#">Breadcrumb3</a>
-  <a class="p-breadcrumbs__link" href="#">Breadcrumb4</a>
-</nav>
+<ul class="p-breadcrumbs">
+  <li class="p-breadcrumbs__item"><a href="#">Breadcrumb1</a></li>
+  <li class="p-breadcrumbs__item"><a href="#">Breadcrumb2</a></li>
+  <li class="p-breadcrumbs__item"><a href="#">Breadcrumb3</a></li>
+  <li class="p-breadcrumbs__item">Breadcrumb4</li>
+</ul>

--- a/scss/_patterns_breadcrumbs.scss
+++ b/scss/_patterns_breadcrumbs.scss
@@ -2,9 +2,13 @@
 @mixin vf-p-breadcrumbs {
 
   .p-breadcrumbs {
+    list-style: none;
+    margin: 0;
+    padding: 0;
     width: 100%;
 
-    &__link {
+    &__item {
+      display: inline;
       font-weight: normal;
       margin-right: 1rem;
       position: relative;


### PR DESCRIPTION
## Done

Update breadcrumb pattern to work with lists

## QA

- Pull code
- Run `gulp jekyll`
- Check [http://127.0.0.1:4000/vanilla-framework/examples/patterns/breadcrumbs/](http://127.0.0.1:4000/vanilla-framework/examples/patterns/breadcrumbs/)

## Details

Fixes #827
