### PR TITLE
Add form validation pattern

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,3 +13,5 @@ destination: _jekyll/_site
 
 # Exclude metadata and development time dependencies (like Grunt plugins)
 exclude: ["*.md", "*.scss", "node_modules", "package.json", "Gemfile", "Gemfile.lock", "gulpfile.js", "gulp", "LICENSE"]
+
+port: 4321

--- a/docs/en/patterns/form-validation.md
+++ b/docs/en/patterns/form-validation.md
@@ -1,0 +1,16 @@
+---
+title: Form validation
+---
+
+# Error / Warning / Success states
+
+By wrapping ```<label>``` and input form elements in a wrapper called ```.p-form-validation```, you can then dynamically add state classes to indicate form field validation states.
+
+- ```.is-success```
+- ```.is-warning```
+- ```.is-error``` 
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/form-validation"
+    class="js-example">
+    View examples of form validation patterns
+</a>

--- a/examples/base/forms/input.html
+++ b/examples/base/forms/input.html
@@ -5,6 +5,6 @@ category: _base
 ---
 
 <form>
-    <label for="exampleTextInput">Label</label>
-    <input type="text" id="exampleTextInput" placeholder="Placeholder text" />
+  <label for="exampleTextInput">Label</label>
+  <input type="text" id="exampleTextInput" placeholder="Placeholder text" />
 </form>

--- a/examples/patterns/form-validation.html
+++ b/examples/patterns/form-validation.html
@@ -1,0 +1,39 @@
+---
+layout: default
+title: Forms / Validation
+category: _patterns
+---
+
+<form>
+  <div class="p-form-validation is-error">
+    <label for="exampleTextInputError">Error</label>
+    <input class="p-form-validation__input" type="text" id="exampleTextInputError" placeholder="Placeholder text" />
+    <p class="p-form-validation__message">
+      <strong>Error:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+    </p>
+  </div>
+
+  <div class="p-form-validation is-warning">
+    <label for="exampleTextInputWarning">Warning</label>
+    <input class="p-form-validation__input" type="text" id="exampleTextInputWarning" placeholder="Placeholder text" />
+    <p class="p-form-validation__message">
+      <strong>Warning:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+    </p>
+  </div>
+
+  <div class="p-form-validation is-success">
+    <label for="exampleTextInputSuccess">Success</label>
+    <input class="p-form-validation__input" type="text" id="exampleTextInputSuccess" placeholder="Placeholder text" />
+    <p class="p-form-validation__message">
+      <strong>Success:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+    </p>
+  </div>
+</form>
+
+<div class="p-form-validation is-success">
+  <label for="textarea">Label</label>
+  <textarea class="p-form-validation__input" id="textarea" rows="3">Textarea</textarea>
+  <p class="p-form-validation__message">
+    <strong>Success:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+  </p>
+</div>

--- a/examples/patterns/form-validation.html
+++ b/examples/patterns/form-validation.html
@@ -7,9 +7,7 @@ category: _patterns
 <form>
   <div class="p-form-validation is-error">
     <label for="exampleTextInputError">Error</label>
-    <div class="p-form-validation__icon">
-      <input class="p-form-validation__input" type="text" id="exampleTextInputError" placeholder="Placeholder text" />
-    </div>
+    <input class="p-form-validation__input" type="text" id="exampleTextInputError" placeholder="Placeholder text" />
     <p class="p-form-validation__message">
       <strong>Error:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
     </p>
@@ -17,9 +15,7 @@ category: _patterns
 
   <div class="p-form-validation is-warning">
     <label for="exampleTextInputWarning">Warning</label>
-    <div class="p-form-validation__icon">
-      <input class="p-form-validation__input" type="text" id="exampleTextInputWarning" placeholder="Placeholder text" />
-    </div>
+    <input class="p-form-validation__input" type="text" id="exampleTextInputWarning" placeholder="Placeholder text" />
     <p class="p-form-validation__message">
       <strong>Warning:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
     </p>
@@ -27,9 +23,7 @@ category: _patterns
 
   <div class="p-form-validation is-success">
     <label for="exampleTextInputSuccess">Success</label>
-    <div class="p-form-validation__icon">
-      <input class="p-form-validation__input" type="text" id="exampleTextInputSuccess" placeholder="Placeholder text" />
-    </div>
+    <input class="p-form-validation__input" type="text" id="exampleTextInputSuccess" placeholder="Placeholder text" />
     <p class="p-form-validation__message">
       <strong>Success:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
     </p>
@@ -38,9 +32,7 @@ category: _patterns
 
 <div class="p-form-validation is-success">
   <label for="textarea">Label</label>
-  <div class="p-form-validation__icon">
-    <textarea class="p-form-validation__input" id="textarea" rows="3">Textarea</textarea>
-  </div>
+  <textarea class="p-form-validation__input" id="textarea" rows="3">Textarea</textarea>
   <p class="p-form-validation__message">
     <strong>Success:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
   </p>

--- a/examples/patterns/form-validation.html
+++ b/examples/patterns/form-validation.html
@@ -7,7 +7,9 @@ category: _patterns
 <form>
   <div class="p-form-validation is-error">
     <label for="exampleTextInputError">Error</label>
-    <input class="p-form-validation__input" type="text" id="exampleTextInputError" placeholder="Placeholder text" />
+    <div class="p-form-validation__icon">
+      <input class="p-form-validation__input" type="text" id="exampleTextInputError" placeholder="Placeholder text" />
+    </div>
     <p class="p-form-validation__message">
       <strong>Error:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
     </p>
@@ -15,7 +17,9 @@ category: _patterns
 
   <div class="p-form-validation is-warning">
     <label for="exampleTextInputWarning">Warning</label>
-    <input class="p-form-validation__input" type="text" id="exampleTextInputWarning" placeholder="Placeholder text" />
+    <div class="p-form-validation__icon">
+      <input class="p-form-validation__input" type="text" id="exampleTextInputWarning" placeholder="Placeholder text" />
+    </div>
     <p class="p-form-validation__message">
       <strong>Warning:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
     </p>
@@ -23,7 +27,9 @@ category: _patterns
 
   <div class="p-form-validation is-success">
     <label for="exampleTextInputSuccess">Success</label>
-    <input class="p-form-validation__input" type="text" id="exampleTextInputSuccess" placeholder="Placeholder text" />
+    <div class="p-form-validation__icon">
+      <input class="p-form-validation__input" type="text" id="exampleTextInputSuccess" placeholder="Placeholder text" />
+    </div>
     <p class="p-form-validation__message">
       <strong>Success:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
     </p>
@@ -32,7 +38,9 @@ category: _patterns
 
 <div class="p-form-validation is-success">
   <label for="textarea">Label</label>
-  <textarea class="p-form-validation__input" id="textarea" rows="3">Textarea</textarea>
+  <div class="p-form-validation__icon">
+    <textarea class="p-form-validation__input" id="textarea" rows="3">Textarea</textarea>
+  </div>
   <p class="p-form-validation__message">
     <strong>Success:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
   </p>

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -4,6 +4,8 @@
   label {
     cursor: pointer;
     display: block;
+    font-size: 1rem;
+    line-height: 1.5;
 
     @each $state, $color in $states {
       &.has-#{$state} {
@@ -115,6 +117,7 @@
   // Textarea styles
   textarea {
     @extend %input-elements;
+    margin-bottom: .5rem;
     overflow: auto;
     vertical-align: top;
   }
@@ -163,13 +166,18 @@
   font-size: 1rem;
   font-weight: 300;
   outline: none;
-  padding: .6875rem .8125rem;
+  padding: .8rem .5333rem;
   vertical-align: baseline;
   width: 100%;
+
+  @media (min-width: $breakpoint-medium) {
+    padding: .75rem .5rem;
+  }
 
   &:active,
   &:focus {
     border-color: $color-mid-dark;
+    color: $color-dark;
     outline: none;
   }
 

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -20,7 +20,8 @@
     @extend %validation-wrapper;
 
     .p-form-validation__input { // Not using parent selector here as two classes are required to override atribute selectors in reset
-      margin-bottom: 0;
+      background-position: calc(100% - 1rem) 50%;
+      background-repeat: no-repeat;
       padding: .5rem 2.5rem .5rem .75rem;
     }
 
@@ -47,33 +48,24 @@
   .is-error {
 
     .p-form-validation__input {
+      background-image: url('#{$assets-path}4b0cd7fc-icon-error.svg');
       border-color: $color-negative;
-    }
-
-    .p-form-validation__icon::after {
-      content: url('#{$assets-path}4b0cd7fc-icon-error.svg');
     }
   }
 
   .is-success {
 
     .p-form-validation__input {
+      background-image: url('#{$assets-path}94949185-icon-success.svg');
       border-color: $color-positive;
-    }
-
-    .p-form-validation__icon::after {
-      content: url('#{$assets-path}94949185-icon-success.svg');
     }
   }
 
   .is-warning {
 
     .p-form-validation__input {
+      background-image: url('#{$assets-path}c41194d3-icon-warning.svg');
       border-color: $color-warning;
-    }
-
-    .p-form-validation__icon::after {
-      content: url('#{$assets-path}c41194d3-icon-warning.svg');
     }
   }
 }

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -17,13 +17,17 @@
     &::after {
       position: absolute;
       right: .75rem;
-      top: calc(50% - 8px);
+      top: calc(50% - 7px);
     }
   }
 
   .p-form-validation {
 
     @extend %validation-wrapper;
+
+    .p-form-validation__input { // Not using parent selector here as two classes are required to override atribute selectors in reset
+      padding: .5rem 2.5rem .5rem .75rem;
+    }
 
     &__message {
       font-size: .9333rem;

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -1,0 +1,69 @@
+// form validation styling for form inputs
+
+@mixin vf-p-form-validation {
+
+  %validation-wrapper {
+    color: $color-dark;
+    line-height: 1.5;
+    margin-bottom: 1rem;
+    margin-top: .5333rem;
+    position: relative;
+
+    @media (min-width: $breakpoint-medium) {
+      font-size: .875rem;
+      margin-top: .5rem;
+    }
+
+    &::after {
+      position: absolute;
+      right: .75rem;
+      top: calc(50% - 8px);
+    }
+  }
+
+  .p-form-validation {
+
+    @extend %validation-wrapper;
+
+    &__message {
+      font-size: .9333rem;
+
+      @media (min-width: $breakpoint-medium) {
+        font-size: .875rem;
+      }
+    }
+  }
+
+  .is-error {
+
+    .p-form-validation__input {
+      border-color: $color-negative;
+    }
+
+    &::after {
+      content: url('#{$assets-path}4b0cd7fc-icon-error.svg');
+    }
+  }
+
+  .is-success {
+
+    .p-form-validation__input {
+      border-color: $color-positive;
+    }
+
+    &::after {
+      content: url('#{$assets-path}94949185-icon-success.svg');
+    }
+  }
+
+  .is-warning {
+
+    .p-form-validation__input {
+      border-color: $color-warning;
+    }
+
+    &::after {
+      content: url('#{$assets-path}c41194d3-icon-warning.svg');
+    }
+  }
+}

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -20,8 +20,8 @@
     @extend %validation-wrapper;
 
     .p-form-validation__input { // Not using parent selector here as two classes are required to override atribute selectors in reset
-      padding: .5rem 2.5rem .5rem .75rem;
       margin-bottom: 0;
+      padding: .5rem 2.5rem .5rem .75rem;
     }
 
     .p-form-validation__icon {

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -13,12 +13,6 @@
       font-size: .875rem;
       margin-top: .5rem;
     }
-
-    &::after {
-      position: absolute;
-      right: .75rem;
-      top: calc(50% - 7px);
-    }
   }
 
   .p-form-validation {
@@ -27,6 +21,18 @@
 
     .p-form-validation__input { // Not using parent selector here as two classes are required to override atribute selectors in reset
       padding: .5rem 2.5rem .5rem .75rem;
+      margin-bottom: 0;
+    }
+
+    .p-form-validation__icon {
+
+      position: relative;
+
+      &::after {
+        position: absolute;
+        right: .75rem;
+        top: calc(50% - .5rem);
+      }
     }
 
     &__message {
@@ -44,7 +50,7 @@
       border-color: $color-negative;
     }
 
-    &::after {
+    .p-form-validation__icon::after {
       content: url('#{$assets-path}4b0cd7fc-icon-error.svg');
     }
   }
@@ -55,7 +61,7 @@
       border-color: $color-positive;
     }
 
-    &::after {
+    .p-form-validation__icon::after {
       content: url('#{$assets-path}94949185-icon-success.svg');
     }
   }
@@ -66,7 +72,7 @@
       border-color: $color-warning;
     }
 
-    &::after {
+    .p-form-validation__icon::after {
       content: url('#{$assets-path}c41194d3-icon-warning.svg');
     }
   }

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -44,7 +44,8 @@
 'patterns_navigation',
 'patterns_notifications',
 'patterns_pull-quotes',
-'patterns_strip';
+'patterns_strip',
+'patterns_form-validation';
 
 // Utilities
 @import
@@ -91,6 +92,7 @@
   @include vf-p-notification;
   @include vf-p-pull-quotes;
   @include vf-p-strip;
+  @include vf-p-form-validation;
   // Utilities
   @include vf-u-clearfix;
   @include vf-u-floats;


### PR DESCRIPTION
## Done

- Added form validation pattern

## QA

- Pull code
- Run `gulp jekyll`
- Compare [examples](http://127.0.0.1:4005/vanilla-framework/examples/patterns/form-validation/) to the [design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Forms)

Note: The spec states the icons should be 12px from the bottom - in practice, this is not enough:

![screen shot 2017-02-23 at 10 22 27](https://cloud.githubusercontent.com/assets/505570/23257113/4b8c8cb8-f9ba-11e6-906e-b802a02cac2d.png)

As they also need to work `<textarea>` elements also, I have vertically centred the icons instead.

## Details

Fixes #797 
