### PR TITLE
Add aria and accessibility improvements to navigation pattern

### DIFF
--- a/examples/patterns/navigation/dark.html
+++ b/examples/patterns/navigation/dark.html
@@ -13,16 +13,16 @@ category: _patterns
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close Menu</a>
     </div>
-    <nav class="p-navigation__nav">
+    <nav class="p-navigation__nav" role="menubar">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>
-      <ul class="p-navigation__links">
-        <li class="p-navigation__link"><a href="#">Link1</a></li>
-        <li class="p-navigation__link"><a href="#">Link2</a></li>
-        <li class="p-navigation__link"><a href="#">Link3</a></li>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link" role="menuitem"><a href="#">Link1</a></li>
+        <li class="p-navigation__link" role="menuitem"><a href="#">Link2</a></li>
+        <li class="p-navigation__link" role="menuitem"><a href="#">Link3</a></li>
       </ul>
     </nav>
   </div>

--- a/examples/patterns/navigation/dark.html
+++ b/examples/patterns/navigation/dark.html
@@ -13,7 +13,7 @@ category: _patterns
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav" role="menubar">
       <span class="u-off-screen">

--- a/examples/patterns/navigation/light.html
+++ b/examples/patterns/navigation/light.html
@@ -13,16 +13,16 @@ category: _patterns
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close Menu</a>
     </div>
-    <nav class="p-navigation__nav">
+    <nav class="p-navigation__nav" role="menubar">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>
-      <ul class="p-navigation__links">
-        <li class="p-navigation__link"><a href="#">Link1</a></li>
-        <li class="p-navigation__link"><a href="#">Link2</a></li>
-        <li class="p-navigation__link"><a href="#">Link3</a></li>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link" role="menuitem"><a href="#">Link1</a></li>
+        <li class="p-navigation__link" role="menuitem"><a href="#">Link2</a></li>
+        <li class="p-navigation__link" role="menuitem"><a href="#">Link3</a></li>
       </ul>
     </nav>
   </div>

--- a/examples/patterns/navigation/light.html
+++ b/examples/patterns/navigation/light.html
@@ -13,7 +13,7 @@ category: _patterns
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav" role="menubar">
       <span class="u-off-screen">


### PR DESCRIPTION
## Done

Add aria and accessibility improvements to navigation pattern

Note: This does not include all the changes as recommended by @richmccartney in his Codepen as I don't think we should add state aria markup that will be invalid unless custom JS scripting is added. 
The reason for this is that many people will copy/paste the navigation snippet from the docs without ever writing the JS needed to make the aria state labels work correctly thus making sites more confusing for screen readers etc. to that end, I've only added aria labels that will always be correct, with or without JS.

## QA

- Pull code
- Review aria changes
- Run `./run serve --watch`
- Review http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/dark/
- Review http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/light/

## Details

Fixes #971 

