### PR TITLE
Add margin top/bottom to <hr>

### DIFF
--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -6,5 +6,6 @@
     border: 0;
     border-top: 1px solid $color-mid-light;
     height: 0;
+    margin: $sp-medium 0;
   }
 }


### PR DESCRIPTION
## Done

Add margin top/bottom to `<hr>` as without explicit margin settings, vertical rhythm rules will add a large top margin.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/hr/
- Check that margin top and bottom is `1rem`

## Details

Fixes #1180 
