### PR TITLE
Fix up breadcrumb links

### DIFF
--- a/examples/patterns/breadcrumbs.html
+++ b/examples/patterns/breadcrumbs.html
@@ -5,8 +5,8 @@ category: _patterns
 ---
 
 <ul class="p-breadcrumbs">
-  <li class="p-breadcrumbs__item"><a href="#">Breadcrumb1</a></li>
-  <li class="p-breadcrumbs__item"><a href="#">Breadcrumb2</a></li>
-  <li class="p-breadcrumbs__item"><a href="#">Breadcrumb3</a></li>
-  <li class="p-breadcrumbs__item">Breadcrumb4</li>
+  <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="#">Breadcrumb One</a></li>
+  <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="#">Breadcrumb Two</a></li>
+  <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="#">Breadcrumb Three</a></li>
+  <li class="p-breadcrumbs__item">Breadcrumb Four</li>
 </ul>

--- a/scss/_patterns_breadcrumbs.scss
+++ b/scss/_patterns_breadcrumbs.scss
@@ -7,20 +7,36 @@
     width: 100%;
 
     &__item {
-      display: inline;
-      font-weight: normal;
-      margin-right: 1rem;
+      display: inline-block;
+      margin-bottom: .25rem;
+      margin-left: .25rem;
+      margin-right: .75rem;
       position: relative;
 
-      &::after {
-        content: '\203A';
-        position: absolute;
-        right: -.75rem;
-        top: -.15rem;
+      &:not(:first-of-type) {
+        margin-right: -.25rem;
+        text-indent: 1rem;
       }
 
-      &:last-child::after {
-        content: ' ';
+      &:first-of-type {
+        margin-right: -.25rem;
+      }
+
+      &:not(:first-of-type)::before {
+        content: '\203A';
+        left: -.75rem;
+        position: absolute;
+        top: 0;
+      }
+    }
+
+    &__link {
+      color: $color-dark;
+      font-weight: 400;
+      text-decoration: none;
+
+      &:hover {
+        color: $color-link;
       }
     }
   }


### PR DESCRIPTION
## Done

Amended breadcrumb styling to match spec

## QA

- Pull code
- Run `gulp jekyll`
- Compare [example](http://127.0.0.1:4000/vanilla-framework/examples/patterns/breadcrumbs/) to [spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Breadcrumbs)

## Details

Fixes #828 
