### PR TITLE
point to png favicon

### DIFF
--- a/docs/metadata.yaml
+++ b/docs/metadata.yaml
@@ -1,4 +1,4 @@
-site_favicon: "https://assets.ubuntu.com/v1/383ca4d9-vanilla_favicon_16px.svg"
+site_favicon: "https://assets.ubuntu.com/v1/ab36e6ed-vanilla_favicon_32px.png"
 site_logo_url: "https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg"
 site_title: ~
 


### PR DESCRIPTION
## Done

Updated favicon to be png. Svg's only work in firefox and safari, apparently.

## QA

- Pull https://github.com/ubuntudesign/docs.vanillaframework.io
- Modify build-html:11:
`git clone https://github.com/Lukewh/vanilla-framework --branch update-favicon`
- Run ./build-html
- Run caddy
- Open http://127.0.0.1:8543/en/
- See favicon!

## Details

Fixes https://github.com/ubuntudesign/docs.vanillaframework.io/issues/90

## Screenshots

<img width="105" alt="screen shot 2017-07-20 at 15 23 15" src="https://user-images.githubusercontent.com/479384/28422248-601d73a4-6d5f-11e7-9732-02997338ac78.png">

