### PR TITLE
Remove background color rules from fieldsets

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -124,15 +124,9 @@
 
   // Fieldset styles
   fieldset {
-    background-color: $color-light;
-    background-position: -.9375rem -.9375rem;
-    background-repeat: no-repeat;
+    border: 1px solid $color-mid-light;
     border-radius: .125rem;
     padding: .9375rem 1.25rem;
-
-    @media only screen and (min-width: $breakpoint-large) {
-      padding: .9375rem 1.25rem;
-    }
 
     & + & {
       @include default-vertical-spacing;

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -124,8 +124,9 @@
 
   // Fieldset styles
   fieldset {
-    border: 1px solid $color-mid-light;
+    background-color: $color-light;
     border-radius: .125rem;
+    color: $color-dark;
     padding: .9375rem 1.25rem;
 
     & + & {

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -2,7 +2,7 @@
 $color-transparent:      transparent !default;
 
 $color-brand:            #333 !default;
-$color-link:        #007aa6 !default;
+$color-link:            #007aa6 !default;
 
 $color-x-light:          #fff !default;
 $color-light:            #f7f7f7 !default;


### PR DESCRIPTION
## Done

Remove background color rules from fieldsets

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/strips/strips-dark/
- Add a fieldset to the `.p-strip--dark` example:

```
<div class="p-strip--dark">
  <div class="row">
    <fieldset>
      <form class="" action="index.html" method="post">
        <input type="text">
        <input type="text">
        <input type="text">
        <input type="text">
        <input type="text">
      </form>
    </fieldset>
  </div>
</div>
```

## Details

Fixes #1113 