### PR TITLE
Add padding to single element in rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ title: Home
 <!-- Header -->
 <div class="p-strip">
     <div class="row">
-      <div class="12-col">
+      <div class="col-12">
         <h1>{{ site.name }}</h1>
         <hr />
       </div>

--- a/scss/_patterns_vertical-spacing.scss
+++ b/scss/_patterns_vertical-spacing.scss
@@ -63,11 +63,11 @@
   }
 
   // Adds padding to single element rows
-  .row > *:only-child {
+  .row > *:only-child:not([class^="#{$grid-col-name}-"]) {
     @include default-vertical-spacing;
   }
 
-  .row:first-of-type > *:only-child {
+  .row:first-of-type > *:only-child:not([class^="#{$grid-col-name}-"]) {
     margin-bottom: 1.25rem;
     margin-top: 0;
 

--- a/scss/_patterns_vertical-spacing.scss
+++ b/scss/_patterns_vertical-spacing.scss
@@ -61,4 +61,22 @@
       }
     }
   }
+
+  // Adds padding to single element rows
+  .row > *:only-child {
+    @include default-vertical-spacing;
+  }
+
+  .row:first-of-type > *:only-child {
+    margin-bottom: 1.25rem;
+    margin-top: 0;
+
+    @media screen and (min-width: #{$breakpoint-medium}) {
+      margin-bottom: 1.75rem;
+    }
+
+    @media screen and (min-width: #{$breakpoint-large}) {
+      margin-bottom: $sp-x-large;
+    }
+  }
 }

--- a/scss/_patterns_vertical-spacing.scss
+++ b/scss/_patterns_vertical-spacing.scss
@@ -10,6 +10,19 @@
   }
 }
 
+@mixin default-vertical-spacing-reversed {
+  margin-bottom: 1.25rem;
+  margin-top: 0;
+
+  @media screen and (min-width: #{$breakpoint-medium}) {
+    margin-bottom: 1.75rem;
+  }
+
+  @media screen and (min-width: #{$breakpoint-large}) {
+    margin-bottom: $sp-x-large;
+  }
+}
+
 @mixin vf-p-vertical-spacing {
   * {
     + * {
@@ -63,20 +76,19 @@
   }
 
   // Adds padding to single element rows
-  .row > *:only-child:not([class^="#{$grid-col-name}-"]) {
-    @include default-vertical-spacing;
-  }
-
-  .row:first-of-type > *:only-child:not([class^="#{$grid-col-name}-"]) {
-    margin-bottom: 1.25rem;
-    margin-top: 0;
-
-    @media screen and (min-width: #{$breakpoint-medium}) {
-      margin-bottom: 1.75rem;
+  .row {
+    &:first-of-type > *:only-child {
+      &:not([class^="#{$grid-col-name}-"]),
+      & > *:not([class^="#{$grid-col-name}-"]) {
+        @include default-vertical-spacing-reversed;
+      }
     }
 
-    @media screen and (min-width: #{$breakpoint-large}) {
-      margin-bottom: $sp-x-large;
+    & > *:only-child {
+      &:not([class^="#{$grid-col-name}-"]),
+      & > *:not([class^="#{$grid-col-name}-"]) {
+        @include default-vertical-spacing;
+      }
     }
   }
 }


### PR DESCRIPTION
## Done
Targeting single elements within rows and adding the spacing required. 

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Edit one of the examples with the following example:
``` html
<section class="p-strip--dark">
  <div class="row">
    <h2>Title</h2>
  </div>
  <div class="row">
    <div class="col-6">
      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
    </div>
    <div class="col-6">
      <img src="http://suplugins.com/podium/images/placeholder-05.jpg" alt="" />
    </div>
  </div>
</section>

<section class="p-strip is-bordered">
  <div class="row">
    <div class="col-4 p-card">
      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
    </div>
    <div class="col-4 p-card">
      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
    </div>
    <div class="col-4 p-card">
      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
    </div>
  </div>
  <div class="row">
    <div class="col-12">
      <p><button class="p-button--neutral">Neutral button</button></p>
    </div>
  </div>
</section>
```
- Go to the pattern and see that title has spacing from the paragraph and the button has padding from the cards.

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1091

## Screenshots
![breadcrumbs - vanilla framework - examples](https://user-images.githubusercontent.com/1413534/27632887-011db9ca-5bf5-11e7-81d6-55807475009d.png)
