### PR TITLE
Add trailing slashes to heading doc examples

### DIFF
--- a/docs/en/patterns/headings.md
+++ b/docs/en/patterns/headings.md
@@ -8,14 +8,14 @@ Heading classes can be added to text elements to give them the same visual appea
 
 Styling for page headings 1-6 are provided to aid content structure.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/headings/default"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/headings/default/"
     class="js-example">
     View example of the default headings pattern
 </a>
 
 Heading classes are not tied to elements and can be freely mixed, for example you can apply `p-heading--one` style to an `h3` element if that better suits your document style and tree.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/headings/mixed"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/headings/mixed/"
     class="js-example">
     View example of the mixed headings pattern
 </a>


### PR DESCRIPTION
## Done
Add trailing slashes to heading doc examples

## QA
- Visually check the links have trailing slashes

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/941
