### PR TITLE
Add table of contents

### DIFF
--- a/docs/en/base/code.md
+++ b/docs/en/base/code.md
@@ -1,6 +1,6 @@
 ---
 title: Code
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Code

--- a/docs/en/base/code.md
+++ b/docs/en/base/code.md
@@ -1,5 +1,5 @@
 ---
-title: Code
+title: Code table_of_contents: True
 ---
 
 # Code

--- a/docs/en/base/code.md
+++ b/docs/en/base/code.md
@@ -1,5 +1,6 @@
 ---
-title: Code table_of_contents: True
+title: Code
+table_of_contents: True
 ---
 
 # Code

--- a/docs/en/base/forms.md
+++ b/docs/en/base/forms.md
@@ -1,5 +1,5 @@
 ---
-title: Forms
+title: Forms table_of_contents: True
 ---
 
 # Forms

--- a/docs/en/base/forms.md
+++ b/docs/en/base/forms.md
@@ -1,5 +1,6 @@
 ---
-title: Forms table_of_contents: True
+title: Forms
+table_of_contents: true
 ---
 
 # Forms

--- a/docs/en/base/reset.md
+++ b/docs/en/base/reset.md
@@ -1,5 +1,5 @@
 ---
-title: Reset
+title: Reset table_of_contents: True
 ---
 
 # Reset

--- a/docs/en/base/reset.md
+++ b/docs/en/base/reset.md
@@ -1,6 +1,6 @@
 ---
 title: Reset
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Reset

--- a/docs/en/base/reset.md
+++ b/docs/en/base/reset.md
@@ -1,5 +1,6 @@
 ---
-title: Reset table_of_contents: True
+title: Reset
+table_of_contents: True
 ---
 
 # Reset

--- a/docs/en/base/table.md
+++ b/docs/en/base/table.md
@@ -1,5 +1,5 @@
 ---
-title: Table
+title: Table table_of_contents: True
 ---
 
 # Table

--- a/docs/en/base/table.md
+++ b/docs/en/base/table.md
@@ -1,5 +1,6 @@
 ---
-title: Table table_of_contents: True
+title: Table
+table_of_contents: True
 ---
 
 # Table

--- a/docs/en/base/table.md
+++ b/docs/en/base/table.md
@@ -1,6 +1,6 @@
 ---
 title: Table
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Table

--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -1,5 +1,6 @@
 ---
-title: Typography table_of_contents: True
+title: Typography
+table_of_contents: True
 ---
 
 # Typography

--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -1,6 +1,6 @@
 ---
 title: Typography
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Typography

--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -1,5 +1,5 @@
 ---
-title: Typography
+title: Typography table_of_contents: True
 ---
 
 # Typography

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,5 +1,6 @@
 ---
-title: Home table_of_contents: True
+title: Home
+table_of_contents: true
 ---
 
 ## Get started

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,5 +1,5 @@
 ---
-title: Home
+title: Home table_of_contents: True
 ---
 
 ## Get started
@@ -55,4 +55,3 @@ If you want to propose new patterns or improvements to Vanilla, make sure to fol
 ## Getting help
 
 If you have any questions or get stuck, you can file an issue on [GitHub](https://github.com/vanilla-framework/vanilla-framework/issues/new) or ask us a question on [Twitter](https://twitter.com/vanillaframewrk) or [Slack](https://vanillaframework.slack.com).
-

--- a/docs/en/patterns/breadcrumbs.md
+++ b/docs/en/patterns/breadcrumbs.md
@@ -1,5 +1,6 @@
 ---
-title: Breadcrumbs table_of_contents: True
+title: Breadcrumbs
+table_of_contents: True
 ---
 
 # Breadcrumbs

--- a/docs/en/patterns/breadcrumbs.md
+++ b/docs/en/patterns/breadcrumbs.md
@@ -1,6 +1,6 @@
 ---
 title: Breadcrumbs
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Breadcrumbs

--- a/docs/en/patterns/breadcrumbs.md
+++ b/docs/en/patterns/breadcrumbs.md
@@ -1,5 +1,5 @@
 ---
-title: Breadcrumbs
+title: Breadcrumbs table_of_contents: True
 ---
 
 # Breadcrumbs

--- a/docs/en/patterns/buttons.md
+++ b/docs/en/patterns/buttons.md
@@ -1,5 +1,6 @@
 ---
-title: Buttons table_of_contents: True
+title: Buttons
+table_of_contents: True
 ---
 
 # Buttons

--- a/docs/en/patterns/buttons.md
+++ b/docs/en/patterns/buttons.md
@@ -1,6 +1,6 @@
 ---
 title: Buttons
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Buttons

--- a/docs/en/patterns/buttons.md
+++ b/docs/en/patterns/buttons.md
@@ -1,5 +1,5 @@
 ---
-title: Buttons
+title: Buttons table_of_contents: True
 ---
 
 # Buttons

--- a/docs/en/patterns/card.md
+++ b/docs/en/patterns/card.md
@@ -1,5 +1,5 @@
 ---
-title: Card
+title: Card table_of_contents: True
 ---
 
 # Card

--- a/docs/en/patterns/card.md
+++ b/docs/en/patterns/card.md
@@ -1,5 +1,6 @@
 ---
-title: Card table_of_contents: True
+title: Card
+table_of_contents: True
 ---
 
 # Card

--- a/docs/en/patterns/card.md
+++ b/docs/en/patterns/card.md
@@ -1,6 +1,6 @@
 ---
 title: Card
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Card

--- a/docs/en/patterns/code-numbered.md
+++ b/docs/en/patterns/code-numbered.md
@@ -1,5 +1,5 @@
 ---
-title: Code numbered
+title: Code numbered table_of_contents: True
 ---
 
 # Code numbered

--- a/docs/en/patterns/code-numbered.md
+++ b/docs/en/patterns/code-numbered.md
@@ -1,5 +1,6 @@
 ---
-title: Code numbered table_of_contents: True
+title: Code numbered
+table_of_contents: True
 ---
 
 # Code numbered

--- a/docs/en/patterns/code-numbered.md
+++ b/docs/en/patterns/code-numbered.md
@@ -1,6 +1,6 @@
 ---
 title: Code numbered
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Code numbered

--- a/docs/en/patterns/code-snippet.md
+++ b/docs/en/patterns/code-snippet.md
@@ -1,5 +1,6 @@
 ---
-title: Code snippet table_of_contents: True
+title: Code snippet
+table_of_contents: True
 ---
 
 # Code snippet

--- a/docs/en/patterns/code-snippet.md
+++ b/docs/en/patterns/code-snippet.md
@@ -1,5 +1,5 @@
 ---
-title: Code snippet
+title: Code snippet table_of_contents: True
 ---
 
 # Code snippet

--- a/docs/en/patterns/code-snippet.md
+++ b/docs/en/patterns/code-snippet.md
@@ -1,6 +1,6 @@
 ---
 title: Code snippet
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Code snippet

--- a/docs/en/patterns/footer.md
+++ b/docs/en/patterns/footer.md
@@ -1,5 +1,6 @@
 ---
-title: Footer table_of_contents: True
+title: Footer
+table_of_contents: True
 ---
 
 # Footer

--- a/docs/en/patterns/footer.md
+++ b/docs/en/patterns/footer.md
@@ -1,5 +1,5 @@
 ---
-title: Footer
+title: Footer table_of_contents: True
 ---
 
 # Footer

--- a/docs/en/patterns/footer.md
+++ b/docs/en/patterns/footer.md
@@ -1,6 +1,6 @@
 ---
 title: Footer
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Footer

--- a/docs/en/patterns/form-validation.md
+++ b/docs/en/patterns/form-validation.md
@@ -1,5 +1,6 @@
 ---
-title: Form validation table_of_contents: True
+title: Form validation
+table_of_contents: True
 ---
 
 # Error / Caution / Success states

--- a/docs/en/patterns/form-validation.md
+++ b/docs/en/patterns/form-validation.md
@@ -1,6 +1,6 @@
 ---
 title: Form validation
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Error / Caution / Success states

--- a/docs/en/patterns/form-validation.md
+++ b/docs/en/patterns/form-validation.md
@@ -1,5 +1,5 @@
 ---
-title: Form validation
+title: Form validation table_of_contents: True
 ---
 
 # Error / Caution / Success states

--- a/docs/en/patterns/grid.md
+++ b/docs/en/patterns/grid.md
@@ -1,5 +1,5 @@
 ---
-title: Grid
+title: Grid table_of_contents: True
 ---
 
 # Grid

--- a/docs/en/patterns/grid.md
+++ b/docs/en/patterns/grid.md
@@ -1,5 +1,6 @@
 ---
-title: Grid table_of_contents: True
+title: Grid
+table_of_contents: True
 ---
 
 # Grid

--- a/docs/en/patterns/grid.md
+++ b/docs/en/patterns/grid.md
@@ -1,6 +1,6 @@
 ---
 title: Grid
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Grid

--- a/docs/en/patterns/inline-images.md
+++ b/docs/en/patterns/inline-images.md
@@ -1,5 +1,6 @@
 ---
-title: Inline images table_of_contents: True
+title: Inline images
+table_of_contents: True
 ---
 
 # Inline images

--- a/docs/en/patterns/inline-images.md
+++ b/docs/en/patterns/inline-images.md
@@ -1,6 +1,6 @@
 ---
 title: Inline images
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Inline images

--- a/docs/en/patterns/inline-images.md
+++ b/docs/en/patterns/inline-images.md
@@ -1,5 +1,5 @@
 ---
-title: Inline images
+title: Inline images table_of_contents: True
 ---
 
 # Inline images

--- a/docs/en/patterns/links.md
+++ b/docs/en/patterns/links.md
@@ -1,5 +1,5 @@
 ---
-title: Links
+title: Links table_of_contents: True
 ---
 
 # Links

--- a/docs/en/patterns/links.md
+++ b/docs/en/patterns/links.md
@@ -1,6 +1,6 @@
 ---
 title: Links
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Links

--- a/docs/en/patterns/links.md
+++ b/docs/en/patterns/links.md
@@ -1,5 +1,6 @@
 ---
-title: Links table_of_contents: True
+title: Links
+table_of_contents: True
 ---
 
 # Links

--- a/docs/en/patterns/lists.md
+++ b/docs/en/patterns/lists.md
@@ -1,5 +1,6 @@
 ---
-title: Lists table_of_contents: True
+title: Lists
+table_of_contents: True
 ---
 
 # Lists

--- a/docs/en/patterns/lists.md
+++ b/docs/en/patterns/lists.md
@@ -1,6 +1,6 @@
 ---
 title: Lists
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Lists

--- a/docs/en/patterns/lists.md
+++ b/docs/en/patterns/lists.md
@@ -1,5 +1,5 @@
 ---
-title: Lists
+title: Lists table_of_contents: True
 ---
 
 # Lists

--- a/docs/en/patterns/matrix.md
+++ b/docs/en/patterns/matrix.md
@@ -1,5 +1,6 @@
 ---
-title: Matrix table_of_contents: True
+title: Matrix
+table_of_contents: True
 ---
 
 # Matrix

--- a/docs/en/patterns/matrix.md
+++ b/docs/en/patterns/matrix.md
@@ -1,6 +1,6 @@
 ---
 title: Matrix
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Matrix

--- a/docs/en/patterns/matrix.md
+++ b/docs/en/patterns/matrix.md
@@ -1,5 +1,5 @@
 ---
-title: Matrix
+title: Matrix table_of_contents: True
 ---
 
 # Matrix

--- a/docs/en/patterns/navigation.md
+++ b/docs/en/patterns/navigation.md
@@ -1,5 +1,6 @@
 ---
-title: Navigation table_of_contents: True
+title: Navigation
+table_of_contents: true
 ---
 
 Vanilla includes a simple navigation bar that you can add to the top of your

--- a/docs/en/patterns/navigation.md
+++ b/docs/en/patterns/navigation.md
@@ -1,5 +1,5 @@
 ---
-title: Navigation
+title: Navigation table_of_contents: True
 ---
 
 Vanilla includes a simple navigation bar that you can add to the top of your

--- a/docs/en/patterns/notification.md
+++ b/docs/en/patterns/notification.md
@@ -1,6 +1,6 @@
 ---
 title: Notification
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Notification

--- a/docs/en/patterns/notification.md
+++ b/docs/en/patterns/notification.md
@@ -1,5 +1,5 @@
 ---
-title: Notification
+title: Notification table_of_contents: True
 ---
 
 # Notification

--- a/docs/en/patterns/notification.md
+++ b/docs/en/patterns/notification.md
@@ -1,5 +1,6 @@
 ---
-title: Notification table_of_contents: True
+title: Notification
+table_of_contents: True
 ---
 
 # Notification

--- a/docs/en/patterns/pull-quote.md
+++ b/docs/en/patterns/pull-quote.md
@@ -1,6 +1,6 @@
 ---
 title: Pull quote
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Pull quote

--- a/docs/en/patterns/pull-quote.md
+++ b/docs/en/patterns/pull-quote.md
@@ -1,5 +1,6 @@
 ---
-title: Pull quote table_of_contents: True
+title: Pull quote
+table_of_contents: True
 ---
 
 # Pull quote

--- a/docs/en/patterns/pull-quote.md
+++ b/docs/en/patterns/pull-quote.md
@@ -1,5 +1,5 @@
 ---
-title: Pull quote
+title: Pull quote table_of_contents: True
 ---
 
 # Pull quote
@@ -17,4 +17,3 @@ visually prominent way.
 ## Related
 
 * [Blockquotes and citations in base typography](/en/base/typography#blockquotes-and-citations)
-

--- a/docs/en/patterns/strip.md
+++ b/docs/en/patterns/strip.md
@@ -1,5 +1,6 @@
 ---
-title: Strip table_of_contents: True
+title: Strip
+table_of_contents: true
 ---
 
 # Strip

--- a/docs/en/patterns/strip.md
+++ b/docs/en/patterns/strip.md
@@ -1,5 +1,5 @@
 ---
-title: Strip
+title: Strip table_of_contents: True
 ---
 
 # Strip

--- a/docs/en/settings/animation-settings.md
+++ b/docs/en/settings/animation-settings.md
@@ -1,5 +1,5 @@
 ---
-title: Animations settings
+title: Animations settings table_of_contents: True
 ---
 
 Vanilla has a cross matrix of duration and easing that can be used to apply

--- a/docs/en/settings/animation-settings.md
+++ b/docs/en/settings/animation-settings.md
@@ -1,6 +1,6 @@
 ---
 title: Animations settings
-table_of_contents: True
+table_of_contents: true
 ---
 
 Vanilla has a cross matrix of duration and easing that can be used to apply

--- a/docs/en/settings/animation-settings.md
+++ b/docs/en/settings/animation-settings.md
@@ -1,5 +1,6 @@
 ---
-title: Animations settings table_of_contents: True
+title: Animations settings
+table_of_contents: True
 ---
 
 Vanilla has a cross matrix of duration and easing that can be used to apply

--- a/docs/en/settings/assets-settings.md
+++ b/docs/en/settings/assets-settings.md
@@ -1,5 +1,6 @@
 ---
-title: Assets settings table_of_contents: True
+title: Assets settings
+table_of_contents: True
 ---
 
 # Assets

--- a/docs/en/settings/assets-settings.md
+++ b/docs/en/settings/assets-settings.md
@@ -1,6 +1,6 @@
 ---
 title: Assets settings
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Assets

--- a/docs/en/settings/assets-settings.md
+++ b/docs/en/settings/assets-settings.md
@@ -1,5 +1,5 @@
 ---
-title: Assets settings
+title: Assets settings table_of_contents: True
 ---
 
 # Assets

--- a/docs/en/settings/breakpoint-settings.md
+++ b/docs/en/settings/breakpoint-settings.md
@@ -1,5 +1,5 @@
 ---
-title: Breakpoints settings
+title: Breakpoints settings table_of_contents: True
 ---
 
 # Breakpoints

--- a/docs/en/settings/breakpoint-settings.md
+++ b/docs/en/settings/breakpoint-settings.md
@@ -1,5 +1,6 @@
 ---
-title: Breakpoints settings table_of_contents: True
+title: Breakpoints settings
+table_of_contents: true
 ---
 
 # Breakpoints

--- a/docs/en/settings/color-settings.md
+++ b/docs/en/settings/color-settings.md
@@ -1,5 +1,5 @@
 ---
-title: Color settings
+title: Color settings table_of_contents: True
 ---
 
 # Color

--- a/docs/en/settings/color-settings.md
+++ b/docs/en/settings/color-settings.md
@@ -1,6 +1,6 @@
 ---
 title: Color settings
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Color

--- a/docs/en/settings/color-settings.md
+++ b/docs/en/settings/color-settings.md
@@ -1,5 +1,6 @@
 ---
-title: Color settings table_of_contents: True
+title: Color settings
+table_of_contents: True
 ---
 
 # Color

--- a/docs/en/settings/font-settings.md
+++ b/docs/en/settings/font-settings.md
@@ -1,5 +1,6 @@
 ---
-title: Font settings table_of_contents: True
+title: Font settings
+table_of_contents: True
 ---
 
 # Font

--- a/docs/en/settings/font-settings.md
+++ b/docs/en/settings/font-settings.md
@@ -1,5 +1,5 @@
 ---
-title: Font settings
+title: Font settings table_of_contents: True
 ---
 
 # Font

--- a/docs/en/settings/font-settings.md
+++ b/docs/en/settings/font-settings.md
@@ -1,6 +1,6 @@
 ---
 title: Font settings
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Font

--- a/docs/en/settings/layout-settings.md
+++ b/docs/en/settings/layout-settings.md
@@ -1,5 +1,5 @@
 ---
-title: Layout settings
+title: Layout settings table_of_contents: True
 ---
 
 # Layout

--- a/docs/en/settings/layout-settings.md
+++ b/docs/en/settings/layout-settings.md
@@ -1,6 +1,6 @@
 ---
 title: Layout settings
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Layout

--- a/docs/en/settings/layout-settings.md
+++ b/docs/en/settings/layout-settings.md
@@ -1,5 +1,6 @@
 ---
-title: Layout settings table_of_contents: True
+title: Layout settings
+table_of_contents: True
 ---
 
 # Layout

--- a/docs/en/settings/spacing-settings.md
+++ b/docs/en/settings/spacing-settings.md
@@ -1,5 +1,6 @@
 ---
-title: Spacing settings table_of_contents: True
+title: Spacing settings
+table_of_contents: True
 ---
 
 # Spacing

--- a/docs/en/settings/spacing-settings.md
+++ b/docs/en/settings/spacing-settings.md
@@ -1,6 +1,6 @@
 ---
 title: Spacing settings
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Spacing

--- a/docs/en/settings/spacing-settings.md
+++ b/docs/en/settings/spacing-settings.md
@@ -1,5 +1,5 @@
 ---
-title: Spacing settings
+title: Spacing settings table_of_contents: True
 ---
 
 # Spacing
@@ -16,4 +16,3 @@ Setting  | Default value
 `$sp-x-large` | `2rem`
 `$sp-xx-large` | `2.5rem`
 `$sp-xxx-large` | `3rem`
-

--- a/docs/en/utilities/align.md
+++ b/docs/en/utilities/align.md
@@ -1,5 +1,6 @@
 ---
-title: Align table_of_contents: True
+title: Align
+table_of_contents: True
 ---
 
 # Align

--- a/docs/en/utilities/align.md
+++ b/docs/en/utilities/align.md
@@ -1,6 +1,6 @@
 ---
 title: Align
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Align

--- a/docs/en/utilities/align.md
+++ b/docs/en/utilities/align.md
@@ -1,5 +1,5 @@
 ---
-title: Align
+title: Align table_of_contents: True
 ---
 
 # Align

--- a/docs/en/utilities/clearfix.md
+++ b/docs/en/utilities/clearfix.md
@@ -1,5 +1,5 @@
 ---
-title: Clearfix
+title: Clearfix table_of_contents: True
 ---
 
 # Clearfix

--- a/docs/en/utilities/clearfix.md
+++ b/docs/en/utilities/clearfix.md
@@ -1,5 +1,6 @@
 ---
-title: Clearfix table_of_contents: True
+title: Clearfix
+table_of_contents: True
 ---
 
 # Clearfix

--- a/docs/en/utilities/clearfix.md
+++ b/docs/en/utilities/clearfix.md
@@ -1,6 +1,6 @@
 ---
 title: Clearfix
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Clearfix

--- a/docs/en/utilities/embedded-media.md
+++ b/docs/en/utilities/embedded-media.md
@@ -1,5 +1,5 @@
 ---
-title: Embedded media
+title: Embedded media table_of_contents: True
 ---
 
 # Embedded media

--- a/docs/en/utilities/embedded-media.md
+++ b/docs/en/utilities/embedded-media.md
@@ -1,5 +1,6 @@
 ---
-title: Embedded media table_of_contents: True
+title: Embedded media
+table_of_contents: True
 ---
 
 # Embedded media

--- a/docs/en/utilities/embedded-media.md
+++ b/docs/en/utilities/embedded-media.md
@@ -1,6 +1,6 @@
 ---
 title: Embedded media
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Embedded media

--- a/docs/en/utilities/equal-height.md
+++ b/docs/en/utilities/equal-height.md
@@ -1,5 +1,6 @@
 ---
-title: Equal height table_of_contents: True
+title: Equal height
+table_of_contents: True
 ---
 
 # Equal height

--- a/docs/en/utilities/equal-height.md
+++ b/docs/en/utilities/equal-height.md
@@ -1,5 +1,5 @@
 ---
-title: Equal height
+title: Equal height table_of_contents: True
 ---
 
 # Equal height

--- a/docs/en/utilities/equal-height.md
+++ b/docs/en/utilities/equal-height.md
@@ -1,6 +1,6 @@
 ---
 title: Equal height
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Equal height

--- a/docs/en/utilities/floats.md
+++ b/docs/en/utilities/floats.md
@@ -1,6 +1,6 @@
 ---
 title: Floats
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Floats

--- a/docs/en/utilities/floats.md
+++ b/docs/en/utilities/floats.md
@@ -1,5 +1,5 @@
 ---
-title: Floats
+title: Floats table_of_contents: True
 ---
 
 # Floats

--- a/docs/en/utilities/floats.md
+++ b/docs/en/utilities/floats.md
@@ -1,5 +1,6 @@
 ---
-title: Floats table_of_contents: True
+title: Floats
+table_of_contents: True
 ---
 
 # Floats

--- a/docs/en/utilities/hide.md
+++ b/docs/en/utilities/hide.md
@@ -1,5 +1,6 @@
 ---
-title: Hide table_of_contents: True
+title: Hide
+table_of_contents: True
 ---
 
 # Hide

--- a/docs/en/utilities/hide.md
+++ b/docs/en/utilities/hide.md
@@ -1,5 +1,5 @@
 ---
-title: Hide
+title: Hide table_of_contents: True
 ---
 
 # Hide

--- a/docs/en/utilities/hide.md
+++ b/docs/en/utilities/hide.md
@@ -1,6 +1,6 @@
 ---
 title: Hide
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Hide

--- a/docs/en/utilities/margin-collapse.md
+++ b/docs/en/utilities/margin-collapse.md
@@ -1,6 +1,6 @@
 ---
 title: Margin collapse
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Margin collapse

--- a/docs/en/utilities/margin-collapse.md
+++ b/docs/en/utilities/margin-collapse.md
@@ -1,5 +1,5 @@
 ---
-title: Margin collapse
+title: Margin collapse table_of_contents: True
 ---
 
 # Margin collapse

--- a/docs/en/utilities/margin-collapse.md
+++ b/docs/en/utilities/margin-collapse.md
@@ -1,5 +1,6 @@
 ---
-title: Margin collapse table_of_contents: True
+title: Margin collapse
+table_of_contents: True
 ---
 
 # Margin collapse

--- a/docs/en/utilities/off-screen.md
+++ b/docs/en/utilities/off-screen.md
@@ -1,6 +1,6 @@
 ---
 title: Off screen
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Off screen

--- a/docs/en/utilities/off-screen.md
+++ b/docs/en/utilities/off-screen.md
@@ -1,5 +1,5 @@
 ---
-title: Off screen
+title: Off screen table_of_contents: True
 ---
 
 # Off screen

--- a/docs/en/utilities/off-screen.md
+++ b/docs/en/utilities/off-screen.md
@@ -1,5 +1,6 @@
 ---
-title: Off screen table_of_contents: True
+title: Off screen
+table_of_contents: True
 ---
 
 # Off screen

--- a/docs/en/utilities/padding-collapse.md
+++ b/docs/en/utilities/padding-collapse.md
@@ -1,5 +1,5 @@
 ---
-title: Padding collapse
+title: Padding collapse table_of_contents: True
 ---
 
 # Padding collapse

--- a/docs/en/utilities/padding-collapse.md
+++ b/docs/en/utilities/padding-collapse.md
@@ -1,5 +1,6 @@
 ---
-title: Padding collapse table_of_contents: True
+title: Padding collapse
+table_of_contents: True
 ---
 
 # Padding collapse

--- a/docs/en/utilities/padding-collapse.md
+++ b/docs/en/utilities/padding-collapse.md
@@ -1,6 +1,6 @@
 ---
 title: Padding collapse
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Padding collapse

--- a/docs/en/utilities/show.md
+++ b/docs/en/utilities/show.md
@@ -1,5 +1,6 @@
 ---
-title: Show table_of_contents: True
+title: Show
+table_of_contents: True
 ---
 
 # Show

--- a/docs/en/utilities/show.md
+++ b/docs/en/utilities/show.md
@@ -1,5 +1,5 @@
 ---
-title: Show
+title: Show table_of_contents: True
 ---
 
 # Show

--- a/docs/en/utilities/show.md
+++ b/docs/en/utilities/show.md
@@ -1,6 +1,6 @@
 ---
 title: Show
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Show

--- a/docs/en/utilities/vertically-center.md
+++ b/docs/en/utilities/vertically-center.md
@@ -1,5 +1,6 @@
 ---
-title: Vertically center table_of_contents: True
+title: Vertically center
+table_of_contents: True
 ---
 
 # Vertically center

--- a/docs/en/utilities/vertically-center.md
+++ b/docs/en/utilities/vertically-center.md
@@ -1,5 +1,5 @@
 ---
-title: Vertically center
+title: Vertically center table_of_contents: True
 ---
 
 # Vertically center

--- a/docs/en/utilities/vertically-center.md
+++ b/docs/en/utilities/vertically-center.md
@@ -1,6 +1,6 @@
 ---
 title: Vertically center
-table_of_contents: True
+table_of_contents: true
 ---
 
 # Vertically center


### PR DESCRIPTION
## Done

`Added table_of_contents: true` to the metadata for each page.

## QA

- Pull https://github.com/ubuntudesign/docs.vanillaframework.io
- Modify build-html:11:
 `git clone https://github.com/Lukewh/vanilla-framework --branch 84-add-table-of-contents`
- Run `./build-html`
- Run `caddy`
- Open http://127.0.0.1:8543/en/
- Ensure tables of content appear for doc pages with sub-headings.

## Details

Fixes https://github.com/ubuntudesign/docs.vanillaframework.io/issues/84
Styling will be improved as part of https://github.com/vanilla-framework/vanilla-docs-theme/issues/1
