### PR TITLE
Add nested columns info to docs

### DIFF
--- a/docs/en/patterns/grid.md
+++ b/docs/en/patterns/grid.md
@@ -34,3 +34,12 @@ By default, prefixes and suffixes only work on top level columns.
     class="js-example">
     View example of the empty columns within the grid
 </a>
+
+## Nested columns
+
+Columns can be nested infinitely by adding `.row` classes within columns. Basically, just remember that all columns must be wrapped in `.row` classes, even when nested.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/grid/nested/"
+    class="js-example">
+    View example of the nested columns within the grid
+</a>

--- a/examples/patterns/grid/empty-columns.html
+++ b/examples/patterns/grid/empty-columns.html
@@ -3,7 +3,6 @@ layout: default
 title: Grid / Empty columns
 category: _patterns
 ---
-
 <div grid-demo>
   <div class="row">
     <div class="col-8">

--- a/examples/patterns/grid/nested.html
+++ b/examples/patterns/grid/nested.html
@@ -1,0 +1,31 @@
+---
+layout: default
+title: Grid / Nested columns
+category: _patterns
+---
+<div grid-demo grid-outline>
+  <div class="row">
+    <div class="col-6">
+      <span>.col-6</span>
+      <div class="row">
+        <div class="col-3">
+          <span>.col-3</span>
+          <div class="row">
+            <div class="col-1">
+              <span>.col-1</span>
+            </div>
+            <div class="col-1">
+              <span>.col-1</span>
+            </div>
+            <div class="col-1">
+              <span>.col-1</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-6">
+      <span>.col-6</span>
+    </div>
+  </div>
+</div>

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -31,4 +31,9 @@ $shelves-column-name: $grid-col-name;
     background: $color-mid-light;
     margin-bottom: $sp-medium;
   }
+
+  [grid-outline] [class*="col-"]  {
+    outline: 1px solid $color-x-light;
+    padding: $sp-xx-small;
+  }
 }


### PR DESCRIPTION
## Done

Add nested columns info to docs

## QA

- Pull code
- Run `./run serve --watch`
- Check nested columns example at: http://0.0.0.0:8101/vanilla-framework/examples/patterns/grid/nested/
- Jump into docs.vf.io
- Change line 11 in `build-html` to `git clone https://github.com/barrymcgee/vanilla-framework --branch 992-nested-grid-docs`
- Run `./build-html`
- Run `caddy`
- View http://127.0.0.1:8543/en/patterns/grid

## Details

Fixes #992