### PR TITLE
Make sure nav pattern last item has bottom border

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -23,7 +23,6 @@
       $border-color: $color-mid-light,
       $text-color: $color-dark
     );
-    border-bottom: 1px solid $color-mid-light;
   }
 }
 
@@ -136,6 +135,10 @@
           border-top: 1px solid $color-mid-light;
           color: $color-dark;
           text-align: left;
+
+          &:last-child {
+            border-bottom: 1px solid $color-mid-light;
+          }
         }
 
         @media (min-width: $breakpoint-navigation-threshold + 1) {


### PR DESCRIPTION
## Done

Make sure nav pattern last item has bottom border

## QA

- Pull code
- Run `gulp jekyll`
- Reduce the screen width to small screen breakpoint
- Go to http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/dark/
- Open menu and verify the last item has a bottom border
- Go to http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/light/
- Open menu and verify the last item has a bottom border

## Details

Fixes #1104 

## Demo

Dark: http://vanilla-framework-1104-s-screen-nav-border.demo.haus/vanilla-framework/examples/patterns/navigation/dark/

Light: http://vanilla-framework-1104-s-screen-nav-border.demo.haus/vanilla-framework/examples/patterns/navigation/light/