### PR TITLE
Remove the base font size change on small screens

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -55,11 +55,7 @@
   }
 
   html {
-    font-size: calc(#{$font-base-size} * .9375);
-
-    @media screen and (min-width: $breakpoint-medium) {
-      font-size: $font-base-size;
-    }
+    font-size: $font-base-size;
   }
 
   body {

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -62,11 +62,7 @@
     color: $color-dark;
     font-family: unquote($font-base-family);
     font-weight: 300;
-    line-height: 1.6;
-
-    @media screen and (min-width: $breakpoint-medium) {
-      line-height: 1.5;
-    }
+    line-height: 1.5;
   }
 
   /// Base typography
@@ -80,23 +76,13 @@
   [class^="p-heading--"] {
     font-family: unquote($font-heading-family);
     font-weight: 300;
-    margin-bottom: 1.2rem;
+    margin-bottom: $sp-large;
     margin-top: 0;
-
-    @media screen and (min-width: $breakpoint-medium) {
-      margin-bottom: $sp-large;
-      margin-top: 0;
-    }
   }
 
   p {
-    margin-bottom: 1.2rem;
+    margin-bottom: $sp-large;
     margin-top: 0;
-
-    @media screen and (min-width: $breakpoint-medium) {
-      margin-bottom: $sp-large;
-      margin-top: 0;
-    }
   }
 
   button,
@@ -140,11 +126,7 @@
   p + h3,
   pre + h3,
   ul + h3 {
-    margin-top: $sp-large;
-
-    @media only screen and (min-width: $breakpoint-medium)  {
-      margin-top: 1.6rem;
-    }
+    margin-top: 1.6rem;
   }
 
   // lists
@@ -176,21 +158,13 @@
     > p {
       font-size: $sp-medium;
       font-style: italic;
-      margin-bottom: .8rem;
-
-      @media only screen and (min-width: $breakpoint-medium)  {
-        margin-bottom: $sp-small;
-      }
+      margin-bottom: $sp-small;
     }
 
     > cite {
       font-size: $sp-medium;
       font-style: normal;
-      margin-top: .8rem;
-
-      @media only screen and (min-width: $breakpoint-medium)  {
-        margin-top: $sp-small;
-      }
+      margin-top: $sp-small;
     }
   }
 
@@ -221,13 +195,8 @@
 }
 
 @mixin heading-1 {
-  font-size: 2.134rem;
-  line-height: 1.125;
-
-  @media only screen and (min-width: $breakpoint-medium)  {
-    font-size: $sp-xx-large;
-    line-height: 1.2;
-  }
+  font-size: $sp-xx-large;
+  line-height: 1.2;
 
   @media only screen and (min-width: $breakpoint-large) {
     font-size: $sp-xxx-large;
@@ -236,13 +205,8 @@
 }
 
 @mixin heading-2 {
-  font-size: 1.734rem;
-  line-height: 1.154;
-
-  @media only screen and (min-width: $breakpoint-medium)  {
-    font-size: $sp-x-large;
-    line-height: 1.25;
-  }
+  font-size: $sp-x-large;
+  line-height: 1.25;
 
   @media only screen and (min-width: $breakpoint-large) {
     font-size: 2.25rem;
@@ -251,13 +215,8 @@
 }
 
 @mixin heading-3 {
-  font-size: 1.534rem;
-  line-height: 1.305;
-
-  @media only screen and (min-width: $breakpoint-medium)  {
-    font-size: 1.625rem;
-    line-height: 1.154;
-  }
+  font-size: 1.625rem;
+  line-height: 1.154;
 
   @media only screen and (min-width: $breakpoint-large) {
     font-size: 1.75rem;
@@ -266,13 +225,8 @@
 }
 
 @mixin heading-4 {
-  font-size: 1.334rem;
-  line-height: 1.2;
-
-  @media only screen and (min-width: $breakpoint-medium)  {
-    font-size: 1.375rem;
-    line-height: 1.364;
-  }
+  font-size: 1.375rem;
+  line-height: 1.364;
 
   @media only screen and (min-width: $breakpoint-large) {
     font-size: $sp-large;
@@ -281,13 +235,8 @@
 }
 
 @mixin heading-5 {
-  font-size: 1.2rem;
-  line-height: 1.334;
-
-  @media only screen and (min-width: $breakpoint-medium)  {
-    font-size: 1.188rem;
-    line-height: 1.264;
-  }
+  font-size: 1.188rem;
+  line-height: 1.264;
 
   @media only screen and (min-width: $breakpoint-large) {
     font-size: 1.313rem;
@@ -296,14 +245,8 @@
 }
 
 @mixin heading-6 {
-  font-size: 1.067rem;
-  line-height: 1.125;
+  font-size: 1.063rem;
+  line-height: 1.412;
   margin-bottom: 1.2rem;
-  margin-top: 1.2rem;
-
-  @media only screen and (min-width: $breakpoint-medium) {
-    font-size: 1.063rem;
-    line-height: 1.412;
-    margin-top: $sp-large;
-  }
+  margin-top: $sp-large;
 }


### PR DESCRIPTION
## Done
Set the base font size to always be the font-base-size across all breakpoints.

## QA
- I believe this review is just a code review
- Then check the percy output to see if anything has broken

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1053
