### PR TITLE
Fixed spacing of inline whitespace in breadcrumbs

### DIFF
--- a/scss/_patterns_breadcrumbs.scss
+++ b/scss/_patterns_breadcrumbs.scss
@@ -3,23 +3,19 @@
 // Default breadcrumbs styling
 @mixin vf-p-breadcrumbs {
   .p-breadcrumbs {
+    @extend %clearfix;
     list-style: none;
     margin: 0;
     padding: 0;
     width: 100%;
 
     &__item {
-      display: inline-block;
-      margin: 0 $sp-small $sp-xx-small $sp-xx-small;
+      float: left;
+      margin: 0 0 $sp-xx-small $sp-xx-small;
       position: relative;
 
       &:not(:first-of-type) {
-        margin-right: -.25rem;
         text-indent: $sp-medium;
-      }
-
-      &:first-of-type {
-        margin-right: -.25rem;
       }
 
       &:not(:first-of-type)::before {


### PR DESCRIPTION
## Done

Changed `inline-block` into float not to depend on whitespace between inline breadcrumb items.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Go to breadcrumbs example page
- Breadcrumbs should look the same as before

Removing whitespace from HTML between breadcrumb items should not affect breadcrumb spacing.

## Details

Fixes #1146 
