### PR TITLE
Add docs for spacing settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ env3/
 # Project-specific ignores
 js/app.js.map
 
+/docs/build

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -18,6 +18,11 @@ navigation:
   - location: settings/layout-settings.md
     title: Layout
 
+  - location: settings/spacing-settings.md
+    title: Spacing
+
+
+
 - title: Base
   children:
 

--- a/docs/en/settings/spacing-settings.md
+++ b/docs/en/settings/spacing-settings.md
@@ -5,16 +5,16 @@ site_title: Spacing | Vanilla framework documentation
 
 # Spacing
 
-Vanilla uses spacing variables across the codebase to help ensure consistency of spacing between elements in across patterns and utilities. 
+Vanilla uses spacing variables across the codebase to help ensure consistency of spacing between elements in across patterns and utilities.
 
 Setting  | Default value
  ------------- | -------------
-`$sp-xx-small` | 0.25rem
-`$sp-x-small` | 0.5rem
-`$sp-small` | 0.75rem
-`$sp-medium` | 1rem
-`$sp-large` | 1.5rem
-`$sp-x-large` | 2rem
-`$sp-xx-large` | 2.5rem
-`$sp-xxx-large` | 3rem
+`$sp-xx-small` | `0.25rem`
+`$sp-x-small` | `0.5rem`
+`$sp-small` | `0.75rem`
+`$sp-medium` | `1rem`
+`$sp-large` | `1.5rem`
+`$sp-x-large` | `2rem`
+`$sp-xx-large` | `2.5rem`
+`$sp-xxx-large` | `3rem`
 

--- a/docs/en/settings/spacing-settings.md
+++ b/docs/en/settings/spacing-settings.md
@@ -1,0 +1,20 @@
+---
+title: Spacing
+site_title: Spacing | Vanilla framework documentation
+---
+
+# Spacing
+
+Vanilla uses spacing variables across the codebase to help ensure consistency of spacing between elements in across patterns and utilities. 
+
+Setting  | Default value
+ ------------- | -------------
+`$sp-xx-small` | 0.25rem
+`$sp-x-small` | 0.5rem
+`$sp-small` | 0.75rem
+`$sp-medium` | 1rem
+`$sp-large` | 1.5rem
+`$sp-x-large` | 2rem
+`$sp-xx-large` | 2.5rem
+`$sp-xxx-large` | 3rem
+


### PR DESCRIPTION
## Done

Add docs for spacing settings

## QA

- Pull code
- Build and view docs as per https://github.com/vanilla-framework/vanilla-framework#building-documentation-pages
- Check that 'Settings  > Spacing' section is correct and reflects https://github.com/vanilla-framework/vanilla-framework/blob/develop/scss/_settings_spacing.scss

## Details

Fixes #1048 