### PR TITLE
Zero margin bottom on `.u-equal-height` util

### DIFF
--- a/scss/_utilities_equal-height.scss
+++ b/scss/_utilities_equal-height.scss
@@ -9,4 +9,9 @@
       display: flex;
     }
   }
+
+  // Zero margin bottom if .u-equal-height is the only class applied to an element
+  [class="u-equal-height"] {
+    margin-bottom: 0 !important;
+  }
 }


### PR DESCRIPTION
## Done

Zero margin bottom if `.u-equal-height` is the only class applied to an element

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/utilities/equal-height/
- Duplicate the code block and verify that `.u-equal-height` does not have bottom margin

## Details

Fixes #1152
