### PR TITLE
Adjust the spacing of the pull quote

### DIFF
--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -15,12 +15,20 @@
       @extend %heading-3;
       color: $color-dark;
       font-style: normal;
-      margin: 0;
 
       &:first-of-type::before {
         @extend %quotes;
         content: '\201C\2002'; // Unicode for left double quotation mark +  1/2 em space
         margin-left: -1.5rem;
+        padding-right: 1.5rem;
+        position: relative;
+        top: .1rem;
+
+        @media (min-width: $breakpoint-medium)  {
+          margin-left: -1.9rem;
+          padding-right: 1.9rem;
+          top: .4rem;
+        }
       }
 
       &:last-of-type {


### PR DESCRIPTION
## Done
Tweaked the spacing around the first quote in the pull quote pattern.

## QA
- Pull down code
- Run `gulp jekyll`
- Go to http://localhost:4321/vanilla-framework/examples/patterns/pull-quotes/
- Check the spacing now matches the [design spec](https://github.com/ubuntudesign/vanilla-design/blob/master/Pull%20quote/pull-quote.png)

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/904
