### PR TITLE
Small text should be 14px through all breakpoints

### DIFF
--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -103,7 +103,10 @@ descriptions.
 
 ## Small text
 
-<small>This is some &lt;small&gt; text with a font size of 13 pixels.</small>
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/small/"
+    class="js-example">
+    View example of the small text
+</a>
 
 ## Strong text
 

--- a/examples/base/small.html
+++ b/examples/base/small.html
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Small text
+category: _base
+---
+
+<small>This is some &lt;small&gt; text with a font size of 14 pixels.</small>

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -246,7 +246,7 @@
   }
 
   small {
-    font-size: .8125rem;
+    font-size: .875rem;
   }
 
   sub,


### PR DESCRIPTION
Note: @spencerbygraves Please see @yaili's note on #1046 before reviewing.

## Done

Small text should be 14px through all breakpoints

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/small/
- Check text size is 14px through all breakpoints

## Details

Fixes #1046
