### PR TITLE
Add logo and favicon src to docs metadata

### DIFF
--- a/docs/metadata.yaml
+++ b/docs/metadata.yaml
@@ -1,2 +1,4 @@
-site_title: Vanilla framework documentation
+site_favicon: "https://assets.ubuntu.com/v1/383ca4d9-vanilla_favicon_16px.svg"
+site_logo_url: "https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg"
+site_title: ~
 


### PR DESCRIPTION
## Done

- Added ref to Vanilla logo
- Added favicon ref
- Removed site title

## QA

- Pull this branch
- Run local docs
- Check lcoal site for logo and favicon

## Details

Fixes https://github.com/ubuntudesign/docs.vanillaframework.io/issues/85,
Fixes https://github.com/canonical-websites/vanillaframework.io/issues/12