### PR TITLE
Broken links sweep

### DIFF
--- a/docs/en/base/code.md
+++ b/docs/en/base/code.md
@@ -24,5 +24,5 @@ If you want to refer to a larger piece of code, use <code>&lt;pre&gt;</code> tog
 
 ### Related
 
-* [Code numbered pattern](/en/patterns/code-numbered/)
-* [Code snippet pattern](/en/patterns/code-snippet/)
+* [Code numbered pattern](/en/patterns/code-numbered)
+* [Code snippet pattern](/en/patterns/code-snippet)

--- a/docs/en/base/forms.md
+++ b/docs/en/base/forms.md
@@ -95,4 +95,4 @@ You can use the ```<fieldset>``` element to divide the form into different logic
 
 ### Related
 
-* [Buttons pattern](/en/patterns/buttons/)
+* [Buttons pattern](/en/patterns/buttons)

--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -119,7 +119,7 @@ descriptions.
 
 ## Enabling Cyrillic, Greek and Latin fonts
 
-Due to the extra extra weight of loading these fonts they are not imported by
+Due to the extra weight of loading these fonts they are not imported by
 default. To enable Cyrillic, Greek and Latin fonts on Ubuntu please set the
 following font setting to true.
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -44,14 +44,6 @@ Download the latest version of Vanilla from [GitHub](https://github.com/vanilla-
 
 To make improvements to Vanilla itself, please follow the instructions on the project’s [README.md](https://github.com/vanilla-framework/vanilla-framework#vanilla-framework).
 
-## Guidelines
-
-If you want to propose new patterns or improvements to Vanilla, make sure to follow these guidelines, which help to keep Vanilla robust and accessible:
-
-- [Accessibility guidelines]()
-- [Browser support]()
-- [Coding standards]()
-
 ## Getting help
 
 If you have any questions or get stuck, you can file an issue on [GitHub](https://github.com/vanilla-framework/vanilla-framework/issues/new) or ask us a question on [Twitter](https://twitter.com/vanillaframewrk) or [Slack](https://vanillaframework.slack.com).

--- a/docs/en/patterns/code-numbered.md
+++ b/docs/en/patterns/code-numbered.md
@@ -7,9 +7,9 @@ table_of_contents: true
 
 The code numbered pattern can be used when displaying large blocks of code to enable users to quickly reference a specific line.
 
-Code numbered extends the [base styling of code](/en/base/code/).
+Code numbered extends the [base styling of code](/en/base/code).
 
-See also: [code snippet](/en/patterns/code-snippet/).
+See also: [code snippet](/en/patterns/code-snippet).
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/code-numbered/"
     class="js-example">

--- a/docs/en/patterns/code-numbered.md
+++ b/docs/en/patterns/code-numbered.md
@@ -7,9 +7,9 @@ table_of_contents: true
 
 The code numbered pattern can be used when displaying large blocks of code to enable users to quickly reference a specific line.
 
-Code numbered extends the [base styling of code](/base/code/).
+Code numbered extends the [base styling of code](/en/base/code/).
 
-See also: [code snippet](/patterns/code-snippet/).
+See also: [code snippet](/en/patterns/code-snippet/).
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/code-numbered/"
     class="js-example">

--- a/docs/en/patterns/code-snippet.md
+++ b/docs/en/patterns/code-snippet.md
@@ -1,6 +1,6 @@
 ---
 title: Code snippet
-table_of_contents: true
+table_of_contents: false
 ---
 
 # Code snippet

--- a/docs/en/patterns/grid.md
+++ b/docs/en/patterns/grid.md
@@ -13,7 +13,7 @@ Vanilla's default grid has 12 columns and `20px` gutters. On large screens, each
 
 Layouts can be created combining rows with different number of columns to an ideal maximum of 4 columns per row. Each column should span a minimum of 3 columns.
 
-Read also: [Breakpoints](/en/settings/breakpoints)
+Read also: [Breakpoints](/en/settings/breakpoint-settings)
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/grid/default/"
     class="js-example">

--- a/docs/en/patterns/lists.md
+++ b/docs/en/patterns/lists.md
@@ -79,5 +79,4 @@ tutorial or instructions — you can use the class ```.p-list-step```.
 
 ### Related
 
-* [Base lists](/en/base/lists)
 * [Inline images pattern](/en/patterns/inline-images)

--- a/docs/en/patterns/lists.md
+++ b/docs/en/patterns/lists.md
@@ -79,5 +79,5 @@ tutorial or instructions — you can use the class ```.p-list-step```.
 
 ### Related
 
-* [Base lists](/en/base/lists/)
-* [Inline images pattern](/en/patterns/inline-images/)
+* [Base lists](/en/base/lists)
+* [Inline images pattern](/en/patterns/inline-images)

--- a/docs/en/patterns/navigation.md
+++ b/docs/en/patterns/navigation.md
@@ -3,6 +3,8 @@ title: Navigation
 table_of_contents: true
 ---
 
+# Navigation
+
 Vanilla includes a simple navigation bar that you can add to the top of your
 sites.
 

--- a/docs/en/patterns/notification.md
+++ b/docs/en/patterns/notification.md
@@ -1,6 +1,6 @@
 ---
 title: Notification
-table_of_contents: true
+table_of_contents: false
 ---
 
 # Notification

--- a/docs/en/patterns/pull-quote.md
+++ b/docs/en/patterns/pull-quote.md
@@ -1,6 +1,6 @@
 ---
 title: Pull quote
-table_of_contents: true
+table_of_contents: false
 ---
 
 # Pull quote


### PR DESCRIPTION
## Done

- Remove any related links with trailing slash
- Remove duplicate word
- Fix broken link

## QA

- Switch into docs.vanillaframework.io repo
- Change line 11 in `build-html` to 
```
git clone https://github.com/barrymcgee/vanilla-framework --branch 1184-broken-links-sweep
```
- Run `./build-html` in that repo, followed by `caddy`
- Check each page and ensure all links are correct

## Details

Fixes #1184 
