### PR TITLE
remove border from .p-card—highlighted

### DIFF
--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -1,6 +1,5 @@
 @mixin p-card {
   background: $color-x-light;
-  border: 1px solid $color-mid-light;
   border-radius: 2px;
   margin-bottom: $sp-medium;
   padding: 1.333rem;
@@ -29,6 +28,7 @@
 
   .p-card {
     @include p-card;
+    border: 1px solid $color-mid-light;
 
     & & {
       margin-bottom: 0;
@@ -37,7 +37,6 @@
 
   .p-card--highlighted {
     @include p-card;
-    border: 0;
     box-shadow: 0 1px 5px 1px transparentize($color-dark, .8);
   }
 }

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -37,6 +37,7 @@
 
   .p-card--highlighted {
     @include p-card;
+    border: 0;
     box-shadow: 0 1px 5px 1px transparentize($color-dark, .8);
   }
 }

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -2,11 +2,7 @@
   background: $color-x-light;
   border-radius: 2px;
   margin-bottom: $sp-medium;
-  padding: 1.333rem;
-
-  @media (min-width: $breakpoint-medium) {
-    padding: 1.25rem;
-  }
+  padding: 1.25rem;
 
   &__title {
     font-size: $sp-large;


### PR DESCRIPTION
## Done

* removed border per the [spec](https://github.com/ubuntudesign/vanilla-design/blob/master/Card/card.md)

## QA

1. run locally
2. see the change [via jekyll](http://127.0.0.1:4000/vanilla-framework/examples/patterns/card/highlighted/)
3. compare to the spec and [demo](http://vanilla-framework-1074-remove-p-card-highlighted-border.demo.haus/vanilla-framework/examples/patterns/card/highlighted/)

## Details

Fixes #1074

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/26541522/e7c083f4-444d-11e7-9beb-5f4b5891303e.png)
