### PR TITLE
Switch redundant img styles into media include

### DIFF
--- a/scss/_base_images.scss
+++ b/scss/_base_images.scss
@@ -1,8 +1,0 @@
-// Images default styling
-@mixin vf-images {
-  img {
-    border: 0;
-    height: auto;
-    max-width: 100%;
-  }
-}

--- a/scss/_base_media.scss
+++ b/scss/_base_media.scss
@@ -1,5 +1,12 @@
 // Media element styles
 @mixin vf-b-media {
+
+  img {
+    border: 0;
+    height: auto;
+    max-width: 100%;
+  }
+
   // Corrects overflow displayed oddly in IE9
   svg:not(:root) {
     overflow: hidden;

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -20,7 +20,6 @@
 'base_button',
 'base_forms',
 'base_code',
-'base_images',
 'base_links',
 'base_lists',
 'base_hr',


### PR DESCRIPTION
## Done

- These base images were being imported but not included.
- Deleted the separate images file and moved into `_base_media.scss` with related <figure> styles

## QA

- Run `gulp build`
- Ensure no error