### PR TITLE
Remove nested mixin declaration from _patterns_links.scss

### DIFF
--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -1,10 +1,10 @@
 // Link style patterns
+
+@mixin link-svg-icon($color: $color-dark) {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='" + url-friendly-color($color) + "' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='" + url-friendly-color($color) + "' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='" + url-friendly-color($color) + "' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E");
+}
+
 @mixin vf-p-links {
-
-  @mixin link-svg-icon($color: $color-dark) {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='" + url-friendly-color($color) + "' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='" + url-friendly-color($color) + "' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='" + url-friendly-color($color) + "' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E");
-  }
-
   .p-link {
     // Used for links point at a different domain
     &--external {


### PR DESCRIPTION
## Done

Removed nested mixin declaration from _patterns_links.scss. A fix to node-sass has made this illegal: https://github.com/sass/node-sass/issues/1459

## QA

- Pull code
- Run `sass --no-cache --style=extended scss/build.scss build/css/build.scss`
- Ensure no errors

## Details

Fixes #1016 
