### PR TITLE
Add trailing slashes to example links

### DIFF
--- a/docs/en/base/forms.md
+++ b/docs/en/base/forms.md
@@ -6,14 +6,14 @@ title: Forms
 
 Vanilla form controls have global styling defined at the HTML element level. Labels and most input types are 100% width of the ```<form>``` parent element.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/form"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/form/"
     class="js-example">
     View example of a base form
 </a>
 
 ## Input elements
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/input"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/input/"
     class="js-example">
     View example of an input element
 </a>
@@ -26,7 +26,7 @@ Vanilla supports all HTML5 input types: ```text```, ```password```, ```datetime`
 
 The ```<textarea>``` tag defines a multi-line text input control.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/textarea"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/textarea/"
     class="js-example">
     View example of an input element
 </a>
@@ -37,12 +37,12 @@ Note: The attribute ```readonly``` disables the input but it still retains a def
 
 Use checkboxes and radio buttons to select one or more options.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/checkboxes"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/checkboxes/"
     class="js-example">
     View example of the base checkboxes
 </a>
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/radio-buttons"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/radio-buttons/"
     class="js-example">
     View example of the base radio buttons
 </a>
@@ -51,14 +51,14 @@ Use checkboxes and radio buttons to select one or more options.
 
 Use the ```<select>``` element to create a drop-down list.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/selects"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/selects/"
     class="js-example">
     View example of the base selects
 </a>
 
 Use the ```multiple``` attribute to create a multiple select control.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/select-multiple"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/select-multiple/"
     class="js-example">
     View example of the base multiple selects
 </a>
@@ -67,7 +67,7 @@ Use the ```multiple``` attribute to create a multiple select control.
 
 Adding the ```[disabled="disabled"]``` attribute to an input will prevent user interaction. All disabled inputs have an opacity of ```0.5``` and ```not-allowed``` cursor on hover.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/disabled-input"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/disabled-input/"
     class="js-example">
     View example of a disabled input
 </a>  
@@ -76,7 +76,7 @@ Adding the ```[disabled="disabled"]``` attribute to an input will prevent user i
 
 Applying the classes ```.has-error```, ```.has-success``` or ```.has-warning``` to an input or label will style that element differently to provide visual feedback in case there is an error, success or warning notification related to the element.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/feedback"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/feedback/"
     class="js-example">
     View example of the base form feedback
 </a>
@@ -85,7 +85,7 @@ Applying the classes ```.has-error```, ```.has-success``` or ```.has-warning``` 
 
 You can use the ```<fieldset>``` element to divide the form into different logical sections.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/fieldset"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/fieldset/"
     class="js-example">
     View example of the base form fieldset
 </a>

--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -8,14 +8,14 @@ All text in Vanilla uses the Ubuntu typeface.
 
 Vanilla's typographic scale has a base font size of 14 pixels (small screens) and a font weight of 300.  At the medium breakpoint, the base font size is 15 pixels, and at the large breakpoint it is 16 pixels.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/headings"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/headings/"
     class="js-example">
     View example of the base headings
 </a>
 
 ## Blockquotes and citations
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/blockquotes"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/blockquotes/"
     class="js-example">
     View example of the base blockquotes
 </a>

--- a/docs/en/patterns/buttons.md
+++ b/docs/en/patterns/buttons.md
@@ -12,7 +12,7 @@ You can apply `button` classes on buttons and link elements.
 
 A base button is usually used alongside a neutral button.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/buttons/base"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/buttons/base/"
     class="js-example">
     View example of the base button pattern
 </a>
@@ -21,7 +21,7 @@ A base button is usually used alongside a neutral button.
 
 A neutral button can be used to indicate a positive action that isn't necessarily the main call-to-action.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/buttons/neutral"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/buttons/neutral/"
     class="js-example">
     View example of the neutral button pattern
 </a>
@@ -30,7 +30,7 @@ A neutral button can be used to indicate a positive action that isn't necessaril
 
 A positive button can be used to indicate a positive action that is the main call-to-action.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/buttons/positive"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/buttons/positive/"
     class="js-example">
     View example of the positive button pattern
 </a>
@@ -39,7 +39,7 @@ A positive button can be used to indicate a positive action that is the main cal
 
 A negative button can be used to indicate a negative action that is destructive or permanent.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/buttons/neutral"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/buttons/neutral/"
     class="js-example">
     View example of the negative button pattern
 </a>
@@ -48,7 +48,7 @@ A negative button can be used to indicate a negative action that is destructive 
 
 You can use the brand button with the main color of your brand.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/buttons/brand"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/buttons/brand/"
     class="js-example">
     View example of the brand button pattern
 </a>
@@ -57,7 +57,7 @@ You can use the brand button with the main color of your brand.
 
 Should you wish to place a button after a line of inline text, as a CTA for example, you can do so by wrapping the text in a `<span>` and placing the button immediately after it.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/buttons/inline"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/buttons/inline/"
     class="js-example">
     View example of the inline button pattern
 </a>

--- a/docs/en/patterns/form-validation.md
+++ b/docs/en/patterns/form-validation.md
@@ -8,9 +8,9 @@ By wrapping ```<label>``` and input form elements in a wrapper called ```.p-form
 
 - ```.is-success```
 - ```.is-warning```
-- ```.is-error``` 
+- ```.is-error```
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/form-validation"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/form-validation/"
     class="js-example">
     View examples of form validation patterns
 </a>

--- a/docs/en/patterns/headings.md
+++ b/docs/en/patterns/headings.md
@@ -6,7 +6,7 @@ title: Headings
 
 Heading classes can be added to text elements to give them the same visual appearance as base h1, h2, h3, etc., elements.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/headings"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/headings/"
     class="js-example">
     View example of the headings pattern
 </a>

--- a/docs/en/patterns/notification.md
+++ b/docs/en/patterns/notification.md
@@ -8,7 +8,7 @@ title: Notification
 
 Notifications are used to display global information. A notification will display at the top and fill the full width of the page. A notification can be a default, warning, negative or position.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/notifications/notifications"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/notifications/notifications/"
     class="js-example">
     View example of the default notification pattern
 </a>

--- a/docs/en/patterns/pull-quote.md
+++ b/docs/en/patterns/pull-quote.md
@@ -4,10 +4,10 @@ title: Pull quote
 
 # Pull quote
 
-Use the pull quote pattern to highlight content from different sources in a 
+Use the pull quote pattern to highlight content from different sources in a
 visually prominent way.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/pull-quotes"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/pull-quotes/"
     class="js-example">
     View example of the pull quote pattern
 </a>

--- a/docs/en/utilities/vertically-center.md
+++ b/docs/en/utilities/vertically-center.md
@@ -6,7 +6,7 @@ title: Vertically center
 
 The `.u-vertically-center` class will vertically center the direct child of the element it is placed on.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/vertically-center"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/vertically-center/"
     class="js-example">
     View example of the vertically center util
 </a>


### PR DESCRIPTION
## Done
Found that example links without trailing slashes load over http. I'm not 100% sure why as they are linking to https. This will now make all available examples work.

## QA
- This is a strange one to QA but go to https://docs.vanillaframework.io/en/base/forms.
- Inspect the first example link
- Add a trailing slash to the href `https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/form/`
- Switch to the console and run the follow command to retrigger example-js: `document.querySelectorAll('.js-example').forEach(renderExample);`
- See that the example loads correctly.

## Details
Fixes https://github.com/ubuntudesign/docs.vanillaframework.io/issues/73