### PR TITLE
Form validation tweaks

### DIFF
--- a/examples/patterns/form-validation.html
+++ b/examples/patterns/form-validation.html
@@ -28,12 +28,12 @@ category: _patterns
       <strong>Success:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
     </p>
   </div>
-</form>
 
-<div class="p-form-validation is-success">
-  <label for="textarea">Label</label>
-  <textarea class="p-form-validation__input" id="textarea" rows="3">Textarea</textarea>
-  <p class="p-form-validation__message">
-    <strong>Success:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-  </p>
-</div>
+  <div class="p-form-validation is-success">
+    <label for="textarea">Label</label>
+    <textarea class="p-form-validation__input" id="textarea" rows="3">Textarea</textarea>
+    <p class="p-form-validation__message">
+      <strong>Success:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+    </p>
+  </div>
+</form>

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -18,7 +18,7 @@
     @extend %validation-wrapper;
 
     .p-form-validation__input { // Not using parent selector here as two classes are required to override atribute selectors in reset
-      background-position: calc(100% - 1rem) 50%;
+      background-position: calc(100% - 1rem) .75rem;
       background-repeat: no-repeat;
       padding: .5rem 2.5rem .5rem .75rem;
     }


### PR DESCRIPTION
## Done

- Changed icon position on form validation so it is 12px from top, not 50%
- Tweaked example to move `<textarea>` example inside form element

## QA

- Pull code & run `gulp jekyll`
- Compare [example](http://127.0.0.1:4000/vanilla-framework/examples/patterns/form-validation/) with [spec](https://github.com/ubuntudesign/vanilla-design/blob/master/Forms/forms.png)

## Details

Fixes #912 
