### PR TITLE
Add themes to the navigation

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -121,3 +121,9 @@ navigation:
 
     - location: utilities/visibility.md
       title: Visibility
+
+- title: Themes
+  children:
+
+    - location: vanilla-brochure-theme/
+      title: Brochure theme


### PR DESCRIPTION
## Done
Added themes to the docs navigation

## QA

- Pull code
- Switch over to your docs.vanillaframework.io branch
- Create a file callled `build-local` with the follow content:
```bash
echo 'Building vanilla-frameworks documentation'
documentation-builder --base-directory ../vanilla-framework/docs  \
                      --site-root '/en/'  \
                      --output-path .  \
                      --template-path template.html  \
                      --tag-manager-code 'GTM-K92JCQ'  \
                      --no-link-extensions \
                      --force
echo 'Completed vanilla-framework documentation build'

echo 'Build vanilla-brochure-theme documentation'
documentation-builder --base-directory ../vanilla-brochure-theme/docs \
                      --site-root '/en/vanilla-brochure-theme' \
                      --output-path 'en/vanilla-brochure-theme' \
                      --template-path template.html \
                      --tag-manager-code 'GTM-K92JCQ'  \
                      --no-link-extensions \
                      --force

mv en/vanilla-brochure-theme/en/* en/vanilla-brochure-theme/.
rm -rf en/vanilla-brochure-theme/en/
echo 'Completed vanilla-brochure-theme documentation build'
```
- Run `./build-local`
- Run `caddy`
- Go to http://127.0.0.1:8543/en/
- Check that Themes is in the navigation and links to the vanilla-brochure-theme documentation.

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1160
