### PR TITLE
Combine brochure theme divider pattern

### DIFF
--- a/docs/en/patterns/divider.md
+++ b/docs/en/patterns/divider.md
@@ -16,7 +16,7 @@ A divider is used to separate related content items.
 
 #### Vanilla patterns
 
-These patterns are an extention or addition of the patterns available on Vanilla
+These patterns are an extension or addition of the patterns available on Vanilla
 framework.
 
 [Vanilla framework list patterns](https://docs.vanillaframework.io/en/patterns/lists)

--- a/docs/en/patterns/divider.md
+++ b/docs/en/patterns/divider.md
@@ -1,0 +1,22 @@
+---
+collection: patterns
+title: Divider
+---
+
+## Divider list
+
+A divider is used to separate related content items.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/divider/"
+  class="js-example">
+  View example of the patterns divider
+</a>
+
+---
+
+#### Vanilla patterns
+
+These patterns are an extention or addition of the patterns available on Vanilla
+framework.
+
+[Vanilla framework list patterns](https://docs.vanillaframework.io/en/patterns/lists)

--- a/examples/patterns/divider.html
+++ b/examples/patterns/divider.html
@@ -1,0 +1,20 @@
+---
+layout: default
+title: Divider
+category: _patterns
+---
+
+<div class="row p-divider">
+  <div class="col-4 p-divider__block">
+    <h2>Lorem ipsum</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
+  </div>
+  <div class="col-4 p-divider__block">
+    <h2>Dolor sit</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
+  </div>
+  <div class="col-4 p-divider__block">
+    <h2>Cumque commodi</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
+  </div>
+</div>

--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -1,0 +1,32 @@
+@mixin vf-p-divider {
+
+  .p-divider {
+
+    @media (min-width: $breakpoint-medium) {
+      display: flex;
+    }
+
+    &__block {
+      border-bottom: 1px solid $color-mid-light;
+
+      &:last-child {
+        border-bottom: 0;
+      }
+
+      @media (max-width: $breakpoint-medium) {
+        padding-bottom: $sp-large;
+      }
+
+      @media (min-width: $breakpoint-medium) {
+        border-bottom: 0;
+        border-right: 1px solid $color-mid-light;
+        padding-right: 1rem;
+
+        &:last-child {
+          border-right: 0;
+          padding-right: 0;
+        }
+      }
+    }
+  }
+}

--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -1,3 +1,5 @@
+@import 'settings';
+
 @mixin vf-p-divider {
 
   .p-divider {

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -40,6 +40,7 @@
 'patterns_buttons',
 'patterns_code-numbered',
 'patterns_code-snippet',
+'patterns_divider',
 'patterns_footer',
 'patterns_grid',
 'patterns_headings',
@@ -92,6 +93,7 @@
   @include vf-p-card;
   @include vf-p-code-numbered;
   @include vf-p-code-snippet;
+  @include vf-p-divider;
   @include vf-p-footer;
   @include vf-p-grid;
   @include vf-p-grid-modifications;


### PR DESCRIPTION
## Done
Copied over the divider pattern and accompanying documentation from the brochure theme. 

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/divider/
- Check it looks like https://vanilla-framework.github.io/vanilla-brochure-theme/examples/patterns/divider/

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1208
