### PR TITLE
Make u-equal-height immune to vertical spacing

### DIFF
--- a/examples/templates/vertical-spacing.html
+++ b/examples/templates/vertical-spacing.html
@@ -1,0 +1,67 @@
+---
+layout: default
+title: Vertical spacing
+category: _templates
+---
+
+<div class="p-strip is-bordered is-deep">
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-4">
+        <h2>Guidelines</h2>
+        <p>If you are contributing to Vanilla, make sure to read and follow these guidelines.</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="" class="p-link--soft">Accessibility&nbsp;›</a>
+          </li>
+          <li class="p-list__item">
+            <a href="" class="p-link--soft">Browser support&nbsp;›</a>
+          </li>
+          <li class="p-list__item">
+            <a href="" class="p-link--soft">Coding standards&nbsp;›</a>
+          </li>
+        </ul>
+      </div>
+      <div class="col-8 prefix-2 u-vertically-center">
+        <img src="https://assets.ubuntu.com/v1/4a810e12-guidelines-illustration.svg" alt="">
+      </div>
+    </div>
+  </div>
+</div>
+
+<section class="p-strip--dark">
+  <div class="row">
+    <div class="col-12">
+      <h2>Title</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
+    </div>
+    <div class="col-6">
+      <img src="http://suplugins.com/podium/images/placeholder-05.jpg" alt="" />
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-4 p-card">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
+    </div>
+    <div class="col-4 p-card">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
+    </div>
+    <div class="col-4 p-card">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <p><button class="p-button--neutral">Neutral button</button></p>
+    </div>
+  </div>
+</section>
+

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ title: Home
 
 <div class="p-strip">
     <div class="row">
-        <div class="col-4">
+        <div class="col-3">
             <h3>Base</h3>
             <nav>
               <ul class="p-list">
@@ -40,7 +40,7 @@ title: Home
               </ul>
             </nav>
         </div>
-        <div class="col-4">
+        <div class="col-3">
             <h3>Patterns</h3>
             <nav>
                 <ul class="p-list">
@@ -58,13 +58,31 @@ title: Home
                 </ul>
             </nav>
         </div>
-        <div class="col-4">
+        <div class="col-3">
             <h3>Utilities</h3>
             <nav>
               <ul class="p-list">
                 {% for page in sortedpages %}
                   {% assign pageitems = page | split: '#' %}
                   {% if pageitems[1] contains '/utilities/' %}
+                  <li class="p-list__item">
+                    <a href="{{ pageitems[1] | prepend:site.baseurl }}"
+                      class="p-link--soft">
+                      {{ pageitems[0] }}
+                    </a>
+                  </li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
+            </nav>
+        </div>
+        <div class="col-3">
+            <h3>Templates</h3>
+            <nav>
+              <ul class="p-list">
+                {% for page in sortedpages %}
+                  {% assign pageitems = page | split: '#' %}
+                  {% if pageitems[1] contains '/templates/' %}
                   <li class="p-list__item">
                     <a href="{{ pageitems[1] | prepend:site.baseurl }}"
                       class="p-link--soft">

--- a/scss/_base_vertical-spacing.scss
+++ b/scss/_base_vertical-spacing.scss
@@ -80,14 +80,14 @@
   // Adds padding to single element rows
   .row {
     &:first-of-type > *:only-child {
-      &:not([class^="#{$grid-col-name}-"]),
+      &:not([class^="#{$grid-col-name}-"]):not([class="u-equal-height"]),
       & > *:only-child:not([class^="#{$grid-col-name}-"]) {
         @include default-vertical-spacing-reversed;
       }
     }
 
     & > *:only-child {
-      &:not([class^="#{$grid-col-name}-"]),
+      &:not([class^="#{$grid-col-name}-"]):not([class="u-equal-height"]),
       & > *:only-child:not([class^="#{$grid-col-name}-"]) {
         @include default-vertical-spacing;
       }

--- a/scss/_base_vertical-spacing.scss
+++ b/scss/_base_vertical-spacing.scss
@@ -78,19 +78,11 @@
   }
 
   // Adds padding to single element rows
-  .row {
-    &:first-of-type > *:only-child {
-      &:not([class^="#{$grid-col-name}-"]):not([class="u-equal-height"]),
-      & > *:only-child:not([class^="#{$grid-col-name}-"]) {
-        @include default-vertical-spacing-reversed;
-      }
-    }
+  .row:first-of-type [class^="col-"]:only-child > *:only-child {
+    @include default-vertical-spacing-reversed;
+  }
 
-    & > *:only-child {
-      &:not([class^="#{$grid-col-name}-"]):not([class="u-equal-height"]),
-      & > *:only-child:not([class^="#{$grid-col-name}-"]) {
-        @include default-vertical-spacing;
-      }
-    }
+  .row [class^="col-"]:only-child > *:only-child {
+    @include default-vertical-spacing;
   }
 }


### PR DESCRIPTION
## Done
Disable vertical spacing on `u-equal-height` 

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/templates/vertical-spacing/
- Check that the Guidelines section `u-equal-height` has no margin-bottom.
- Check that the "Title" in the Title section has margin-bottom
- Check that the button at the end of the last strip has margin-top

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1152
