### PR TITLE
Remove hover underline from navigation links

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -116,11 +116,16 @@
         width: auto;
       }
 
+      &,
       & > a {
         // For when this class is applied to something that contains <a>s, e.g.:
         // <li class="p-navigation__link"><a></a></li>
         border-bottom: 0;
         display: block;
+
+        &:hover {
+          text-decoration: none;
+        }
       }
 
       &:last-child {


### PR DESCRIPTION
## Done

Remove hover underline from navigation links

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/light/
- Hover over links and verify there is no underline

## Details

Fixes #1063 