### PR TITLE
Remove right/left padding from Matrix pattern

### DIFF
--- a/examples/patterns/matrix.html
+++ b/examples/patterns/matrix.html
@@ -47,4 +47,25 @@ category: _patterns
       <p class="p-matrix__desc">Short description</p>
     </div>
   </li>
+  <li class="p-matrix__item">
+    <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+    <div class="p-matrix__content">
+      <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
+      <p class="p-matrix__desc">Short description</p>
+    </div>
+  </li>
+  <li class="p-matrix__item">
+    <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+    <div class="p-matrix__content">
+      <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
+      <p class="p-matrix__desc">Short description</p>
+    </div>
+  </li>
+  <li class="p-matrix__item">
+    <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+    <div class="p-matrix__content">
+      <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
+      <p class="p-matrix__desc">Short description</p>
+    </div>
+  </li>
 </ul>

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -16,7 +16,7 @@
       @extend %clearfix;
       border-top: 1px dotted $color-mid-dark;
       margin-top: 0;
-      padding: $sp-medium;
+      padding: $sp-medium 0;
 
       &:empty {
         display: none; // hide orphans
@@ -30,11 +30,21 @@
         border-right: 1px dotted $color-mid-dark;
         border-top: 1px dotted $color-mid-dark;
         margin-bottom: 0;
-        padding-right: $sp-medium;
-        width: calc(33.333% - .666666rem);
+        padding: $sp-medium;
+        width: 33.333%;
 
         &:empty {
           display: block; // hide orphans
+        }
+
+        &:first-child,
+        &:nth-child(4n) {
+          padding-left: 0;
+        }
+
+        &:last-child,
+        &:nth-child(3n) {
+          padding-right: 0;
         }
 
         &:nth-child(-n+3) {

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -38,7 +38,7 @@
         }
 
         &:first-child,
-        &:nth-child(4n) {
+        &:nth-child(3n+1) {
           padding-left: 0;
         }
 


### PR DESCRIPTION
## Done

Remove right/left padding from Matrix pattern

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/matrix/
- Check that the pattern has no right or left padding

## Details

Fixes #1066 