### PR TITLE
Add note to Matrix docs on empty columns

### DIFF
--- a/docs/en/patterns/matrix.md
+++ b/docs/en/patterns/matrix.md
@@ -15,3 +15,5 @@ Matrix items will display in one column on small screens. At resolutions above
     class="js-example">
     View example of the matrix pattern
 </a>
+
+**Note**: for the Matrix pattern to display correctly on large screens, you'll need to add list items in a multiple of three. If you do not have content for all the items, leave them empty but the list item must be present. 


### PR DESCRIPTION
## Done

Add note to Matrix docs on empty columns. This is because list items must be added to the Matrix pattern in multiples of three otherwise you'll get missing borders.

## QA

- Pull code
- Run `./run serve --watch`
- Open https://docs.vanillaframework.io/en/patterns/matrix
- Remove content from the last Matrix list item
- Verify that correct borders persist

## Details

Fixes #1065

