### PR TITLE
Making whole navigation items clickable

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -120,16 +120,7 @@
         // For when this class is applied to something that contains <a>s, e.g.:
         // <li class="p-navigation__link"><a></a></li>
         border-bottom: 0;
-        color: $color-dark;
         display: block;
-        font-size: .875rem;
-        padding: .84375rem $sp-x-small; // 0.84375rem = (48px [height] - 21px [line-height]) / 2
-
-        @media (min-width: $breakpoint-navigation-threshold + 1) {
-          color: $text-color;
-          padding-left: ($sp-large - $sp-xx-small);
-          padding-right: ($sp-large - $sp-xx-small);
-        }
       }
 
       &:last-child {
@@ -165,8 +156,14 @@
         }
       }
 
+      .p-navigation__link > a,
       > a {
-        // For when this class is applied to something that contains <a>s, e.g.:
+        // For links nested in navigation list, e.g:
+        // <ul class="p-navigation__links">
+        //  <li class="p-navigation__link"><a></a></li>
+        // </ul>
+        //
+        // and for links nested directly in navigation, e.g:
         // <div class="p-navigation__links">
         //   <a class="class="p-navigation__link"></a>
         // </div>

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -118,14 +118,17 @@
 
       & > a {
         // For when this class is applied to something that contains <a>s, e.g.:
-        // <li class="p-navigation__list"><a></a></li>
+        // <li class="p-navigation__link"><a></a></li>
         border-bottom: 0;
         color: $color-dark;
-        font-size: .93333rem;
+        display: block;
+        font-size: .875rem;
+        padding: .84375rem $sp-x-small; // 0.84375rem = (48px [height] - 21px [line-height]) / 2
 
         @media (min-width: $breakpoint-navigation-threshold + 1) {
           color: $text-color;
-          font-size: .875rem;
+          padding-left: ($sp-large - $sp-xx-small);
+          padding-right: ($sp-large - $sp-xx-small);
         }
       }
 
@@ -148,7 +151,6 @@
 
       .p-navigation__link {
         border-left: 1px solid $color-mid-light;
-        padding: $sp-small $sp-x-small;
 
         @media (max-width: $breakpoint-navigation-threshold) {
           background-color: $color-light;
@@ -161,18 +163,22 @@
             border-bottom: 1px solid $color-mid-light;
           }
         }
-
-        @media (min-width: $breakpoint-navigation-threshold + 1) {
-          padding: $sp-small ($sp-large - $sp-xx-small);
-        }
       }
 
       > a {
         // For when this class is applied to something that contains <a>s, e.g.:
-        // <li class="p-navigation__list"><a></a></li>
-        @media (max-width: $breakpoint-navigation-threshold) {
-          color: $color-dark;
-          display: block;
+        // <div class="p-navigation__links">
+        //   <a class="class="p-navigation__link"></a>
+        // </div>
+
+        color: $color-dark;
+        font-size: .875rem;
+        padding: .84375rem $sp-x-small;  // 0.84375rem = (48px [height] - 21px [line-height]) / 2
+
+        @media (min-width: $breakpoint-navigation-threshold + 1) {
+          color: $text-color;
+          padding-left: ($sp-large - $sp-xx-small);
+          padding-right: ($sp-large - $sp-xx-small);
         }
       }
 


### PR DESCRIPTION
## Done



- moved padding from `.p-navigation__link` to `<a>` element to make click area larger
- removed unnecessary font size change between breakpoints
- made sure to support navigation `<a>` links both nested in list elements and used directly with `.p-navigation__link` class

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Go to navigation example (light or dark)
- Clicking on any part of navigation item should work (not just on link text)

## Details

Fixes #1154

## Screenshots

<img width="352" alt="screen shot 2017-07-17 at 16 21 10" src="https://user-images.githubusercontent.com/83575/28272516-049cb1f2-6b0c-11e7-9e97-1e05b9294f6d.png">

