### PR TITLE
853 Update grid docs

### DIFF
--- a/docs/en/patterns/grid.md
+++ b/docs/en/patterns/grid.md
@@ -21,11 +21,13 @@ Read also: [Breakpoints](/en/settings/breakpoints)
 
 ## Empty columns
 
-Adding empty columns before or after an element might be useful when you need extra space between elements and columns than that provided by the default grid.
+Prefixes and suffixes add extra horizontal padding to columns, creating some negative space between or around them.
 
-The classes `.prefix-1`, `.prefix-2`, `.prefix-3`, and so on, will add empty columns before the element to the number of columns specified in the class.
+To add some space to the left of the column add a `.prefix-[n]` class, where `n` is the number of grid units the space should take up.
 
-The classes `.suffix-1`, `.suffix-2`, `.suffix-3`, and so on, will add empty columns after the element to the number of columns specified in the class.
+To add some space to the right add a `.suffix-[n]` class.
+
+By default, prefixes and suffixes only work on top level columns. 
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/grid/empty-columns/"
     class="js-example">

--- a/examples/patterns/grid/default.html
+++ b/examples/patterns/grid/default.html
@@ -3,97 +3,98 @@ layout: default
 title: Grid / Default
 category: _patterns
 ---
-
-<div class="row">
-    <div class="col-12">
-        <span>.col-12</span>
+<div grid-demo>
+    <div class="row">
+        <div class="col-12">
+            <span>.col-12</span>
+        </div>
     </div>
-</div>
-<div class="row">
-    <div class="col-11">
-        <span>.col-11</span>
+    <div class="row">
+        <div class="col-11">
+            <span>.col-11</span>
+        </div>
+        <div class="col-1">
+            <span>.col-1</span>
+        </div>
     </div>
-    <div class="col-1">
-        <span>.col-1</span>
+    <div class="row">
+        <div class="col-10">
+            <span>.col-10</span>
+        </div>
+        <div class="col-2">
+            <span>.col-2</span>
+        </div>
     </div>
-</div>
-<div class="row">
-    <div class="col-10">
-        <span>.col-10</span>
+    <div class="row">
+        <div class="col-9">
+            <span>.col-9</span>
+        </div>
+        <div class="col-3">
+            <span>.col-3</span>
+        </div>
     </div>
-    <div class="col-2">
-        <span>.col-2</span>
+    <div class="row">
+        <div class="col-8">
+            <span>.col-8</span>
+        </div>
+        <div class="col-4">
+            <span>.col-4</span>
+        </div>
     </div>
-</div>
-<div class="row">
-    <div class="col-9">
-        <span>.col-9</span>
+    <div class="row">
+        <div class="col-7">
+            <span>.col-7</span>
+        </div>
+        <div class="col-5">
+            <span>.col-5</span>
+        </div>
     </div>
-    <div class="col-3">
-        <span>.col-3</span>
+    <div class="row">
+        <div class="col-6">
+            <span>.col-6</span>
+        </div>
+        <div class="col-6">
+            <span>.col-6</span>
+        </div>
     </div>
-</div>
-<div class="row">
-    <div class="col-8">
-        <span>.col-8</span>
+    <div class="row">
+        <div class="col-5">
+            <span>.col-5</span>
+        </div>
+        <div class="col-7">
+            <span>.col-7</span>
+        </div>
     </div>
-    <div class="col-4">
-        <span>.col-4</span>
+    <div class="row">
+        <div class="col-4">
+            <span>.col-4</span>
+        </div>
+        <div class="col-8">
+            <span>.col-8</span>
+        </div>
     </div>
-</div>
-<div class="row">
-    <div class="col-7">
-        <span>.col-7</span>
+    <div class="row">
+        <div class="col-3">
+            <span>.col-3</span>
+        </div>
+        <div class="col-9">
+            <span>.col-9</span>
+        </div>
     </div>
-    <div class="col-5">
-        <span>.col-5</span>
+    <div class="row">
+        <div class="col-2">
+            <span>.col-2</span>
+        </div>
+        <div class="col-10">
+            <span>.col-10</span>
+        </div>
     </div>
-</div>
-<div class="row">
-    <div class="col-6">
-        <span>.col-6</span>
-    </div>
-    <div class="col-6">
-        <span>.col-6</span>
-    </div>
-</div>
-<div class="row">
-    <div class="col-5">
-        <span>.col-5</span>
-    </div>
-    <div class="col-7">
-        <span>.col-7</span>
-    </div>
-</div>
-<div class="row">
-    <div class="col-4">
-        <span>.col-4</span>
-    </div>
-    <div class="col-8">
-        <span>.col-8</span>
-    </div>
-</div>
-<div class="row">
-    <div class="col-3">
-        <span>.col-3</span>
-    </div>
-    <div class="col-9">
-        <span>.col-9</span>
-    </div>
-</div>
-<div class="row">
-    <div class="col-2">
-        <span>.col-2</span>
-    </div>
-    <div class="col-10">
-        <span>.col-10</span>
-    </div>
-</div>
-<div class="row">
-    <div class="col-1">
-        <span>.col-1</span>
-    </div>
-    <div class="col-11">
-        <span>.col-11</span>
+    <div class="row">
+        <div class="col-1">
+            <span>.col-1</span>
+        </div>
+        <div class="col-11">
+            <span>.col-11</span>
+        </div>
     </div>
 </div>

--- a/examples/patterns/grid/default.html
+++ b/examples/patterns/grid/default.html
@@ -5,95 +5,95 @@ category: _patterns
 ---
 
 <div class="row">
-    <div class="col-12 theme__outline">
+    <div class="col-12">
         <span>.col-12</span>
     </div>
 </div>
 <div class="row">
-    <div class="col-11 theme__outline">
+    <div class="col-11">
         <span>.col-11</span>
     </div>
-    <div class="col-1 theme__outline">
+    <div class="col-1">
         <span>.col-1</span>
     </div>
 </div>
 <div class="row">
-    <div class="col-10 theme__outline">
+    <div class="col-10">
         <span>.col-10</span>
     </div>
-    <div class="col-2 theme__outline">
+    <div class="col-2">
         <span>.col-2</span>
     </div>
 </div>
 <div class="row">
-    <div class="col-9 theme__outline">
+    <div class="col-9">
         <span>.col-9</span>
     </div>
-    <div class="col-3 theme__outline">
+    <div class="col-3">
         <span>.col-3</span>
     </div>
 </div>
 <div class="row">
-    <div class="col-8 theme__outline">
+    <div class="col-8">
         <span>.col-8</span>
     </div>
-    <div class="col-4 theme__outline">
+    <div class="col-4">
         <span>.col-4</span>
     </div>
 </div>
 <div class="row">
-    <div class="col-7 theme__outline">
+    <div class="col-7">
         <span>.col-7</span>
     </div>
-    <div class="col-5 theme__outline">
+    <div class="col-5">
         <span>.col-5</span>
     </div>
 </div>
 <div class="row">
-    <div class="col-6 theme__outline">
+    <div class="col-6">
         <span>.col-6</span>
     </div>
-    <div class="col-6 theme__outline">
+    <div class="col-6">
         <span>.col-6</span>
     </div>
 </div>
 <div class="row">
-    <div class="col-5 theme__outline">
+    <div class="col-5">
         <span>.col-5</span>
     </div>
-    <div class="col-7 theme__outline">
+    <div class="col-7">
         <span>.col-7</span>
     </div>
 </div>
 <div class="row">
-    <div class="col-4 theme__outline">
+    <div class="col-4">
         <span>.col-4</span>
     </div>
-    <div class="col-8 theme__outline">
+    <div class="col-8">
         <span>.col-8</span>
     </div>
 </div>
 <div class="row">
-    <div class="col-3 theme__outline">
+    <div class="col-3">
         <span>.col-3</span>
     </div>
-    <div class="col-9 theme__outline">
+    <div class="col-9">
         <span>.col-9</span>
     </div>
 </div>
 <div class="row">
-    <div class="col-2 theme__outline">
+    <div class="col-2">
         <span>.col-2</span>
     </div>
-    <div class="col-10 theme__outline">
+    <div class="col-10">
         <span>.col-10</span>
     </div>
 </div>
 <div class="row">
-    <div class="col-1 theme__outline">
+    <div class="col-1">
         <span>.col-1</span>
     </div>
-    <div class="col-11 theme__outline">
+    <div class="col-11">
         <span>.col-11</span>
     </div>
 </div>

--- a/examples/patterns/grid/empty-columns.html
+++ b/examples/patterns/grid/empty-columns.html
@@ -4,27 +4,29 @@ title: Grid / Empty columns
 category: _patterns
 ---
 
-<div class="row">
-  <div class="col-8">
-    <div class="theme__outline">.col-8</div>
+<div grid-demo>
+  <div class="row">
+    <div class="col-8">
+      .col-8
+    </div>
+    <div class="col-4">
+      .col-4
+    </div>
   </div>
-  <div class="col-4">
-    <div class="theme__outline">.col-4</div>
+  <div class="row">
+      <div class="col-7">
+        .col-7
+      </div>
+      <div class="col-4 prefix-1">
+        .col-4.prefix-1
+      </div>
   </div>
-</div>
-<div class="row">
-    <div class="col-7">
-        <div class="theme__outline">.col-7</div>
-    </div>
-    <div class="col-4 prefix-1">
-        <div class="theme__outline">.col-4.prefix-1</div>
-    </div>
-</div>
-<div class="row">
-    <div class="col-7">
-        <div class="theme__outline">.col-7</div>
-    </div>
-    <div class="col-4 suffix-1">
-        <div class="theme__outline">.col-4.suffix-1</div>
-    </div>
+  <div class="row">
+      <div class="col-7">
+        .col-7
+      </div>
+      <div class="col-4 suffix-1">
+        .col-4.suffix-1
+      </div>
+  </div>
 </div>

--- a/scss/grid/shelves.scss
+++ b/scss/grid/shelves.scss
@@ -10,3 +10,9 @@ Copyright (c) 2012, Pete Browne
 @import "./shelves/functions";
 @import "./shelves/variables";
 @import "./shelves/mixins";
+
+// Demo helper
+[grid-demo] [class*="col-"]  {
+  background: $color-mid-light;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Done

- Removed redundant `.theme__outline` class
- Updated styles to include grid outline helper
- Clarified explanation docs around prefix/suffix

## QA

- Pull code
- Run `gulp jekyll`
- Check grid examples
- Check docs

## Details

Fixes #853 