### PR TITLE
Add bottom border to L screen navigation

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -25,6 +25,7 @@
       $border-color: $color-mid-light,
       $text-color: $color-dark
     );
+    border-bottom: 1px solid $color-mid-light;
   }
 }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -26,6 +26,11 @@
       $text-color: $color-dark
     );
     border-bottom: 1px solid $color-mid-light;
+
+    // remove double bottom border on open nav
+    &:target .p-navigation__nav .p-navigation__link:last-child {
+      border-bottom: 0;
+    }
   }
 }
 


### PR DESCRIPTION

## Done

Add bottom border to L screen navigation

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/light/
- Verify bottom border on L breakpoints is correct

## Demo

http://vanilla-framework-1150-nav-btn-border.demo.haus/vanilla-framework/examples/patterns/navigation/light/

## Details

Fixes #1150
