### PR TITLE
Caution icon 404 travis checks fix

### DIFF
--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -61,7 +61,7 @@
   .is-caution {
 
     .p-form-validation__input {
-      background-image: url('#{$assets-path}c41194d3-icon-caution.svg');
+      background-image: url('#{$assets-path}db30f04c-icon-caution.svg');
       border-color: $color-caution;
     }
   }


### PR DESCRIPTION
## Done

Replace caution icon image 

The current .is-caution image being request in _patterns_form-validation.scss doesn’t exist and is causing the Travis CI checks on developer.ubuntu.com https://travis-ci.org/canonical-websites/developer.ubuntu.com/builds/226822666?utm_source=github_status&utm_medium=notification 

The image being requested should have been this one https://assets.ubuntu.com/v1/c41194d3-icon-warning.svg

For the sake of consistency in naming I’ve uploaded a new image to the asset manager

## QA

Check that the new image https://assets.ubuntu.com/v1/db30f04c-icon-caution.svg exists and that it’s the same as https://assets.ubuntu.com/v1/c41194d3-icon-warning.svg, also check that it’s being requested in  _patterns_form-validation.scss

