### PR TITLE
Update travis.yml to point at #general slack room

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,9 @@ notifications:
   irc:
     channels:
       - "chat.freenode.net#vanilla-framework"
-      - "chat.freenode.net#canonical-webteam"
     on_success: change
     on_failure: always
     on_success: change
   slack:
     rooms:
-      - vanillaframework:wvRcrt4C6ODhvHxrUkTaKlD5#travis
+      - vanillaframework:wvRcrt4C6ODhvHxrUkTaKlD5#general


### PR DESCRIPTION
## Done

Becuase the #travis slack room no longer exists. Also deleting #canonical-webteam room ping as it's pretty much redundant.

## QA

Sanity check code