### PR TITLE
Remove padding jump from input elements

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -177,13 +177,9 @@
   font-size: $sp-medium;
   font-weight: 300;
   outline: none;
-  padding: .8rem .5333rem;
+  padding: $sp-x-small $sp-small;
   vertical-align: baseline;
   width: 100%;
-
-  @media (min-width: $breakpoint-medium) {
-    padding: $sp-small $sp-x-small;
-  }
 
   &:active,
   &:focus {


### PR DESCRIPTION
## Done

Remove padding jump from input elements between breakpoints

## QA

- Pull code
- Run `./run serve --watch`
- Go to: http://0.0.0.0:8101/vanilla-framework/examples/base/forms/input/
- Ensure there is no jump in input fields between breakpoints

## Demo

http://vanilla-framework-fix-input-padding-jump.demo.haus/

## Details

This was raised as part of a review point for #1086