### PR TITLE
Zero top margin on `<pre>` elements

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -16,10 +16,15 @@
     hyphens: none;
     line-height: 1.5;
     margin-bottom: 0;
+    margin-top: 0;
     tab-size: 4;
     white-space: pre-wrap;
     word-spacing: normal;
     word-wrap: break-word;
+
+    & + & {
+      @include default-vertical-spacing;
+    }
   }
 
   pre {


### PR DESCRIPTION
## Done

User stylesheets tend to add `1em` of margin-top onto `<pre>` tags by default. This change will zero top margin on `<pre>` elements

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/code/
- Paste the following into `/examples/base/code.html`

```
<div id="getting-started" class="p-strip is-bordered is-deep"> <div class="row"> <div class="col-12"> <h2>Quick start</h2> </div> </div> <div class="row"> <div class="col-5"> <p>The recommended method of including Vanilla Framework in your project is via NPM. You can then simply include the framework in your SCSS files and compile.</p> <p>For other methods, please see the <a href="#">advanced usage docs.</a></p> </div> <div class="col-7 prefix-1">
  
    <pre><code>npm install --save-dev vanilla-framework
<span class="hljs-built_in">export</span> SASS_PATH=`<span class="hljs-built_in">pwd</span>`/node_modules:<span class="hljs-variable">${SASS_PATH}</span>

<span class="hljs-comment">// Add to your main build scss file the following line</span>
<span class="hljs-annotation">@import</span> <span class="hljs-string">'vanilla-framework/scss/build'</span></code></pre>
    </div> </div> </div>
```

Check that the code block does not have top margin.

## Details

Fixes #1153
