### PR TITLE
Update inline images pattern

### DIFF
--- a/docs/en/settings/color-settings.md
+++ b/docs/en/settings/color-settings.md
@@ -6,7 +6,7 @@ title: Color
 
 Vanilla works with a fairly neutral color palette consisting of a range of greys and a traffic light palette (red, yellow, green) plus blue.
 
-You can define a brand color (<code>$color-brand</code>) that can be used for call-to-action buttons and other highlights across the framework. The default Vanilla brand color is <code>$color-dark</code>.
+You can define a brand color (`$color-brand`) that can be used for call-to-action buttons and other highlights across the framework. The default Vanilla brand color is `$color-dark`.
 
 When planning your pages, make sure there is an even distribution and well-balanced percentage of light and strong colors. Think of the screen as a whole: it shouldn't be top- or bottom-heavy.
 
@@ -20,52 +20,52 @@ When planning your pages, make sure there is an even distribution and well-balan
 </thead>
 <tbody>
 <tr>
-<td><code>$color-brand</code></td>
-<td style="background-color: #333; color: #fff;">#333</td>
+<td>`$color-brand`</td>
+<td style="background-color: #333; color: #fff;">`#333`</td>
 </tr>
 <tr>
-<td><code>$color-x-light</code></td>
-<td style="background-color: #fff;">#fff</td>
+<td>`$color-x-light`</td>
+<td style="background-color: #fff;">`#fff`</td>
 </tr>
 <tr>
-<td><code>$color-light</code></td>
-<td style="background-color: #f7f7f7;">#f7f7f7</td>
+<td>`$color-light`</td>
+<td style="background-color: #f7f7f7;">`#f7f7f7`</td>
 </tr>
 <tr>
-<td><code>$color-mid-light</code></td>
-<td style="background-color: #cdcdcd; color: #fff;">#cdcdcd</td>
+<td>`$color-mid-light`</td>
+<td style="background-color: #cdcdcd; color: #fff;">`#cdcdcd`</td>
 </tr>
 <tr>
-<td><code>$color-mid-dark</code></td>
-<td style="background-color: #666; color: #fff;">#666</td>
+<td>`$color-mid-dark`</td>
+<td style="background-color: #666; color: #fff;">`#666`</td>
 </tr>
 <tr>
-<td><code>$color-dark</code></td>
-<td style="background-color: #111; color: #fff;">#111</td>
+<td>`$color-dark`</td>
+<td style="background-color: #111; color: #fff;">`#111`</td>
 </tr>
 <tr>
-<td><code>$color-x-dark</code></td>
-<td style="background-color: #000; color: #fff;">#000</td>
+<td>`$color-x-dark`</td>
+<td style="background-color: #000; color: #fff;">`#000`</td>
 </tr>
 <tr>
-<td><code>$color-negative</code></td>
-<td style="background-color: #c7162b; color: #fff;">#c7162b</td>
+<td>`$color-negative`</td>
+<td style="background-color: #c7162b; color: #fff;">`#c7162b`</td>
 </tr>
 <tr>
-<td><code>$color-warning</code></td>
-<td style="background-color: #f99b11;">#f99b11</td>
+<td>`$color-warning`</td>
+<td style="background-color: #f99b11;">`#f99b11`</td>
 </tr>
 <tr>
-<td><code>$color-positive</code></td>
-<td style="background-color: #0e8420; color: #fff;">#0e8420</td>
+<td>`$color-positive`</td>
+<td style="background-color: #0e8420; color: #fff;">`#0e8420`</td>
 </tr>
 <tr>
-<td><code>$color-information</code></td>
-<td style="background-color: #335280; color: #fff;">#335280</td>
+<td>`$color-information`</td>
+<td style="background-color: #335280; color: #fff;">`#335280`</td>
 </tr>
 <tr>
-<td><code>$color-link</code></td>
-<td style="background-color: #007aa6; color: #fff;">#007aa6</td>
+<td>`$color-link`</td>
+<td style="background-color: #007aa6; color: #fff;">`#007aa6`</td>
 </tr>
 </tbody>
 </table>

--- a/docs/en/utilities/vertically-center.md
+++ b/docs/en/utilities/vertically-center.md
@@ -8,5 +8,5 @@ The `.u-vertically-center` class will vertically center the direct child of the 
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/vertically-center/"
     class="js-example">
-    View example of the vertically center util
+    View example of the vertically center utility
 </a>

--- a/examples/patterns/inline-images.html
+++ b/examples/patterns/inline-images.html
@@ -7,21 +7,21 @@ category: _patterns
 
 <div class="p-inline-images">
   <li class="p-inline-images__item">
-    <img src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" />
+    <img src="http://placehold.it/150x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" />
+    <img src="http://placehold.it/175x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="https://assets.ubuntu.com/v1/47ffe923-landscape-logo.svg" alt="Landscape" />
+    <img src="http://placehold.it/150x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="https://assets.ubuntu.com/v1/33409c7b-logo-maas.svg" alt="MAAS" />
+    <img src="http://placehold.it/175x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="https://assets.ubuntu.com/v1/7e21b535-logo-juju.svg" alt="Juju" />
+    <img src="http://placehold.it/150x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="https://assets.ubuntu.com/v1/5051e6e5-core_logo.svg" alt="Ubuntu Core" />
+    <img src="http://placehold.it/175x200" alt="Placeholder image" />
   </li>
 </div>

--- a/examples/patterns/inline-images.html
+++ b/examples/patterns/inline-images.html
@@ -4,12 +4,24 @@ title: Inline images
 category: _patterns
 ---
 
+
 <div class="p-inline-images">
-  <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
-  <img class="p-inline-images__img" src="http://placehold.it/175x200" alt="Placeholder image" />
-  <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
-  <img class="p-inline-images__img" src="http://placehold.it/175x200" alt="Placeholder image" />
-  <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
-  <img class="p-inline-images__img" src="http://placehold.it/175x200" alt="Placeholder image" />
-  <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
+  <li class="p-inline-images__item">
+    <img src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" />
+  </li>
+  <li class="p-inline-images__item">
+    <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" />
+  </li>
+  <li class="p-inline-images__item">
+    <img src="https://assets.ubuntu.com/v1/47ffe923-landscape-logo.svg" alt="Landscape" />
+  </li>
+  <li class="p-inline-images__item">
+    <img src="https://assets.ubuntu.com/v1/33409c7b-logo-maas.svg" alt="MAAS" />
+  </li>
+  <li class="p-inline-images__item">
+    <img src="https://assets.ubuntu.com/v1/7e21b535-logo-juju.svg" alt="Juju" />
+  </li>
+  <li class="p-inline-images__item">
+    <img src="https://assets.ubuntu.com/v1/5051e6e5-core_logo.svg" alt="Ubuntu Core" />
+  </li>
 </div>

--- a/gulp/lint.js
+++ b/gulp/lint.js
@@ -10,7 +10,7 @@ gulp.task('lint:sass', function() {
 });
 
 gulp.task('lint:spellcheck', function(cb) {
-  return exec('node_modules/markdown-spellcheck/bin/mdspell docs/**/*.md -r -n -a --en-gb', function (err, stdout, stderr) {
+  return exec('node_modules/markdown-spellcheck/bin/mdspell docs/en/**/*.md -r -n -a --en-gb', function (err, stdout, stderr) {
     console.log(stdout);
     cb(err);
   });

--- a/scss/_patterns_inline-images.scss
+++ b/scss/_patterns_inline-images.scss
@@ -6,19 +6,37 @@
     list-style: none; // if list is used as wrapper
     text-align: center;
 
-    &__img {
+    &__item {
       display: inline-block;
-      max-width: calc(50% - #{$sp-x-large}); // 2 items per row
-      padding: $sp-medium;
+      max-width: 5.625rem;
+      margin: $sp-x-large;
       text-align: center;
       width: 100%;
+      vertical-align: middle;
 
-      @media (min-width: $breakpoint-small) { // 3 items per row
-        max-width: calc(33.3333% - #{$sp-x-large});
+      @media (min-width: $breakpoint-medium) {
+        max-width: 11.25rem;
+        margin: $sp-xxx-large;
       }
 
-      @media (min-width: $breakpoint-large) { // 4 items per row
-        max-width: calc(25% - #{$sp-x-large});
+      * {
+        width: 100%;
+      }
+    }
+
+    @include deprecate('2.0.0', 'Use .p-inline-images__item instead') {
+      &__img {
+        display: inline-block;
+        max-width: 5.625rem;
+        margin: $sp-x-large;
+        text-align: center;
+        width: 100%;
+        vertical-align: middle;
+
+        @media (min-width: $breakpoint-medium) {
+          max-width: 11.25rem;
+          margin: $sp-xxx-large;
+        }
       }
     }
   }

--- a/scss/_patterns_inline-images.scss
+++ b/scss/_patterns_inline-images.scss
@@ -8,7 +8,7 @@
 
     &__item {
       display: inline-block;
-      max-width: 5.625rem;
+      max-width: 6rem;
       margin: $sp-x-large;
       text-align: center;
       width: 100%;
@@ -27,7 +27,7 @@
     @include deprecate('2.0.0', 'Use .p-inline-images__item instead') {
       &__img {
         display: inline-block;
-        max-width: 5.625rem;
+        max-width: 6rem;
         margin: $sp-x-large;
         text-align: center;
         width: 100%;

--- a/scss/_patterns_inline-images.scss
+++ b/scss/_patterns_inline-images.scss
@@ -8,15 +8,15 @@
 
     &__item {
       display: inline-block;
-      max-width: 6rem;
       margin: $sp-x-large;
+      max-width: 6rem;
       text-align: center;
-      width: 100%;
       vertical-align: middle;
+      width: 100%;
 
       @media (min-width: $breakpoint-medium) {
-        max-width: 11.25rem;
         margin: $sp-xxx-large;
+        max-width: 11.25rem;
       }
 
       * {
@@ -27,15 +27,15 @@
     @include deprecate('2.0.0', 'Use .p-inline-images__item instead') {
       &__img {
         display: inline-block;
-        max-width: 6rem;
         margin: $sp-x-large;
+        max-width: 6rem;
         text-align: center;
-        width: 100%;
         vertical-align: middle;
+        width: 100%;
 
         @media (min-width: $breakpoint-medium) {
-          max-width: 11.25rem;
           margin: $sp-xxx-large;
+          max-width: 11.25rem;
         }
       }
     }


### PR DESCRIPTION
## Done
Updated the inline-images pattern to match the image sizes as closely as possible using the spacing variables. Deprecated the `__img` element as it doesn't always target the image. Created `__item` as a generic replacement.

## QA
- Pull code and run `gulp jekyll`
- Go to http://127.0.0.1:4000/vanilla-framework/examples/patterns/inline-images/
- Check that the logos are similar to the spec with the following caveat (padding: 48px as its the largest spacing we have)

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1039

## Screenshots
![10576587](https://cloud.githubusercontent.com/assets/1413534/25409766/3ce382bc-2a0b-11e7-83b3-fac0dbaf6855.png)
