### PR TITLE
Remove explicit color setting from strip mixin

### DIFF
--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -1,7 +1,6 @@
 @import 'settings';
 
 @mixin strip {
-  background-color: transparent;
   clear: both;
   margin-top: 0;
   padding: $sp-x-large 0;
@@ -13,6 +12,7 @@
 
   .p-strip {
     @include strip;
+    background-color: transparent;
 
     &--light {
       @include strip;


### PR DESCRIPTION
## Done

Remove explicit color setting from strip mixin. 

This is because including this as part of the strip mixin menas it is overriding --color variants of strip further downstream.

## QA

- Verify there are no visual changes via Percy

## Related

https://github.com/vanilla-framework/vanilla-brochure-theme/issues/99