### PR TITLE
Update heading docs

### DIFF
--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -8,11 +8,6 @@ All text in Vanilla uses the Ubuntu typeface.
 
 Vanilla's typographic scale has a base font size of 14 pixels (small screens) and a font weight of 300.  At the medium breakpoint, the base font size is 15 pixels, and at the large breakpoint it is 16 pixels.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/headings/"
-    class="js-example">
-    View example of the base headings
-</a>
-
 ## Blockquotes and citations
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/blockquotes/"

--- a/docs/en/patterns/headings.md
+++ b/docs/en/patterns/headings.md
@@ -6,7 +6,16 @@ title: Headings
 
 Heading classes can be added to text elements to give them the same visual appearance as base h1, h2, h3, etc., elements.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/headings/"
+Styling for page headings 1-6 are provided to aid content structure.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/headings/default"
     class="js-example">
-    View example of the headings pattern
+    View example of the default headings pattern
+</a>
+
+Heading classes are not tied to elements and can be freely mixed, for example you can apply `p-heading--one` style to an `h3` element if that better suits your document style and tree.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/headings/mixed"
+    class="js-example">
+    View example of the mixed headings pattern
 </a>

--- a/examples/patterns/headings/default.html
+++ b/examples/patterns/headings/default.html
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Headings / Default
+category: _patterns
+---
+
+<h1 class="p-heading--one">Heading one</h1>
+<h2 class="p-heading--two">Heading two</h2>
+<h3 class="p-heading--three">Heading three</h3>
+<h4 class="p-heading--four">Heading four</h4>
+<h5 class="p-heading--five">Heading five</h5>
+<h6 class="p-heading--six">Heading six</h6>

--- a/examples/patterns/headings/mixed.html
+++ b/examples/patterns/headings/mixed.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Headings
+title: Headings / Mixed classes
 category: _patterns
 ---
 


### PR DESCRIPTION
## Done

- Remove heading examples from base typography
- Clarify headings pattern and explain and how heading classes can be used on different head elements

## QA

- Pull code
- Run `gulp jekyll`
- Review docs changes
- Review http://127.0.0.1:4000/vanilla-framework/examples/patterns/headings/default/
- Review http://127.0.0.1:4000/vanilla-framework/examples/patterns/headings/mixed/

## Details

Fixes #881 #831 #878 
