### PR TITLE
Docs link to the parent website

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -130,3 +130,8 @@ navigation:
 
     - location: vanilla-brochure-theme/index.md
       title: Brochure theme
+
+- location: /
+  title: vanillaframework.io
+  external: true
+

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -131,7 +131,7 @@ navigation:
     - location: vanilla-brochure-theme/index.md
       title: Brochure theme
 
-- location: /
+- location: https://vanillaframework.io/
   title: vanillaframework.io
   external: true
 


### PR DESCRIPTION
## Done
Added a link to the parent site within docs.

## QA

- Pull code
- `cd` to your docs.vanillaframework.io branch 
- Update build-html to:
```bash
BLUE='\033[1;34m'
GREEN='\033[0;32m'
NC='\033[0m' # No Color

echo "${BLUE}Clearing build${NC}"
rm -rf en
echo "${GREEN}Build removed${NC}"

echo "${BLUE}Building vanilla-frameworks documentation${NC}"
documentation-builder --base-directory ../vanilla-framework/docs  \
                      --site-root '/en/'  \
                      --output-path .  \
                      --template-path template.html  \
                      --tag-manager-code 'GTM-K92JCQ'  \
                      --no-link-extensions \
                      --force
echo "${GREEN}Completed vanilla-framework documentation build${NC}"

echo "${BLUE}Build vanilla-brochure-theme documentation${NC}"
documentation-builder --base-directory ../vanilla-brochure-theme/docs \
                      --site-root '/en/vanilla-brochure-theme/index' \
                      --output-path 'en/vanilla-brochure-theme' \
                      --template-path template.html \
                      --tag-manager-code 'GTM-K92JCQ'  \
                      --no-link-extensions \
                      --force

mv en/vanilla-brochure-theme/en/* en/vanilla-brochure-theme/.
rm -rf en/vanilla-brochure-theme/en/
echo "${GREEN}Completed vanilla-brochure-theme documentation build${NC}"
```
- Run `./build-local`
- Run `caddy`
- Go to http://127.0.0.1:8543/en/
- Check there is a link to vanillaframework.io

## Details
Fixes https://app.zenhub.com/workspace/o/vanilla-framework/vanilla-docs-theme/issues/22 Fixes https://app.zenhub.com/workspace/o/canonical-websites/vanillaframework.io/issues/57