### PR TITLE
Refactor styling to .p-code-numbered

### DIFF
--- a/examples/patterns/code-numbered.html
+++ b/examples/patterns/code-numbered.html
@@ -4,12 +4,12 @@ title: Code numbered
 category: _patterns
 ---
 
-<pre class="p-code-numbered"><code><span class="code-line">this is a code sample line 1</span>
+<pre class="p-code-numbered"><code><span class="code-line">this is a code sample line 1 this is a code sample line 1 this is a code sample line 1 this is a code sample line 1 this is a code sample line 1 this is a code sample line 1 this is a code sample line 1</span>
 <span class="code-line">this is a code sample line 2</span>
 <span class="code-line">this is a code sample line 3</span>
 <span class="code-line">this is a code sample line 4</span>
 <span class="code-line">this is a code sample line 5</span>
-<span class="code-line">this is a code sample line 6</span>
+<span class="code-line">this is a code sample line 6 this is a code sample line 6 this is a code sample line 6 this is a code sample line 6 this is a code sample line 6 this is a code sample line 6 </span>
 <span class="code-line">this is a code sample line 7</span>
 <span class="code-line">this is a code sample line 8</span>
 <span class="code-line">this is a code sample line 9</span>

--- a/scss/_patterns_code-numbered.scss
+++ b/scss/_patterns_code-numbered.scss
@@ -7,7 +7,7 @@
     background: $color-x-light;
     color: $color-dark;
     counter-reset: line-numbering;
-    padding: 1rem 0 0;
+    padding: $sp-medium 0 0;
     position: relative;
 
     &::before {
@@ -19,7 +19,7 @@
       background: $color-light;
       display: block;
       margin: -#{$sp-large} 0 0 0;
-      padding: $sp-x-small 0 $sp-x-small 5.5rem;
+      padding: $sp-x-small $sp-medium $sp-x-small #{$sidebar-width + $sp-medium};
       position: relative;
 
       &:first-child,

--- a/scss/_patterns_code-numbered.scss
+++ b/scss/_patterns_code-numbered.scss
@@ -19,7 +19,7 @@
       background: $color-light;
       display: block;
       margin: -#{$sp-large} 0 0 0;
-      padding: $sp-x-small $sp-medium $sp-x-small #{$sidebar-width + $sp-medium};
+      padding: $sp-x-small $sp-medium 0 #{$sidebar-width + $sp-medium};
       position: relative;
 
       &:first-child,

--- a/scss/_patterns_code-numbered.scss
+++ b/scss/_patterns_code-numbered.scss
@@ -1,21 +1,56 @@
 // Code and pre styles
 @mixin vf-p-code-numbered {
+
+  $sidebar-width: 4.5rem;
+
   .p-code-numbered {
-    background: $color-light;
+    background: $color-x-light;
     color: $color-dark;
     counter-reset: line-numbering;
-    padding: $sp-medium;
+    padding: 1rem 0 0;
+    position: relative;
 
-    .code-line::before {
-      color: $color-mid-dark;
-      content: counter(line-numbering);
-      counter-increment: line-numbering;
-      display: inline-block;
-      padding-right: $sp-medium; // space after numbers
-      pointer-events: none;
-      text-align: right;
-      user-select: none;
-      width: $sp-xxx-large;
+    &::before {
+      background-color: $color-x-light;
+      width: $sidebar-width;
+    }
+
+    .code-line {
+      background: $color-light;
+      display: block;
+      margin: -#{$sp-large} 0 0 0;
+      padding: $sp-x-small 0 $sp-x-small 5.5rem;
+      position: relative;
+
+      &:first-child,
+      &:first-child::before {
+        padding-top: 1.25rem;
+      }
+
+      &:last-child,
+      &:last-child::before {
+        padding-bottom: $sp-medium;
+      }
+
+      &::before {
+        background: $color-x-light;
+        border-right: 1px solid $color-dark;
+        color: $color-mid-dark;
+        content: counter(line-numbering);
+        counter-increment: line-numbering;
+        display: inline-block;
+        height: 9999px; // infinity figure to ensure sidebar fills full height of each item
+        left: 0;
+        margin-right: $sp-medium;
+        max-height: 100%;
+        padding: $sp-x-small $sp-medium $sp-medium $sp-medium; // space after numbers
+        pointer-events: none;
+        position: absolute;
+        text-align: right;
+        top: 0;
+        user-select: none;
+        width: $sidebar-width;
+      }
     }
   }
 }


### PR DESCRIPTION
## Done

Refactor styling to .p-code-numbered

## QA

- Pull code
- Run `gulp jekyll`
- Check [example](http://127.0.0.1:4000/vanilla-framework/examples/patterns/code-numbered/) against the [spec](https://github.com/ubuntudesign/vanilla-design/blob/master/Code/code.md)

## Details

Fixes #856 