### PR TITLE
Remove margin from navigation pattern

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -4,7 +4,6 @@
     @extend %clearfix;
     background-color: $color-brand;
     color: $color-x-light;
-    margin-bottom: $sp-x-large;
     position: relative;
     width: 100%;
 


### PR DESCRIPTION
## Done
Removed margin-bottom from the navigation pattern

## QA
- Pull code and run `gulp jekyll`
- Go to http://127.0.0.1:4000/vanilla-framework/examples/patterns/navigation/fixed-width/
- Check that the navigation no longer has margin-bottom

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/982

## Screenshots
![navigation - fixed width - vanilla framework - examples](https://cloud.githubusercontent.com/assets/1413534/25432349/02ff7878-2a7c-11e7-9fb9-b92303735558.png)
