### PR TITLE
Rename warning to caution

### DIFF
--- a/docs/en/base/forms.md
+++ b/docs/en/base/forms.md
@@ -74,7 +74,7 @@ Adding the ```[disabled="disabled"]``` attribute to an input will prevent user i
 
 ## Validation classes
 
-Applying the classes ```.is-error```, ```.is-warning``` or ```.is-success``` to an input will style that element differently to provide visual feedback in case there is an error, warning or success notification related to the element.
+Applying the classes ```.is-error```, ```.is-caution``` or ```.is-success``` to an input will style that element differently to provide visual feedback in case there is an error, caution or success notification related to the element.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/form-validation/"
     class="js-example">

--- a/docs/en/patterns/form-validation.md
+++ b/docs/en/patterns/form-validation.md
@@ -2,12 +2,12 @@
 title: Form validation
 ---
 
-# Error / Warning / Success states
+# Error / Caution / Success states
 
 By wrapping ```<label>``` and input form elements in a wrapper called ```.p-form-validation```, you can then dynamically add state classes to indicate form field validation states.
 
 - ```.is-success```
-- ```.is-warning```
+- ```.is-caution```
 - ```.is-error```
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/form-validation/"

--- a/docs/en/patterns/notification.md
+++ b/docs/en/patterns/notification.md
@@ -6,7 +6,7 @@ title: Notification
 
 ## .p-notification
 
-Notifications are used to display global information. A notification will display at the top and fill the full width of the page. A notification can be a default, warning, negative or position.
+Notifications are used to display global information. A notification will display at the top and fill the full width of the page. A notification can be a default, caution, negative or position.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/notifications/notifications/"
     class="js-example">
@@ -14,13 +14,13 @@ Notifications are used to display global information. A notification will displa
 </a>
 
 
-## .p-notification--warning
+## .p-notification--caution
 
-This warning variant should be used to convey information that is not critical but the user should be aware of.
+This caution variant should be used to convey information that is not critical but the user should be aware of.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/notifications/warning/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/notifications/caution/"
     class="js-example">
-    View example of the warning notification pattern
+    View example of the caution notification pattern
 </a>
 
 ## .p-notification--negative
@@ -49,5 +49,5 @@ Note: All functionality must be developed in independently.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/notifications/action/"
     class="js-example">
-    View example of the warning notification pattern
+    View example of the caution notification pattern
 </a>

--- a/docs/en/settings/color-settings.md
+++ b/docs/en/settings/color-settings.md
@@ -52,7 +52,7 @@ When planning your pages, make sure there is an even distribution and well-balan
 <td style="background-color: #c7162b; color: #fff;">`#c7162b`</td>
 </tr>
 <tr>
-<td>`$color-warning`</td>
+<td>`$color-caution`</td>
 <td style="background-color: #f99b11;">`#f99b11`</td>
 </tr>
 <tr>

--- a/examples/patterns/form-validation.html
+++ b/examples/patterns/form-validation.html
@@ -13,11 +13,11 @@ category: _patterns
     </p>
   </div>
 
-  <div class="p-form-validation is-warning">
-    <label for="exampleTextInputWarning">Warning</label>
-    <input class="p-form-validation__input" type="text" id="exampleTextInputWarning" placeholder="Placeholder text" />
+  <div class="p-form-validation is-caution">
+    <label for="exampleTextInputCaution">Caution</label>
+    <input class="p-form-validation__input" type="text" id="exampleTextInputCaution" placeholder="Placeholder text" />
     <p class="p-form-validation__message">
-      <strong>Warning:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+      <strong>Caution:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
     </p>
   </div>
 

--- a/examples/patterns/notifications/caution.html
+++ b/examples/patterns/notifications/caution.html
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Notifications / Warning
+title: Notifications / Caution
 category: _patterns
 ---
 
-<div class="p-notification--warning">
+<div class="p-notification--caution">
   <p class="p-notification__response">
     <span class="p-notification__status">Blocked:</span>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt ipsum nemo autem reiciendis nulla tempore natus repudiandae dolorem. Corporis maxime, iure maiores repellat, odit facilis!
   </p>

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -58,11 +58,11 @@
     }
   }
 
-  .is-warning {
+  .is-caution {
 
     .p-form-validation__input {
-      background-image: url('#{$assets-path}c41194d3-icon-warning.svg');
-      border-color: $color-warning;
+      background-image: url('#{$assets-path}c41194d3-icon-caution.svg');
+      border-color: $color-caution;
     }
   }
 }

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -78,8 +78,8 @@
 }
 
 // Warning notification styling
-@include deprecate('2.0.0', 'Use .vf-notifications-caution instead') {
-  @mixin vf-notifications-warning {
+@mixin vf-notifications-warning {
+  @include deprecate('2.0.0', 'Use .vf-notifications-caution instead') {
     .p-notification--warning {
       @include notification;
       border-color: $color-warning;

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -22,7 +22,7 @@
 @mixin vf-p-notification {
   @include vf-notifications-default;
   @include vf-notifications-positive;
-  @include vf-notifications-warning;
+  @include vf-notifications-caution;
   @include vf-notifications-negative;
 }
 
@@ -64,15 +64,30 @@
   }
 }
 
-// Warning notification styling
-@mixin vf-notifications-warning {
-  .p-notification--warning {
+// Caution notification styling
+@mixin vf-notifications-caution {
+  .p-notification--caution {
     @include notification;
-    border-color: $color-warning;
+    border-color: $color-caution;
 
     .p-notification__response {
-      background-image: url("data:image/svg+xml,%3Csvg width='17px' height='17px' viewBox='0 0 17 17' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='notification-warning' transform='translate(1.000000, 1.000000)'%3E%3Cg id='Page-3---colours'%3E%3Cg id='Notifications---single'%3E%3Cg id='Group'%3E%3Cg id='ICON'%3E%3Ccircle id='circle5432' stroke='" + url-friendly-color($color-warning) + "' stroke-width='1.5' fill='" + url-friendly-color($color-warning) + "' cx='7.2500086' cy='7.2500086' r='7.2500086'%3E%3C/circle%3E%3Cpath d='M6.2500086,3.2500086 L6.2500086,8.2500086 L8.2500086,8.2500086 L8.2500086,3.2500086 L6.2500086,3.2500086 L6.2500086,3.2500086 L6.2500086,3.2500086 Z M6.2500086,9.2500086 L6.2500086,11.2500086 L8.2500086,11.2500086 L8.2500086,9.2500086 L6.2500086,9.2500086 L6.2500086,9.2500086 L6.2500086,9.2500086 Z' id='rect5434' fill='" + url-friendly-color($color-x-light) + "'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+      background-image: url("data:image/svg+xml,%3Csvg width='17px' height='17px' viewBox='0 0 17 17' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='notification-caution' transform='translate(1.000000, 1.000000)'%3E%3Cg id='Page-3---colours'%3E%3Cg id='Notifications---single'%3E%3Cg id='Group'%3E%3Cg id='ICON'%3E%3Ccircle id='circle5432' stroke='" + url-friendly-color($color-caution) + "' stroke-width='1.5' fill='" + url-friendly-color($color-caution) + "' cx='7.2500086' cy='7.2500086' r='7.2500086'%3E%3C/circle%3E%3Cpath d='M6.2500086,3.2500086 L6.2500086,8.2500086 L8.2500086,8.2500086 L8.2500086,3.2500086 L6.2500086,3.2500086 L6.2500086,3.2500086 L6.2500086,3.2500086 Z M6.2500086,9.2500086 L6.2500086,11.2500086 L8.2500086,11.2500086 L8.2500086,9.2500086 L6.2500086,9.2500086 L6.2500086,9.2500086 L6.2500086,9.2500086 Z' id='rect5434' fill='" + url-friendly-color($color-x-light) + "'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
       padding-left: $sp-large;
+    }
+  }
+}
+
+// Warning notification styling
+@include deprecate('2.0.0', 'Use .vf-notifications-caution instead') {
+  @mixin vf-notifications-warning {
+    .p-notification--warning {
+      @include notification;
+      border-color: $color-warning;
+
+      .p-notification__response {
+        background-image: url("data:image/svg+xml,%3Csvg width='17px' height='17px' viewBox='0 0 17 17' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='notification-warning' transform='translate(1.000000, 1.000000)'%3E%3Cg id='Page-3---colours'%3E%3Cg id='Notifications---single'%3E%3Cg id='Group'%3E%3Cg id='ICON'%3E%3Ccircle id='circle5432' stroke='" + url-friendly-color($color-caution) + "' stroke-width='1.5' fill='" + url-friendly-color($color-caution) + "' cx='7.2500086' cy='7.2500086' r='7.2500086'%3E%3C/circle%3E%3Cpath d='M6.2500086,3.2500086 L6.2500086,8.2500086 L8.2500086,8.2500086 L8.2500086,3.2500086 L6.2500086,3.2500086 L6.2500086,3.2500086 L6.2500086,3.2500086 Z M6.2500086,9.2500086 L6.2500086,11.2500086 L8.2500086,11.2500086 L8.2500086,9.2500086 L6.2500086,9.2500086 L6.2500086,9.2500086 L6.2500086,9.2500086 Z' id='rect5434' fill='" + url-friendly-color($color-x-light) + "'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+        padding-left: $sp-large;
+      }
     }
   }
 }

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -79,7 +79,7 @@
 
 // Warning notification styling
 @mixin vf-notifications-warning {
-  @include deprecate('2.0.0', 'Use .vf-notifications-caution instead') {
+  @include deprecate('2.0.0', 'Use .p-notifications--caution instead') {
     .p-notification--warning {
       @include notification;
       border-color: $color-warning;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -13,7 +13,8 @@ $color-dark:             #111 !default;
 $color-x-dark:           #000 !default;
 
 $color-negative:         #c7162b !default;
-$color-warning:          #f99b11 !default;
+$color-caution:          #f99b11 !default;
+$color-warning:          $color-caution !default; // To be removed in version 2.0
 $color-positive:         #0e8420 !default;
 $color-information:      #335280 !default;
 
@@ -24,7 +25,8 @@ $grid-border-style:      1px dotted $color-mid-light !default;
 
 $states: (
   error: $color-negative,
-  warning: $color-warning,
+  caution: $color-caution,
+  warning: $color-warning, // To be removed in version 2.0
   success: $color-positive,
   information: $color-information
 );

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -1,3 +1,7 @@
+// Vendor Sass utilities
+@import
+'utilities_deprecate';
+
 // Global Sass functions
 @import
 'global_functions';
@@ -55,7 +59,6 @@
 'utilities_equal-height',
 'utilities_off-screen',
 'utilities_content-align',
-'utilities_deprecate',
 'utilities_margin-collapse',
 'utilities_padding-collapse',
 'utilities_embedded-media',


### PR DESCRIPTION
## Done
Renamed warning to caution and deprecated the warning classes and colour.

## QA
- Pull down code and run `gulp jekyll`
- Go to http://127.0.0.1:4000/vanilla-framework/examples/patterns/notifications/caution/
- Check that the notification is now caution, not warning.
- Check the documentation is correct

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/979

