### PR TITLE
Space external links example using <p> instead of <br>

### DIFF
--- a/examples/patterns/links/links-external.html
+++ b/examples/patterns/links/links-external.html
@@ -4,5 +4,9 @@ title: Links / External
 category: _patterns
 ---
 
-<a href="#" class="p-link--external">External link</a><br>
-<a href="#" class="p-link--external p-link--strong">External / Strong link</a>
+<p>
+  <a href="#" class="p-link--external">External link</a>
+</p>
+<p>
+  <a href="#" class="p-link--external p-link--strong">External / Strong link</a>
+</p>


### PR DESCRIPTION
## Done

Spoace external links example using `<p>` instead of `<br>`

## QA

Check code

## Details

Fixes #946
