### PR TITLE
Remove color from pull quotes pattern

### DIFF
--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -33,7 +33,6 @@
 
     > p {
       @include heading-3;
-      color: $color-dark;
       font-style: normal;
 
       &:first-of-type::before {


### PR DESCRIPTION
## Done
Remove color from the pull quote pattern.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/en/patterns/pull-quote
- Check the pull quote looks the same as https://docs.vanillaframework.io/en/patterns/pull-quote

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1166
