### PR TITLE
add margin-bottom to form labels + fix padding bug on fields

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -163,7 +163,7 @@
   font-size: $sp-medium;
   font-weight: 300;
   outline: none;
-  padding: .5333rem .8rem;
+  padding: $sp-x-small .8rem;
   vertical-align: baseline;
   width: 100%;
 

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -5,6 +5,7 @@
     display: block;
     font-size: $sp-medium;
     line-height: 1.5;
+    margin-bottom: $sp-x-small;
 
     @each $state, $color in $states {
       &.has-#{$state} {
@@ -162,12 +163,12 @@
   font-size: $sp-medium;
   font-weight: 300;
   outline: none;
-  padding: .8rem .5333rem;
+  padding: .5333rem .8rem;
   vertical-align: baseline;
   width: 100%;
 
   @media (min-width: $breakpoint-medium) {
-    padding: $sp-small $sp-x-small;
+    padding: $sp-x-small $sp-small;
   }
 
   &:active,


### PR DESCRIPTION
## Done

* added margin-bottom: 8px per the [spec](https://github.com/ubuntudesign/vanilla-design/blob/master/Forms/forms.md]
* swapped the vertical and horizontal padding on fields as they were added in the incorrect order per the spec

## QA

1. build the css
2. look at [jekyll demo page](http://127.0.0.1:4000/vanilla-framework/examples/base/forms/input/)
3. see that the label has 8px margin on the bottom and the text field has Padding vertical: 8px and Padding horizontal: 12px per the spec

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/26540220/351c8c66-4448-11e7-8c2f-9e81201ca281.png)
