### PR TITLE
Port the muted-heading pattern from brochure theme

### DIFF
--- a/docs/en/patterns/muted-heading.md
+++ b/docs/en/patterns/muted-heading.md
@@ -1,0 +1,13 @@
+---
+collection: patterns
+title: Muted heading
+---
+
+## Muted heading
+
+Muted heading can label a list of icons.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/muted-heading/"
+  class="js-example">
+  View example of the pattern muted heading
+</a>

--- a/examples/patterns/muted-heading.html
+++ b/examples/patterns/muted-heading.html
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Muted heading
+category: _patterns
+---
+
+<h3 class="p-muted-heading">Muted heading</h3>

--- a/scss/_patterns_muted-heading.scss
+++ b/scss/_patterns_muted-heading.scss
@@ -1,0 +1,7 @@
+@mixin vf-p-muted-heading {
+
+  .p-muted-heading {
+    font-size: .875rem;
+    text-transform: uppercase;
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -45,6 +45,7 @@
 'patterns_grid',
 'patterns_headings',
 'patterns_matrix',
+'patterns_muted-heading',
 'patterns_inline-images',
 'patterns_links',
 'patterns_lists',
@@ -98,6 +99,7 @@
   @include vf-p-grid;
   @include vf-p-grid-modifications;
   @include vf-p-matrix;
+  @include vf-p-muted-heading;
   @include vf-p-navigation;
   @include vf-p-links;
   @include vf-p-lists;


### PR DESCRIPTION
## Done
Ported the muted-heading pattern, example and docs.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/muted-heading/
- Check it matches https://vanilla-framework.github.io/vanilla-brochure-theme/examples/patterns/muted-heading/ but left aligned as there was an amendment to the pattern since the last release

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1212
