### PR TITLE
Use .p-card pattern to demo utils in docs

### DIFF
--- a/examples/utilities/align.html
+++ b/examples/utilities/align.html
@@ -4,14 +4,14 @@ title: Align
 category: _utilities
 ---
 
-<div class="u-align--center">
+<div class="p-card u-align--center">
   <p>I am centered text.</p>
 </div>
 
-<div class="u-align--left">
+<div class="p-card u-align--left">
   <p>I am left text.</p>
 </div>
 
-<div class="u-align--right">
+<div class="p-card u-align--right">
   <p>I am right text.</p>
 </div>

--- a/examples/utilities/clearfix.html
+++ b/examples/utilities/clearfix.html
@@ -4,7 +4,7 @@ title: Clearfix
 category: _utilities
 ---
 
-<div class="u-clearfix">
-  <div class="u-float--left">Content floated left</div>
-  <div class="u-float--right">Content floated right</div>
+<div class="p-card u-clearfix">
+  <div class="p-card u-float--left">Content floated left</div>
+  <div class="p-card u-float--right">Content floated right</div>
 </div>

--- a/examples/utilities/equal-height.html
+++ b/examples/utilities/equal-height.html
@@ -4,11 +4,11 @@ title: Equal height
 category: _utilities
 ---
 
-<div class="u-equal-height">
-  <div class="col-8">
+<div class="p-card u-equal-height">
+  <div class="p-card">
     <p>This is a long paragraph of text - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at elit augue. Maecenas eleifend varius leo id facilisis. Nunc sit amet hendrerit nisl. Fusce posuere bibendum mi dignissim venenatis. Ut ornare quis velit ac lobortis. Vestibulum faucibus tortor hendrerit viverra. Maecenas in molestie sapien.</p>
   </div>
-  <div class="col-4">
+  <div class="p-card">
     <p>This is a short piece of text</p>
   </div>
 </div>

--- a/examples/utilities/equal-height.html
+++ b/examples/utilities/equal-height.html
@@ -4,11 +4,16 @@ title: Equal height
 category: _utilities
 ---
 
-<div class="p-card u-equal-height">
-  <div class="p-card">
-    <p>This is a long paragraph of text - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at elit augue. Maecenas eleifend varius leo id facilisis. Nunc sit amet hendrerit nisl. Fusce posuere bibendum mi dignissim venenatis. Ut ornare quis velit ac lobortis. Vestibulum faucibus tortor hendrerit viverra. Maecenas in molestie sapien.</p>
-  </div>
-  <div class="p-card">
-    <p>This is a short piece of text</p>
+<div class="row">
+  <div class="u-equal-height">
+    <div class="p-card col-4">
+      <p>This is a long piece of text This is a long piece of text This is a long piece of text This is a long piece of text This is a long piece of text This is a long piece of text This is a long piece of text This is a long piece of text This is a long piece of text</p>
+    </div>
+    <div class="p-card col-6">
+      <p>This is a short piece of text</p>
+    </div>
+    <div class="p-card col-2">
+      <p>This is a short piece of text</p>
+    </div>
   </div>
 </div>

--- a/examples/utilities/floats.html
+++ b/examples/utilities/floats.html
@@ -4,10 +4,10 @@ title: Floats
 category: _utilities
 ---
 
-<div class="u-float--right">
+<div class="p-card u-float--right">
   Content floated right
 </div>
 
-<div class="u-float--left">
+<div class="p-card u-float--left">
   Content floated left
 </div>

--- a/examples/utilities/margin-collapse.html
+++ b/examples/utilities/margin-collapse.html
@@ -4,32 +4,22 @@ title: Margin collapse
 category: _utilities
 ---
 
-<div class="p-card">
-  <div style="margin:1rem;" class="u-no-margin">
-    This div has no margin
-  </div>
+<div class="p-card u-no-margin">
+  This div has no margin
 </div>
 
-<div class="p-card">
-  <div style="margin:1rem;" class="u-no-margin--top">
-    This div has no top margin
-  </div>
+<div class="p-card u-no-margin--top">
+  This div has no top margin
 </div>
 
-<div class="p-card">
-  <div style="margin:1rem;" class="u-no-margin--right">
-    This div has no right margin
-  </div>
+<div class="p-card u-no-margin--right">
+  This div has no right margin
 </div>
 
-<div class="p-card">
-  <div style="margin:1rem;" class="u-no-margin--bottom">
-    This div has no bottom margin
-  </div>
+<div class="p-card u-no-margin--bottom">
+  This div has no bottom margin
 </div>
 
-<div class="p-card">
-  <div style="margin:1rem;" class="u-no-margin--left">
-      This div has no left margin
-  </div>
+<div class="p-card u-no-margin--left">
+  This div has no left margin
 </div>

--- a/examples/utilities/off-screen.html
+++ b/examples/utilities/off-screen.html
@@ -4,6 +4,6 @@ title: Off-screen
 category: _utilities
 ---
 
-<div class="u-off-screen">
+<div class="p-card u-off-screen">
   To hear a great joke, navigate this page with your favorite screen reader.
 </div>

--- a/examples/utilities/vertically-center.html
+++ b/examples/utilities/vertically-center.html
@@ -4,4 +4,8 @@ title: Vertically center
 category: _utilities
 ---
 
-<div class="u-vertically-center">Vertically centered content</div>
+<div class="p-card u-vertically-center" style="min-height: 500px;">
+  <div class="p-card">
+    Vertically centered content
+  </div>
+</div>

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -4,6 +4,7 @@
     background: $color-x-light;
     border: 1px solid $color-mid-light;
     border-radius: 2px;
+    margin-bottom: 1rem;
     padding: 1.333rem;
 
     @media (min-width: $breakpoint-medium) {
@@ -27,6 +28,10 @@
 
   .p-card {
     @include p-card;
+
+    & & {
+      margin-bottom: 0;
+    }
   }
 
   .p-card--highlighted {


### PR DESCRIPTION
## Done

Updated example markup for utils with cards to demo their effects more visually.

Note: I had to alter the styles of `.p-card` itself to use it in this context:

- Add inherent bottom margin of 1rem to a card
- Remove bottom margin from nested cards

## QA

- Pull code
- Run `gulp jekyll`
- View each of the utils at http://127.0.0.1:4000/vanilla-framework/

## Details

Fixes #942 #939 