### PR TITLE
Add support for Cyrillic, Greek and Latin fonts

### DIFF
--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -117,6 +117,16 @@ descriptions.
 
 <p>This text is <sub>subscripted</sub></p>
 
+## Enabling Cyrillic, Greek and Latin fonts
+
+Due to the extra extra weight of loading these fonts they are not imported by
+default. To enable Cyrillic, Greek and Latin fonts on Ubuntu please set the
+following font setting to true.
+
+``` sass
+$font-allow-cyrillic-greek-latin: true;
+```
+
 <hr />
 
 ## Related

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -43,6 +43,62 @@
       font-weight: 400;
       src: url('#{$assets-path}871f7456-ubuntumono-r-webfont.woff2') format('woff2'), url('#{$assets-path}8df3f408-ubuntumono-r-webfont.woff') format('woff');
     }
+
+    @if $font-allow-cyrillic-greek-latin {
+      // cyrillic-ext
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: normal;
+        font-weight: 300;
+        src: local('Ubuntu'), url('#{$font-import}ODszJI8YqNw8V2xPulzjO_esZW2xOQ-xsNqO47m55DA.woff2') format('woff2');
+        unicode-range: U+0460-052F, U+20B4, U+2DE0-2DFF, U+A640-A69F;
+      }
+
+      // cyrillic
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: normal;
+        font-weight: 300;
+        src: local('Ubuntu'), url('#{$font-import}iQ9VJx1UMASKNiGywyyCXvesZW2xOQ-xsNqO47m55DA.woff2') format('woff2');
+        unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+      }
+
+      // greek-ext
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: normal;
+        font-weight: 300;
+        src: local('Ubuntu'), url('#{$font-import}WkvQmvwsfw_KKeau9SlQ2_esZW2xOQ-xsNqO47m55DA.woff2') format('woff2');
+        unicode-range: U+1F00-1FFF;
+      }
+
+      // greek
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: normal;
+        font-weight: 300;
+        src: local('Ubuntu'), url('#{$font-import}gYAtqXUikkQjyJA1SnpDLvesZW2xOQ-xsNqO47m55DA.woff2') format('woff2');
+        unicode-range: U+0370-03FF;
+      }
+
+      // latin-ext
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: normal;
+        font-weight: 300;
+        src: local('Ubuntu'), url('#{$font-import}Wu5Iuha-XnKDBvqRwQzAG_esZW2xOQ-xsNqO47m55DA.woff2') format('woff2');
+        unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+      }
+
+      // latin
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: normal;
+        font-weight: 300;
+        src: local('Ubuntu'), url('#{$font-import}sDGTilo5QRsfWu6Yc11AXg.woff2') format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215;
+      }
+    }
   }
 
   * {

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -1,11 +1,13 @@
 // Global font settings
 
-$font-base-family:       '"Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif' !default;
+$font-base-family:                '"Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif' !default;
 
-$font-monospace:         '"Ubuntu Mono", Consolas, Monaco, Courier, monospace' !default;
+$font-monospace:                  '"Ubuntu Mono", Consolas, Monaco, Courier, monospace' !default;
 
-$font-base-size:         16px !default;
+$font-base-size:                  16px !default;
 
-$font-heading-family:    $font-base-family !default;
+$font-heading-family:             $font-base-family !default;
 
-$font-import:            'http://fonts.googleapis.com/css?family=Ubuntu' !default;
+$font-import:                     'http://fonts.gstatic.com/s/ubuntu/v9/' !default;
+
+$font-allow-cyrillic-greek-latin: false !default;


### PR DESCRIPTION
## Done
Added the ability to import Cyrillic, Greek and Latin fonts which are enabled via a font setting.

## QA
- Pull branch and run `./run`
- Edit the `headings.md ` file in docs by changing the text of one of the headings to "АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧ"
- Go to http://0.0.0.0:8101/vanilla-framework/examples/base/headings/
- Inspect the heading and go to computed styles and scroll to the bottom and see what the rendered font is. Check it's not Ubuntu.
- Add the following to line 46 of `_base_typography.scss`
``` scss
$font-allow-cyrillic-greek-latin: true;
```
- Refresh the headings page and see the Cyrillic font is rendered by Ubuntu

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/699
