### PR TITLE
Remove header top margin

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -36,6 +36,7 @@
   @extend %clearfix;
   background-color: $background-color;
   color: $text-color;
+  margin-top: 0;
   position: relative;
   width: 100%;
 


### PR DESCRIPTION
## Done

Remove header top margin introduced with the new vertical rhythm https://github.com/vanilla-framework/vanilla-framework/pull/1095

## QA

[See issue 1140 for details](https://github.com/vanilla-framework/vanilla-framework/issues/1140) 

## Details

Fixes #1140 

![screen shot 2017-07-04 at 11 43 56](https://user-images.githubusercontent.com/2152/27827289-7c5d2586-60ae-11e7-9b4a-53a4dbc2a4ea.png)