### PR TITLE
Reformat typography table markdown

### DIFF
--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -33,43 +33,43 @@ Vanilla's typographic scale has a base font size of 14 pixels (small screens) an
 
 ## Typographic scale
 
-  |  Small  |  Medium  |  Large
-:----------- | -----------: | -----------: | -----------:
-**p**  |    |    |  
-font size  |  `15px`  |  `16px`  |  `16px`
-line height  |  `24px`  |  `24px`  |  `24px`
-margin top  |  `18px`  |  `24px`   |  `24px`
-margin bottom  |  `18px`  |  `24px`  |  `24px`
-<h1>h1</h1>  |    |    |  
-font size  |  `32px`  |  `40px`  |  `48px`
-line height  |  `36px`  |  `48px`  |  `60px`
-margin top  |  `18px`  |  `24px`  |  `24px`
-margin bottom  |  `18px`  |  `24px`  |  `24px`
-<h2>h2</h2>  |    |    |  
-font size  |  `26px`  |  `32px`  |  `36px`
-line height  |  `30px`  |  `40px`  |  `42px`
-margin top  |  `18px`  |  `24px`  |  `24px`
-margin bottom  |  `18px`  |  `24px`  |  `24px`
-<h3>h3</h3>  |    |    |  
-font size  |  `23px`  |  `26px`  |  `28px`
-line height  |  `30px`  |  `30px`  |  `36px`
-margin top  |  `18px`  |  `24px`  |  `24px`
-margin bottom  |  `18px`  |  `24px`  |  `24px`
-<h4>h4</h4>  |    |    |  
-font size  |  `20px`  |  `22px`  |  `24px`
-line height  |  `24px`  |  `30px`  |  `30px`
-margin top  |  `18px`  |  `24px`  |  `24px`
-margin bottom  |  `18px`  |  `24px`  |  `24px`
-<h5>h5</h5>  |    |    |  
-font size  |  `18px`  |  `19px`  |  `21px`
-line height  |  `24px`  |  `24px`  |  `24px`
-margin top  |  `18px`  |  `24px`  |  `24px`
-margin bottom  |  `18px`  |  `24px`  |  `24px`
-<h6>h6</h6>  |    |    |  
-font size  |  `16px`  |  `17px`  |  `17px`
-line height  |  `18px`  |  `24px`  |  `24px`
-margin top  |  `18px`  |  `24px`  |  `24px`
-margin bottom  |  `18px`  |  `24px`  |  `24px`
+|               | Small  | Medium | Large  |
+| ------------- | -----  | ------ | -----  |
+| **p**         |        |        |        |
+| font size     | `15px` | `16px` | `16px` |
+| line height   | `24px` | `24px` | `24px` |
+| margin top    | `18px` | `24px` | `24px` |
+| margin bottom | `18px` | `24px` | `24px` |
+| <h1>h1</h1>   |        |        |        |
+| font size     | `32px` | `40px` | `48px` |
+| line height   | `36px` | `48px` | `60px` |
+| margin top    | `18px` | `24px` | `24px` |
+| margin bottom | `18px` | `24px` | `24px` |
+| <h2>h2</h2>   |        |        |        |
+| font size     | `26px` | `32px` | `36px` |
+| line height   | `30px` | `40px` | `42px` |
+| margin top    | `18px` | `24px` | `24px` |
+| margin bottom | `18px` | `24px` | `24px` |
+| <h3>h3</h3>   |        |        |        |
+| font size     | `23px` | `26px` | `28px` |
+| line height   | `30px` | `30px` | `36px` |
+| margin top    | `18px` | `24px` | `24px` |
+| margin bottom | `18px` | `24px` | `24px` |
+| <h4>h4</h4>   |        |        |        |
+| font size     | `20px` | `22px` | `24px` |
+| line height   | `24px` | `30px` | `30px` |
+| margin top    | `18px` | `24px` | `24px` |
+| margin bottom | `18px` | `24px` | `24px` |
+| <h5>h5</h5>   |        |        |        |
+| font size     | `18px` | `19px` | `21px` |
+| line height   | `24px` | `24px` | `24px` |
+| margin top    | `18px` | `24px` | `24px` |
+| margin bottom | `18px` | `24px` | `24px` |
+| <h6>h6</h6>   |        |        |        |
+| font size     | `16px` | `17px` | `17px` |
+| line height   | `18px` | `24px` | `24px` |
+| margin top    | `18px` | `24px` | `24px` |
+| margin bottom | `18px` | `24px` | `24px` |
 
 ## Ordered list
 


### PR DESCRIPTION
So that the table will be treated predictably by different markdown
parsers, we should add preceding and following pipes (`|`) to each line.

In my opinion this also makes it look more like a table in text as well.

I've also normalised spacing, so it looks even more like a table.

Fixes https://github.com/ubuntudesign/docs.vanillaframework.io/issues/71

QA
--

1. See the [GitHub page in my branch](https://github.com/nottrobin/vanilla-framework/blob/71-typography-tabls/docs/en/base/typography.md), check that GitHub displays the table correctly.

2. Check the page renders properly as documentation:
   
   ``` bash
   snap install documentation-builder
   documentation-builder --source-folder docs
   ```
   
   Now open up `build/en/base/typography.html` in your browser, and see that the table looks right, with the headings aligning correctly.