### PR TITLE
Create breakpoint-navigation-threshold

### DIFF
--- a/docs/en/patterns/navigation.md
+++ b/docs/en/patterns/navigation.md
@@ -26,6 +26,6 @@ Note: You can constrain the width of the navigation to match the
     View example of the full width navigation pattern
 </a>
 
-Tip: You can change the breakpoint in which the menu changes to a small screen 
+Tip: You can change the breakpoint at which the menu changes to a small screen 
 menu by adjusting the `$breakpoint-navigation-threshold` in 
 `_settings_breakpoints.scss`.

--- a/docs/en/patterns/navigation.md
+++ b/docs/en/patterns/navigation.md
@@ -25,3 +25,7 @@ Note: You can constrain the width of the navigation to match the
     class="js-example">
     View example of the full width navigation pattern
 </a>
+
+Tip: You can change the breakpoint in which the menu changes to a small screen 
+menu by adjusting the `$breakpoint-navigation-threshold` in 
+`_settings_breakpoints.scss`.

--- a/docs/en/settings/breakpoint-settings.md
+++ b/docs/en/settings/breakpoint-settings.md
@@ -42,6 +42,6 @@ The `$breakpoint-navigation-threshold` is the breakpoint in which the
 navigation switches from horizontal (large screen) navigation to a burger style 
 menu (small screen).
 
-If you have a large number of menu items you may consider overriding this 
+If you have a large number of menu items, you may consider overriding this 
 value to a large breakpoint so the navigation snaps to a burger menu at a 
 larger breakpoint.

--- a/docs/en/settings/breakpoint-settings.md
+++ b/docs/en/settings/breakpoint-settings.md
@@ -37,7 +37,7 @@ Setting  | Default value
 }
 ```
 
-## Modifing the navigation threshold
+## Modifying the navigation threshold
 The `$breakpoint-navigation-threshold` is the breakpoint in which the 
 navigation switches from horizontal (large screen) navigation to a burger style 
 menu (small screen).

--- a/docs/en/settings/breakpoint-settings.md
+++ b/docs/en/settings/breakpoint-settings.md
@@ -11,6 +11,7 @@ Setting  | Default value
 `$breakpoint-small`   | `620px`
 `$breakpoint-medium`   | `768px`
 `$breakpoint-large`   | `1030px`
+`$breakpoint-navigation-threshold`   | `$breakpoint-medium`
 
 ## Target small screens
 
@@ -35,3 +36,12 @@ Setting  | Default value
     //css
 }
 ```
+
+## Modifing the navigation threshold
+The `$breakpoint-navigation-threshold` is the breakpoint in which the 
+navigation switches from horizontal (large screen) navigation to a burger style 
+menu (small screen).
+
+If you have a large number of menu items you may consider overriding this 
+value to a large breakpoint so the navigation snaps to a burger menu at a 
+larger breakpoint.

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -42,13 +42,13 @@
         float: right;
         margin: $sp-medium;
 
-        @media (min-width: $breakpoint-medium) {
+        @media (min-width: $breakpoint-navigation-threshold + 1) {
           display: none;
         }
       }
     }
 
-    @media (max-width: $breakpoint-medium) {
+    @media (max-width: $breakpoint-navigation-threshold) {
       &:target &__toggle--close {
         display: inline-block;
       }
@@ -61,7 +61,7 @@
       font-size: 1.2rem;
       margin: $sp-medium;
 
-      @media (min-width: $breakpoint-medium) {
+      @media (min-width: $breakpoint-navigation-threshold + 1) {
         margin: .9rem;
       }
     }
@@ -70,7 +70,7 @@
       border-bottom: 0;  // For when this class is applied to an <a> directly
       display: block;
 
-      @media (min-width: $breakpoint-medium) {
+      @media (min-width: $breakpoint-navigation-threshold + 1) {
         display: block;
         float: left;
         width: auto;
@@ -94,7 +94,7 @@
       margin: 0; // For if this class is applied to a <ul>
       padding: 0; // For if this class is applied to a <ul>
 
-      @media (min-width: $breakpoint-medium) {
+      @media (min-width: $breakpoint-navigation-threshold + 1) {
         background-color: transparent;
         clear: none;
         float: left;
@@ -104,7 +104,7 @@
         border-left: 1px solid $color-x-light;
         padding: $sp-medium;
 
-        @media (max-width: $breakpoint-medium) {
+        @media (max-width: $breakpoint-navigation-threshold) {
           background-color: $color-light;
           border: 0;
           border-bottom: 1px solid $color-mid-light;
@@ -115,7 +115,7 @@
         > a {
           // For when this class is applied to something that contains <a>s, e.g.:
           // <li class="p-navigation__list"><a></a></li>
-          @media (max-width: $breakpoint-medium) {
+          @media (max-width: $breakpoint-navigation-threshold) {
             color: $color-dark;
           }
         }
@@ -123,7 +123,7 @@
         &:last-of-type {
           border-right: 1px solid $color-x-light;
 
-          @media (max-width: $breakpoint-medium) {
+          @media (max-width: $breakpoint-navigation-threshold) {
             border-bottom: 0;
           }
         }
@@ -133,7 +133,7 @@
     &__nav {
       display: none;
 
-      @media (min-width: $breakpoint-medium) {
+      @media (min-width: $breakpoint-navigation-threshold + 1) {
         display: block;
       }
     }

--- a/scss/_settings_breakpoints.scss
+++ b/scss/_settings_breakpoints.scss
@@ -1,7 +1,9 @@
 // Global breakpoints
 
-$breakpoint-small:      620px !default;
+$breakpoint-small:                620px !default;
 
-$breakpoint-medium:     768px !default;
+$breakpoint-medium:               768px !default;
 
-$breakpoint-large:      1030px !default;
+$breakpoint-large:                1030px !default;
+
+$breakpoint-navigation-threshold: $breakpoint-medium !default


### PR DESCRIPTION
## Done
Created a new breakpoint setting called `$breakpoint-navigation-threshold`. Utilising the variable through the navigation pattern. Documented the new setting.

## QA
- Pull code and run `gulp jekyll`
- Go to http://127.0.0.1:4000/vanilla-framework/examples/patterns/navigation/fixed-width/
- Check that the menu switches at `768px`
- Change the navigation threshold and check the navigation respects the new threshold

## Details
Fixes https://github.com/ubuntudesign/vanilla-design/issues/16 https://github.com/vanilla-framework/vanilla-framework/issues/736
