### PR TITLE
811 soft link override

### DIFF
--- a/examples/patterns/links/links-external.html
+++ b/examples/patterns/links/links-external.html
@@ -4,4 +4,4 @@ title: Links / External
 category: _patterns
 ---
 
-<a class="p-link--external">External link</a>
+<a href="#" class="p-link--external">External link</a>

--- a/examples/patterns/links/links-inverted.html
+++ b/examples/patterns/links/links-inverted.html
@@ -4,4 +4,4 @@ title: Links / Inverted
 category: _patterns
 ---
 
-<a class="p-link--inverted">inverted link</a>
+<a href="#" class="p-link--inverted">inverted link</a>

--- a/examples/patterns/links/links-soft.html
+++ b/examples/patterns/links/links-soft.html
@@ -4,4 +4,4 @@ title: Links / Soft
 category: _patterns
 ---
 
-<a class="p-link--soft">Soft link</a>
+<a href="#" class="p-link--soft">Soft link</a>

--- a/examples/patterns/links/links-strong.html
+++ b/examples/patterns/links/links-strong.html
@@ -4,4 +4,4 @@ title: Links / Strong
 category: _patterns
 ---
 
-<a class="p-link--strong">Strong link</a>
+<a href="#" class="p-link--strong">Strong link</a>

--- a/examples/patterns/links/links-without-underline.html
+++ b/examples/patterns/links/links-without-underline.html
@@ -4,6 +4,6 @@ title: Links / Links w/out underline
 category: _patterns
 ---
 
-<a class="p-link--no-underline" href="#">
+<a  href="#" class="p-link--no-underline">
     <img src="http://placehold.it/150x200" alt="Placeholder image" />
 </a>

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -15,13 +15,13 @@
     &--soft {
       color: $color-dark;
 
-      &:hover {
-        color: $color-link;
-      }
-
       &:visited {
         color: $color-dark;
         text-decoration: none;
+      }
+
+      &:hover {
+        color: $color-link;
       }
 
       &.is-selected {


### PR DESCRIPTION
## Done

- Ensure all link examples have a `href` attribute
- Prevent `:visited` color from overriding `:hover` color on `.p-link--soft`

## QA

- Pull code & `gulp jekyll`
- Check [example](http://127.0.0.1:4000/vanilla-framework/examples/patterns/links/links-soft/#) against [spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Links)

## Details

Fixes #811 