### PR TITLE
Remove ./run start instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,6 @@ You can then compile your Sass changes into `build/css/build.css` by running:
 ./run build
 ```
 
-Or you can run a local server to view your changes live with:
-
-``` bash
-./run start
-```
-
 ## Building documentation pages
 
 The documentation available at <https://docs.vanillaframework.io> is built from

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ You can then compile your Sass changes into `build/css/build.css` by running:
 ./run build
 ```
 
+Or you can run a local server to view your changes live with:
+
+``` bash
+gulp jekyll
+```
+
 ## Building documentation pages
 
 The documentation available at <https://docs.vanillaframework.io> is built from


### PR DESCRIPTION
This option does not work due to unresolved issue with ./run scripts.