### PR TITLE
Add the missing semi colon to the breakpoint settings

### DIFF
--- a/scss/_settings_breakpoints.scss
+++ b/scss/_settings_breakpoints.scss
@@ -6,4 +6,5 @@ $breakpoint-medium:               768px !default;
 
 $breakpoint-large:                1030px !default;
 
-$breakpoint-navigation-threshold: $breakpoint-medium !default
+$breakpoint-navigation-threshold: $breakpoint-medium !default;
+


### PR DESCRIPTION
## Done
Quick fix to add the missing semi colon to the breakpoint settings.

## QA
- Check code and maybe see Vanilla runs fine.
