### PR TITLE
Port the brochure header-icon pattern

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -65,6 +65,9 @@ navigation:
   - location: patterns/grid.md
     title: Grid
 
+  - location: patterns/heading-icon.md
+    title: Heading icon
+
   - location: patterns/inline-images.md
     title: Inline images
 

--- a/docs/en/patterns/heading-icon.md
+++ b/docs/en/patterns/heading-icon.md
@@ -1,0 +1,11 @@
+---
+collection: patterns
+title: Heading icon
+---
+
+## Heading icon
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon/"
+  class="js-example">
+  View example of the pattern heading icons
+</a>

--- a/examples/patterns/heading-icon.html
+++ b/examples/patterns/heading-icon.html
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Heading icon
+category: _patterns
+---
+
+<div class="p-heading-icon">
+  <div class="p-heading-icon__header">
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a4d31b28-icon-quote.svg" />
+    <h3 class="p-heading-icon__title">Lorem ipsum dolor</h3>
+  </div>
+  <p>sit amet, consectetur adipisicing elit. Enim excepturi, repudiandae blanditiis odio perferendis voluptatibus dolorum, dicta illum quae ipsa voluptatum, sunt quasi? Nulla reiciendis magnam nostrum aliquam, beatae doloribus.</p>
+</div>

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -5,7 +5,7 @@
   .p-heading-icon {
 
     color: $color-dark;
-    margin-bottom: 2rem;
+    margin-bottom: $sp-x-large;
 
     @media (min-width: $breakpoint-medium) {
       margin-bottom: 0;
@@ -14,10 +14,10 @@
     &__header {
       align-items: center;
       display: flex;
-      margin-bottom: 1rem;
+      margin-bottom: $sp-medium;
 
       @media (min-width: $breakpoint-large) {
-        margin-bottom: 1.5rem;
+        margin-bottom: $sp-large;
       }
     }
 
@@ -30,13 +30,13 @@
     &__img {
       align-self: flex-start;
       flex-shrink: 0;
-      height: 2.6666rem;
-      margin-right: 1rem;
-      width: 2.6666rem;
+      height: $sp-xx-large;
+      margin-right: $sp-medium;
+      width: $sp-xx-large;
 
       @media (min-width: $breakpoint-medium) {
-        height: 3.75rem;
-        width: 3.75rem;
+        height: $sp-xxx-large + $sp-small;
+        width: $sp-xxx-large + $sp-small;
       }
     }
   }

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -1,0 +1,44 @@
+@import 'settings';
+
+@mixin vf-p-heading-icon {
+
+  .p-heading-icon {
+
+    color: $color-dark;
+    margin-bottom: 2rem;
+
+    @media (min-width: $breakpoint-medium) {
+      margin-bottom: 0;
+    }
+
+    &__header {
+      align-items: center;
+      display: flex;
+      margin-bottom: 1rem;
+
+      @media (min-width: $breakpoint-large) {
+        margin-bottom: 1.5rem;
+      }
+    }
+
+    &__title {
+      @include heading-3;
+      margin-bottom: 0;
+      margin-top: 0;
+    }
+
+    &__img {
+      align-self: flex-start;
+      flex-shrink: 0;
+      height: 2.6666rem;
+      margin-right: 1rem;
+      width: 2.6666rem;
+
+      @media (min-width: $breakpoint-medium) {
+        height: 3.75rem;
+        width: 3.75rem;
+      }
+    }
+  }
+}
+

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -43,6 +43,7 @@
 'patterns_footer',
 'patterns_grid',
 'patterns_headings',
+'patterns_heading-icon',
 'patterns_matrix',
 'patterns_inline-images',
 'patterns_links',
@@ -81,6 +82,7 @@
   @include vf-b-links;
   @include vf-b-lists;
   @include vf-p-headings;
+  @include vf-p-heading-icon;
   @include vf-b-hr;
   @include vf-b-media;
   @include vf-b-tables;


### PR DESCRIPTION
## Done
Copied over the heading-icon pattern and accompanying documentation from the brochure theme. 

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/heading-icon/
- Check it looks like https://vanilla-framework.github.io/vanilla-brochure-theme/examples/patterns/heading-icon/

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1209
