### PR TITLE
Tidy docs

### DIFF
--- a/_jekyll/_layouts/default.html
+++ b/_jekyll/_layouts/default.html
@@ -12,9 +12,7 @@
         {% endif %}
     </head>
 
-    <body>
-      <div id="wrapper" style="margin:2rem;">
-        {{ content }}
-      <div>
+    <body style="margin: 1rem;">
+{{ content }}
     </body>
 </html>

--- a/docs/en/base/code.md
+++ b/docs/en/base/code.md
@@ -14,7 +14,7 @@ When you refer to code inline with other text, use the <code>&lt;code&gt;</code>
 
 If you want to refer to a larger piece of code, use <code>&lt;pre&gt;</code> together with the <code>&lt;code&gt;</code> tag.
 
-<a href="http://127.0.0.1:4321/vanilla-framework/examples/base/code/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/code/"
     class="js-example">
     View example of the base code block
 </a>

--- a/docs/en/base/code.md
+++ b/docs/en/base/code.md
@@ -14,7 +14,7 @@ When you refer to code inline with other text, use the <code>&lt;code&gt;</code>
 
 If you want to refer to a larger piece of code, use <code>&lt;pre&gt;</code> together with the <code>&lt;code&gt;</code> tag.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/code/"
+<a href="http://127.0.0.1:4321/vanilla-framework/examples/base/code/"
     class="js-example">
     View example of the base code block
 </a>


### PR DESCRIPTION
## Done
Small tweak to example template to tidy up the output for the documentation. 

## QA
- Check the code still give us padding as to see the borders of patterns when looking at examples but does not appear in the code in the docs.
- I removed the tabbing on the content to strip the beginning tabbing in the code blocks in the docs.
