### PR TITLE
As discussed, recommend --save-dev

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -10,7 +10,7 @@ You can use Vanilla in your projects in a few different ways.
 
 The recommended way to get Vanilla is through [npm](https://www.npmjs.com/):
 
-`npm install --save vanilla-framework`
+`npm install --save-dev vanilla-framework`
 
 This will pull down the latest version into your local `node_modules` folder and save it into your project's dependencies in `package.json`.
 


### PR DESCRIPTION
Fixes #1139.

After some discussion on [a PR](https://github.com/vanilla-framework/vanilla-framework/pull/1136#discussion_r125323595) and in Slack it was decided that we should advise `--save-dev` instead of `--save`, because the end-user is most likely to be writing a website rather than a Sass module - and in that case they probably want to add Vanilla to `devDependencies` rather than `dependencies`. And in any case, that is simply the more cautious thing to do and therefore a better thing to recommend.