### PR TITLE
Align double digit stepped list

### DIFF
--- a/examples/patterns/lists/lists-stepped.html
+++ b/examples/patterns/lists/lists-stepped.html
@@ -39,7 +39,7 @@ category: _patterns
 
   <li class="p-list-step__item col-8">
     <h3 class="p-list-step__title">
-      <span class="p-list-step__bullet">5</span>
+      <span class="p-list-step__bullet">99</span>
       Last but not least
     </h3>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed purus lorem, dictum vel dolor eu, tincidunt suscipit magna. Suspendisse dignissim nisl vitae turpis iaculis, ut tempor enim gravida.</p>

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -164,16 +164,16 @@
     }
 
     &__bullet {
-      background: $color-mid-dark;
+      background-color: $color-mid-dark;
       border-radius: 50%;
       color: $color-x-light;
       display: inline-block;
       font-size: $sp-large;
       height: 50px;
+      line-height: 50px;
       margin-bottom: .625rem;
       margin-left: -$grid-gutter-width * 3;
       margin-right: .34375rem;
-      padding: .65rem 0;
       text-align: center;
       width: 50px;
 

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -137,13 +137,16 @@
 // Displays a step by step list of instructions
 @mixin vf-p-stepped-list {
   .p-list-step {
-    @extend %clearfix;
     list-style: none;
     margin-left: $grid-gutter-width * 3;
     padding: 0;
 
     &__title {
       position: relative;
+
+      @media only screen and (min-width: $breakpoint-large) {
+        margin-bottom: 0;
+      }
     }
 
     &__item {
@@ -153,37 +156,31 @@
 
       &:first-child {
         margin-top: $sp-small;
+
+        @media only screen and (min-width: $breakpoint-large) {
+          margin-top: 0;
+        }
       }
     }
-  }
 
-  @media only screen and (min-width: $breakpoint-large) {
-    .p-list-step__item:first-child {
-      margin-top: 0;
-    }
+    &__bullet {
+      background: $color-mid-dark;
+      border-radius: 50%;
+      color: $color-x-light;
+      display: inline-block;
+      font-size: $sp-large;
+      height: 50px;
+      margin-bottom: .625rem;
+      margin-left: -$grid-gutter-width * 3;
+      margin-right: .34375rem;
+      padding: .65rem 0;
+      text-align: center;
+      width: 50px;
 
-    .p-list-step__title {
-      margin-bottom: 0;
-    }
-  }
-
-  .p-list-step__bullet {
-    background: $color-mid-dark;
-    border-radius: 50%;
-    color: $color-x-light;
-    display: inline-block;
-    font-size: $sp-large;
-    height: 50px;
-    margin-bottom: .625rem;
-    margin-left: -$grid-gutter-width * 3;
-    margin-right: .34375rem;
-    padding: .65rem 1.15rem;
-    text-align: center;
-    width: 50px;
-
-    @media only screen and (max-width: $breakpoint-large) {
-      position: absolute;
-      top: -5px;
+      @media only screen and (max-width: $breakpoint-large) {
+        position: absolute;
+        top: -5px;
+      }
     }
   }
 }


### PR DESCRIPTION
## Done
Refactor and fix the bullet number alignment issue.

## QA
- Pull down this branch
- Run `./run`
- Go to http://0.0.0.0:8101/vanilla-framework/examples/patterns/lists/lists-stepped/
- Check that the 99 is aligned in the bullet
- Check that the stepped list pattern looks the same as the live version at https://vanilla-framework.github.io/vanilla-framework/examples/patterns/lists/lists-stepped/

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1105
Partly fixes https://github.com/vanilla-framework/vanilla-brochure-theme/issues/81

## Screenshots
![lists - stepped - vanilla framework - examples](https://user-images.githubusercontent.com/1413534/26927025-023f349e-4c48-11e7-9186-ec52443be14b.png)
