### PR TITLE
Fix broken align link

### DIFF
--- a/docs/en/utilities/align.md
+++ b/docs/en/utilities/align.md
@@ -6,7 +6,7 @@ title: Align
 
 You can use these utilities to force the content inside an element to align center, left or right.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/content-align/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/align/"
     class="js-example">
     View example of the content align utility
 </a>


### PR DESCRIPTION
## Done

Fix broken align example link

## QA

Check the link goes to the example

## Details

Currently the example link at https://docs.vanillaframework.io/en/utilities/align goes to https://vanilla-framework.github.io/vanilla-framework/examples/utilities/content-align/ which doesn’t exist, it should go to https://vanilla-framework.github.io/vanilla-framework/examples/utilities/align/