### PR TITLE
Updated breadcrumbs link style

### DIFF
--- a/examples/patterns/breadcrumbs.html
+++ b/examples/patterns/breadcrumbs.html
@@ -5,8 +5,8 @@ category: _patterns
 ---
 
 <ul class="p-breadcrumbs">
-  <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="#">Breadcrumb One</a></li>
-  <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="#">Breadcrumb Two</a></li>
-  <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="#">Breadcrumb Three</a></li>
+  <li class="p-breadcrumbs__item"><a href="#">Breadcrumb One</a></li>
+  <li class="p-breadcrumbs__item"><a href="#">Breadcrumb Two</a></li>
+  <li class="p-breadcrumbs__item"><a href="#">Breadcrumb Three</a></li>
   <li class="p-breadcrumbs__item">Breadcrumb Four</li>
 </ul>

--- a/scss/_patterns_breadcrumbs.scss
+++ b/scss/_patterns_breadcrumbs.scss
@@ -25,15 +25,5 @@
         top: 0;
       }
     }
-
-    &__link {
-      color: $color-dark;
-      font-weight: 400;
-      text-decoration: none;
-
-      &:hover {
-        color: $color-link;
-      }
-    }
   }
 }


### PR DESCRIPTION
## Done

Removed custom link style from breadcrumbs pattern, so breadcrumbs links now have regular link style (as per spec).

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Go to breadcrumbs example
- Breadcrumbs link should have style as [in spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Breadcrumbs)

## Details

Fixes #1034 

## Screenshots

<img width="572" alt="screen shot 2017-07-18 at 11 44 56" src="https://user-images.githubusercontent.com/83575/28311015-979480fa-6bae-11e7-9297-86f76f6e14d0.png">

