### PR TITLE
Update links example

### DIFF
--- a/docs/en/patterns/links.md
+++ b/docs/en/patterns/links.md
@@ -13,6 +13,33 @@ The `.p-link--external` class should be used on hyperlinks that go to a differen
     View example of the external link pattern
 </a>
 
+## Soft link
+
+The `.p-link--soft` class should be used on hyperlinks where many links are grouped together, such as a link cloud.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/links/links-soft/"
+    class="js-example">
+    View example of the soft link pattern
+</a>
+
+## Strong link
+
+The `.p-link--strong` class should be used on hyperlinks that require emphasis.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/links/links-strong/"
+    class="js-example">
+    View example of the strong link pattern
+</a>
+
+## Inverted link
+
+The `.p-link--external` class should be used where links are placed on a dark background.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/links/links-inverted/"
+    class="js-example">
+    View example of the inverted link pattern
+</a>
+
 ## Back to top link
 
 The `.p-top` link can be used to make it easier to go back to the top on long pages. If the page is divided into different sections, you can use more than one per page.

--- a/docs/en/patterns/links.md
+++ b/docs/en/patterns/links.md
@@ -13,15 +13,6 @@ The `.p-link--external` class should be used on hyperlinks that go to a differen
     View example of the external link pattern
 </a>
 
-## Link without underline
-
-The `.p-link--no-underline` class should be used on hyperlinks where an underline should not appear, such as image links. E.g.:
-
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/links/links-without-underline/"
-    class="js-example">
-    View example of the links without underline pattern
-</a>
-
 ## Back to top link
 
 The `.p-top` link can be used to make it easier to go back to the top on long pages. If the page is divided into different sections, you can use more than one per page.

--- a/examples/patterns/links/links-without-underline.html
+++ b/examples/patterns/links/links-without-underline.html
@@ -1,9 +1,0 @@
----
-layout: default
-title: Links / Links w/out underline
-category: _patterns
----
-
-<a  href="#" class="p-link--no-underline">
-    <img src="http://placehold.it/150x200" alt="Placeholder image" />
-</a>

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -15,8 +15,10 @@
       padding-right: .9rem;
     }
 
-    &--no-underline {
-      border: 0;
+    @include deprecate('2.0.0', 'This class is no longer required as links now use text-decoration') {
+      &--no-underline {
+        border: 0;
+      }
     }
 
     &--soft {


### PR DESCRIPTION
## Done

- Deprecated redundant `.p-link--no-underline`
- Added examples to docs of soft, strong & inverted link patterns

## QA

- Sanity check code
- Run local docs and check those examples are imported

## Details

Fixes #984, Fixes #983 
