### PR TITLE
Allow correct spacing between consecutive fieldset

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -134,6 +134,10 @@
       padding: .9375rem 1.25rem;
     }
 
+    & + & {
+      @include default-vertical-spacing;
+    }
+
     h3 {
       border-bottom: 1px dotted $color-mid-dark;
       padding-bottom: .625rem;

--- a/scss/_base_vertical-spacing.scss
+++ b/scss/_base_vertical-spacing.scss
@@ -25,7 +25,7 @@
   }
 }
 
-@mixin vf-p-vertical-spacing {
+@mixin vf-b-vertical-spacing {
   * {
     + * {
       @include default-vertical-spacing;

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -30,7 +30,8 @@
 'base_media',
 'base_reset',
 'base_tables',
-'base_typography';
+'base_typography',
+'base_vertical-spacing';
 
 // Patterns
 @import
@@ -50,8 +51,7 @@
 'patterns_notifications',
 'patterns_pull-quotes',
 'patterns_strip',
-'patterns_form-validation',
-'patterns_vertical-spacing';
+'patterns_form-validation';
 
 // Utilities
 @import
@@ -72,6 +72,7 @@
 @mixin vanilla {
   // Reset
   @include vf-b-reset;
+  @include vf-b-vertical-spacing;
   // Base
   @include vf-b-blockquotes;
   @include vf-b-box-sizing;
@@ -101,7 +102,6 @@
   @include vf-p-pull-quotes;
   @include vf-p-strip;
   @include vf-p-form-validation;
-  @include vf-p-vertical-spacing;
   // Utilities
   @include vf-u-clearfix;
   @include vf-u-floats;

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -72,7 +72,6 @@
 @mixin vanilla {
   // Reset
   @include vf-b-reset;
-  @include vf-b-vertical-spacing;
   // Base
   @include vf-b-blockquotes;
   @include vf-b-box-sizing;
@@ -86,6 +85,7 @@
   @include vf-b-media;
   @include vf-b-tables;
   @include vf-b-typography;
+  @include vf-b-vertical-spacing;
   // Patterns
   @include vf-p-breadcrumbs;
   @include vf-p-buttons;

--- a/scss/base.scss
+++ b/scss/base.scss
@@ -11,11 +11,13 @@
 'base_media',
 'base_reset',
 'base_tables',
-'base_typography';
+'base_typography',
+'base_vertical-spacing';
 
 // Reset
 @include vf-b-reset;
 // Base
+@include vf-b-vertical-spacing;
 @include vf-b-blockquotes;
 @include vf-b-box-sizing;
 @include vf-b-button;


### PR DESCRIPTION
## Done

Allow correct spacing between consecutive fieldset

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/forms/fieldset/
- Edit the example html file and copy/paste the fieldset so there are two in the page
- Verify that the space between the two consecutive fieldsets is `1.5rem`

## Details

Fixes #1081
