### PR TITLE
Add contrast-text-color function on .p-button--brand

### DIFF
--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -10,3 +10,12 @@
     @return '%23' + str-slice('#{$color}', 2, -1);
   }
 }
+
+// Test value of bg $color and return light or dark text color accordingly
+@function contrast-text-color($color) {
+  @if (lightness($color) > 55) {
+    @return $color-x-dark; // Lighter background, return dark color
+  } @else {
+    @return $color-x-light; // Darker background, return light color
+  }
+}

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -1,4 +1,5 @@
 // Default button styling
+
 @mixin vf-p-buttons {
   @include button-plain;
   @include button-neutral;
@@ -34,7 +35,7 @@
     @include button-pattern (
       $button-background-color: $color-brand,
       $button-border-color: $color-brand,
-      $button-text-color: invert($color-brand),
+      $button-text-color: contrast-text-color($color-brand),
       $button-hover-background-color: darken($color-brand, 10%),
       $button-hover-border-color: darken($color-brand, 10%),
       $button-disabled-background-color: $color-brand,


### PR DESCRIPTION
## Done

Add contrast-text-color function on `.p-button--brand` so dark buttons don't have dark text and vice-versa

## QA

- Run `gulp jekyll`
- View http://127.0.0.1:4000/vanilla-framework/examples/patterns/buttons/brand/
- Change `$color-brand` to a dark color like `#000`
- Observe the button text color change to a light color

## Details

Fixes #991 
