### PR TITLE
Improve the single element padding

### DIFF
--- a/scss/_base_vertical-spacing.scss
+++ b/scss/_base_vertical-spacing.scss
@@ -81,14 +81,14 @@
   .row {
     &:first-of-type > *:only-child {
       &:not([class^="#{$grid-col-name}-"]),
-      & > *:not([class^="#{$grid-col-name}-"]) {
+      & > *:only-child:not([class^="#{$grid-col-name}-"]) {
         @include default-vertical-spacing-reversed;
       }
     }
 
     & > *:only-child {
       &:not([class^="#{$grid-col-name}-"]),
-      & > *:not([class^="#{$grid-col-name}-"]) {
+      & > *:only-child:not([class^="#{$grid-col-name}-"]) {
         @include default-vertical-spacing;
       }
     }


### PR DESCRIPTION
## Done
Targeting **only** single elements within rows and adding the spacing required. 

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Edit one of the examples with the following example:
``` html
<section class="p-strip--dark">
  <div class="row">
    <h2>Title</h2>
  </div>
  <div class="row">
    <div class="col-6">
      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
    </div>
    <div class="col-6">
      <img src="http://suplugins.com/podium/images/placeholder-05.jpg" alt="" />
    </div>
  </div>
</section>

<section class="p-strip is-bordered">
  <div class="row">
    <div class="col-4 p-card">
      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
    </div>
    <div class="col-4 p-card">
      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
    </div>
    <div class="col-4 p-card">
      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
    </div>
  </div>
  <div class="row">
    <div class="col-12">
      <p><button class="p-button--neutral">Neutral button</button></p>
    </div>
  </div>
</section>
```
- Go to the pattern and see that title has spacing from the paragraph and the button has padding from the cards.
