### PR TITLE
Added link to grid pattern from strip docs page

### DIFF
--- a/docs/en/patterns/strip.md
+++ b/docs/en/patterns/strip.md
@@ -7,7 +7,7 @@ table_of_contents: true
 
 The strip pattern provides a full width strip container in which to wrap a row. A strip can have light (`.p-strip--light`) or dark (`.p-strip--dark`) grey background.
 
-A `.p-strip` container should always be the parent of a `.row` and never the other way around.
+A `.p-strip` container should always be the parent of a `.row` (from the [Grid pattern](/en/patterns/grid/)) and never the other way around.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/strips/strips-light/"
     class="js-example">


### PR DESCRIPTION
## Done

Added link to grid pattern from strip docs.

## QA

- Pull code
- Run `./run serve --watch`
- Regenerate docs
- Go to Strip pattern docs page
- It should link to Grid pattern page

## Details

Fixes #1035

## Screenshots

<img width="769" alt="screen shot 2017-07-18 at 13 44 03" src="https://user-images.githubusercontent.com/83575/28315559-355e2ea2-6bbf-11e7-8a5b-df99427ee79a.png">

