### PR TITLE
Update the brochure link in navigation

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -125,5 +125,5 @@ navigation:
 - title: Themes
   children:
 
-    - location: vanilla-brochure-theme/
+    - location: vanilla-brochure-theme/index.md
       title: Brochure theme


### PR DESCRIPTION
## Done
Update the brochure theme link in the themes navigation

## QA

- Pull code
- `cd` to your docs.vanillaframework.io branch
- Create a file called `build-local` and add the content below:
```bash
BLUE='\033[1;34m'
GREEN='\033[0;32m'
NC='\033[0m' # No Color

echo "${BLUE}Clearing build${NC}"
rm -rf en
echo "${GREEN}Build removed${NC}"

echo "${BLUE}Building vanilla-frameworks documentation${NC}"
documentation-builder --base-directory ../vanilla-framework/docs  \
                      --site-root '/en/'  \
                      --output-path .  \
                      --template-path template.html  \
                      --tag-manager-code 'GTM-K92JCQ'  \
                      --no-link-extensions \
                      --force
echo "${GREEN}Completed vanilla-framework documentation build${NC}"

echo "${BLUE}Build vanilla-brochure-theme documentation${NC}"
documentation-builder --base-directory ../vanilla-brochure-theme/docs \
                      --site-root '/en/vanilla-brochure-theme/index' \
                      --output-path 'en/vanilla-brochure-theme' \
                      --template-path template.html \
                      --tag-manager-code 'GTM-K92JCQ'  \
                      --no-link-extensions \
                      --force

mv en/vanilla-brochure-theme/en/* en/vanilla-brochure-theme/.
rm -rf en/vanilla-brochure-theme/en/
echo "${GREEN}Completed vanilla-brochure-theme documentation build${NC}"
```

- Run `caddy`
- Go to http://127.0.0.1:8543/en/
- Click on Themes > Brochure theme
- Check the URL is http://127.0.0.1:8543/en/vanilla-brochure-theme/index not http://127.0.0.1:8543/en/vanilla-brochure-theme

