### PR TITLE
Vertically align 'Menu' toggle on S screens

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-gem 'jekyll', '~> 3.4.0'
+gem 'jekyll', '~> 3.5.0'
 
 require 'rbconfig'
 if RbConfig::CONFIG['target_os'] =~ /darwin(1[0-3])/i

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.0)
+    addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     colorator (1.1.0)
-    ffi (1.9.17)
+    ffi (1.9.18)
     forwardable-extended (2.6.0)
-    jekyll (3.4.0)
+    jekyll (3.5.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
-      liquid (~> 3.0)
+      liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
       rouge (~> 1.7)
@@ -22,7 +22,7 @@ GEM
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
     kramdown (1.13.2)
-    liquid (3.0.6)
+    liquid (4.0.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -31,17 +31,17 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
     rb-fsevent (0.9.8)
-    rb-inotify (0.9.8)
-      ffi (>= 0.5.0)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
     rouge (1.11.1)
     safe_yaml (1.0.4)
-    sass (3.4.23)
+    sass (3.4.24)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 3.4.0)
+  jekyll (~> 3.5.0)
 
 BUNDLED WITH
    1.13.4

--- a/examples/patterns/navigation/dark.html
+++ b/examples/patterns/navigation/dark.html
@@ -6,13 +6,15 @@ category: _patterns
 
 <header id="navigation" class="p-navigation" role="banner">
   <div class="row">
-    <div class="p-navigation__logo">
-      <a class="p-navigation__link" href="#">
-        Vanilla
-      </a>
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="#">
+          Vanilla
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Menu</a>
     </div>
-    <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-    <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Menu</a>
     <nav class="p-navigation__nav">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>

--- a/examples/patterns/navigation/light.html
+++ b/examples/patterns/navigation/light.html
@@ -6,13 +6,15 @@ category: _patterns
 
 <header id="navigation" class="p-navigation--light" role="banner">
   <div class="row">
-    <div class="p-navigation__logo">
-      <a class="p-navigation__link" href="#">
-        Vanilla
-      </a>
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="#">
+          Vanilla
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Menu</a>
     </div>
-    <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-    <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Menu</a>
     <nav class="p-navigation__nav">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -43,6 +43,15 @@
   }
 
   .p-navigation {
+
+    &__banner {
+
+      @media (max-width: $breakpoint-medium) {
+        overflow: hidden;
+        position: relative;
+      }
+    }
+
     &__toggle--open,
     &__toggle--close,
     &__link {
@@ -65,8 +74,10 @@
     &__toggle {
       &--open,
       &--close {
-        float: right;
-        margin: $sp-small $sp-medium;
+        margin: 0;
+        position: absolute;
+        right: 1rem;
+        top: calc(50% - .75rem);
 
         @media (min-width: $breakpoint-navigation-threshold + 1) {
           display: none;


### PR DESCRIPTION
## Done

- Bumped jekyll gem version to 3.5.0
- Tweaked 'Menu' button on S screens to that it is always centred, regardless of how big the logo in the pattern is

## QA

- Pull code
- Run `gulp jekyll`
- Go to http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/dark/
- Ensure Menu toggle is centred on small screen no matter how high you make the logo
- Go to http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/light/
- Ensure Menu toggle is centred on small screen no matter how high you make the logo

## Details

Fixes #1103 

## Screenshots

<img width="890" alt="screen shot 2017-06-20 at 17 07 49" src="https://user-images.githubusercontent.com/505570/27343502-094dfe4a-55db-11e7-8551-d6fc6011218a.png">

<img width="771" alt="screen shot 2017-06-20 at 16 17 59" src="https://user-images.githubusercontent.com/505570/27341119-374b1686-55d4-11e7-9557-7983dd51d8aa.png">
