### PR TITLE
Fix 10720 matrix image size

### DIFF
--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -15,6 +15,8 @@
     &__item {
       @extend %clearfix;
       border-top: 1px dotted $color-mid-dark;
+      display: flex;
+      flex-direction: row;
       margin-top: 0;
       padding: $sp-medium 0;
 
@@ -65,18 +67,21 @@
 
     &__img,
     &__content {
-      display: inline-block;
-      float: left;
+      align-self: flex-start;
       margin-top: 0;
     }
 
     &__img {
+      flex-grow: 0;
+      flex-shrink: 0;
       margin-right: $sp-medium;
-      max-width: calc(30% - #{$sp-medium});
+      max-width: 3.75rem;
     }
 
     &__content {
-      max-width: 70%;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
     }
 
     &__title {

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -72,8 +72,6 @@
     }
 
     &__img {
-      flex-grow: 0;
-      flex-shrink: 0;
       margin-right: $sp-medium;
       max-width: 3.75rem;
     }


### PR DESCRIPTION
## Done

Fix issue 1072:  p-matrix__img should be max-width: 60px, not a calculation

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/matrix/
- Check the Matrix pattern in s/m and large
- Went for 3.75rem rather than 60px

## Details

Fixes #1072