### PR TITLE
Vertically center should not affect all breakpoints

### DIFF
--- a/docs/en/utilities/vertically-center.md
+++ b/docs/en/utilities/vertically-center.md
@@ -7,7 +7,7 @@ site_title: Vertically center | Vanilla framework documentation
 
 The `.u-vertically-center` class will vertically center the direct child of the element it is placed on.
 
-Note: only effects medium and large screens.
+Note: only affects medium and large screens.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/vertically-center/"
     class="js-example">

--- a/docs/en/utilities/vertically-center.md
+++ b/docs/en/utilities/vertically-center.md
@@ -7,6 +7,8 @@ site_title: Vertically center | Vanilla framework documentation
 
 The `.u-vertically-center` class will vertically center the direct child of the element it is placed on.
 
+Note: only effects medium and large screens.
+
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/vertically-center/"
     class="js-example">
     View example of the vertically center utility

--- a/scss/_utilities_vertically-center.scss
+++ b/scss/_utilities_vertically-center.scss
@@ -1,7 +1,9 @@
 // Vertically align
 @mixin vf-u-vertically-center {
-  .u-vertically-center {
-    align-items: center !important;
-    display: flex !important;
+  @media (min-width: $breakpoint-medium) {
+    .u-vertically-center {
+      align-items: center !important;
+      display: flex !important;
+    }
   }
 }


### PR DESCRIPTION
## Done
Limited the vertical align utility to medium and large screens. Added a note to the documentation of the vertical align utility.

## QA
- Pull branch and run `./run serve`
- Go to http://0.0.0.0:8101/vanilla-framework/examples/utilities/vertically-center/
- Check that is works as before
- Scale to small screen and see that item is no longer vertically aligned

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1110

