### PR TITLE
Removed toc from homepage

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,6 +1,5 @@
 ---
 title: Home
-table_of_contents: true
 ---
 
 ## Get started


### PR DESCRIPTION
## Done

Removed toc boolean from the homepage

## QA

- Pull https://github.com/ubuntudesign/docs.vanillaframework.io
- Modify build-html:11:
`git clone https://github.com/Lukewh/vanilla-framework --branch remove-toc-from-homepage`
- Run ./build-html
- Run caddy
- Open http://127.0.0.1:8543/en/
- Ensure tables of content doesn't appear on the homepage, but does on other pages.

## Details

Fixes https://github.com/vanilla-framework/vanilla-docs-theme/issues/48
