### PR TITLE
Update default button styling to neutral

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -11,13 +11,18 @@
 /// override colors as desired
 @mixin button-pattern (
   $button-background-color: $color-x-light,
-  $button-border-color: $color-mid-dark,
   $button-text-color: $color-x-dark,
-  $button-hover-background-color: rgba(0, 0, 0, .1),
-  $button-hover-border-color: $color-mid-dark,
   $button-disabled-background-color: $color-transparent,
-  $button-disabled-border-color: $color-transparent
+  $button-disabled-border-color: $color-mid-light,
+  $button-border-color: $color-mid-light,
+  $button-hover-background-color: $color-light,
+  $button-hover-border-color: $color-mid-light
 ) {
+  @include animation(
+    $property: background-color,
+    $duration: fast,
+    $easing: in
+  );
   background-color: $button-background-color;
   border-color: $button-border-color;
   border-radius: .125rem;
@@ -37,7 +42,6 @@
   padding: $sp-small $sp-large;
   text-align: center;
   text-decoration: none;
-  transition: background-color .2s;
   width: 100%;
 
   @media only screen and (min-width: $breakpoint-medium) {

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -11,7 +11,7 @@
 /// override colors as desired
 @mixin button-pattern (
   $button-background-color: $color-x-light,
-  $button-text-color: $color-x-dark,
+  $button-text-color: $color-dark,
   $button-disabled-background-color: $color-transparent,
   $button-disabled-border-color: $color-mid-light,
   $button-border-color: $color-mid-light,


### PR DESCRIPTION
## Done
Changed the default button styling to match the neutral button styling. Updated the button animation to use the new animation mixin.

## QA
- Pull this branch and run `./run`
- Go to http://0.0.0.0:8101/vanilla-framework/examples/base/button/
- Check that is matches the [neutral spec](https://github.com/ubuntudesign/vanilla-design/blob/master/Buttons/buttons.md#common)
- See that the background transition on hover.
- Check the other button are not affected.

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1097

## Demo
http://vanilla-framework-default-button.demo.haus/vanilla-framework/
