### PR TITLE
Buttons with external links have incorrect colour

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -40,6 +40,10 @@
   transition: background-color .2s;
   width: 100%;
 
+  @media only screen and (min-width: $breakpoint-medium) {
+    width: auto;
+  }
+
   &:visited {
     color: $button-text-color;
   }
@@ -65,7 +69,7 @@
     }
   }
 
-  @media only screen and (min-width: $breakpoint-medium) {
-    width: auto;
+  .p-link--external {
+    @include link-svg-icon($button-text-color);
   }
 }


### PR DESCRIPTION
## Done
Added an override to the external icon in the button pattern. Put the media query above children selectors.

## QA
- Pull code and run `gulp jekyll`
- Add to the examples/button/base.html:
```html
<a href="" class="p-button--base">
  <span class="p-link--external">
    External button
  </span>
</a>
<a href="" class="p-button--positive">
  <span class="p-link--external">
    External button
  </span>
</a>
```
- Go to http://127.0.0.1:4000/vanilla-framework/examples/patterns/buttons/base/
- Check the external link is the same color as the text

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1025
