### PR TITLE
Converted a mixture of styles to consistent h3s

### DIFF
--- a/docs/en/base/code.md
+++ b/docs/en/base/code.md
@@ -20,6 +20,8 @@ If you want to refer to a larger piece of code, use <code>&lt;pre&gt;</code> tog
     View example of the base code block
 </a>
 
+<hr />
+
 ### Related
 
 * [Code numbered pattern](/en/patterns/code-numbered/)

--- a/docs/en/base/code.md
+++ b/docs/en/base/code.md
@@ -20,6 +20,7 @@ If you want to refer to a larger piece of code, use <code>&lt;pre&gt;</code> tog
     View example of the base code block
 </a>
 
-Related:
+### Related
+
 * [Code numbered pattern](/en/patterns/code-numbered/)
 * [Code snippet pattern](/en/patterns/code-snippet/)

--- a/docs/en/base/forms.md
+++ b/docs/en/base/forms.md
@@ -93,5 +93,6 @@ You can use the ```<fieldset>``` element to divide the form into different logic
 
 <hr />
 
-## Related:
+### Related
+
 * [Buttons pattern](/en/patterns/buttons/)

--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -129,7 +129,7 @@ $font-allow-cyrillic-greek-latin: true;
 
 <hr />
 
-## Related
+### Related
 
 * [Code](/en/base/code)
 * [Pull quote pattern](/en/patterns/pull-quote)

--- a/docs/en/patterns/lists.md
+++ b/docs/en/patterns/lists.md
@@ -77,7 +77,7 @@ tutorial or instructions — you can use the class ```.p-list-step```.
 
 <hr />
 
-## Related
+### Related
 
 * [Base lists](/en/base/lists/)
 * [Inline images pattern](/en/patterns/inline-images/)

--- a/docs/en/patterns/pull-quote.md
+++ b/docs/en/patterns/pull-quote.md
@@ -15,6 +15,6 @@ visually prominent way.
 
 <hr />
 
-## Related
+### Related
 
 * [Blockquotes and citations in base typography](/en/base/typography#blockquotes-and-citations)


### PR DESCRIPTION
## Done

Updated 'Related' headings to h3's on a few pages.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check the pages referenced in https://github.com/ubuntudesign/docs.vanillaframework.io/issues/87

## Details

Before Related heading there is a `<hr />` that was present on *some* pages. I've added the `<hr />` to any that didn't have it.

## Screenshots

<img width="904" alt="screen shot 2017-07-17 at 16 39 55" src="https://user-images.githubusercontent.com/479384/28276376-a282ac44-6b0e-11e7-906c-c485f9353e62.png">

