### PR TITLE
Improve sup and sub positioning

### DIFF
--- a/examples/base/sub.html
+++ b/examples/base/sub.html
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Sub
+category: _base
+---
+
+<h1>The chemical formula of water: H<sub>2</sub>O</h1>
+<p>The chemical formula of water: H<sub>2</sub>O</p>

--- a/examples/base/sup.html
+++ b/examples/base/sup.html
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Sup
+category: _base
+---
+
+<h1>This is an example of sup<sup>&copy;</sup> in title</h1>
+<p>This is an example of sup<sup>&copy;</sup> in text</p>

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -251,18 +251,10 @@
 
   sub,
   sup {
-    font-size: $sp-small;
+    font-size: .75em;
     line-height: 0;
     position: relative;
     vertical-align: baseline;
-  }
-
-  sup {
-    vertical-align: text-top;
-  }
-
-  sub {
-    vertical-align: text-bottom;
   }
 }
 


### PR DESCRIPTION
## Done
Made the positioning of a `sup` and `sub` relative to the element not root.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/sup/
- Check that both `sup`s in the title and paragraph text is correct

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1109