### PR TITLE
Port the list stepped detailed pattern from brochure theme

### DIFF
--- a/docs/en/patterns/lists.md
+++ b/docs/en/patterns/lists.md
@@ -78,13 +78,13 @@ tutorial or instructions — you can use the class ```.p-list-step```.
 ## Stepped list: detailed
 
 Stepped list should be used for step by step instructions. This pattern is best
-used on a grey strip as the description sections are displayed in a white box.
+used on a `.p-strip--light` as the description sections are displayed in a white
+box.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/lists/lists-stepped-detailed/"
   class="js-example">
   View example of the pattern stepped list detailed
 </a>
-
 
 <hr />
 

--- a/docs/en/patterns/lists.md
+++ b/docs/en/patterns/lists.md
@@ -75,8 +75,20 @@ tutorial or instructions — you can use the class ```.p-list-step```.
     View example of the stepped list pattern
 </a>
 
+## Stepped list: detailed
+
+Stepped list should be used for step by step instructions. This pattern is best
+used on a grey strip as the description sections are displayed in a white box.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/lists/lists-stepped-detailed/"
+  class="js-example">
+  View example of the pattern stepped list detailed
+</a>
+
+
 <hr />
 
 ### Related
 
 * [Inline images pattern](/en/patterns/inline-images)
+

--- a/examples/patterns/lists/lists-stepped-detailed.html
+++ b/examples/patterns/lists/lists-stepped-detailed.html
@@ -1,0 +1,47 @@
+---
+layout: default
+title: Lists / Stepped detailed
+category: _patterns
+---
+
+<ol class="p-stepped-list--detailed">
+  <li class="p-list-step__item col-8">
+    <h3 class="p-list-step__title">
+      <span class="p-list-step__bullet">1</span>
+      First step
+    </h3>
+    <p class="p-list-step__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed purus lorem, dictum vel dolor eu, tincidunt suscipit magna. Suspendisse dignissim nisl vitae turpis iaculis, ut tempor enim gravida.</p>
+  </li>
+
+  <li class="p-list-step__item col-8">
+    <h3 class="p-list-step__title">
+      <span class="p-list-step__bullet">2</span>
+      Second step
+    </h3>
+    <p class="p-list-step__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed purus lorem, dictum vel dolor eu, tincidunt suscipit magna. Suspendisse dignissim nisl vitae turpis iaculis, ut tempor enim gravida.</p>
+  </li>
+
+  <li class="p-list-step__item col-8">
+    <h3 class="p-list-step__title">
+      <span class="p-list-step__bullet">3</span>
+      Third step
+    </h3>
+    <p class="p-list-step__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed purus lorem, dictum vel dolor eu, tincidunt suscipit magna. Suspendisse dignissim nisl vitae turpis iaculis, ut tempor enim gravida.</p>
+  </li>
+
+  <li class="p-list-step__item col-8">
+    <h3 class="p-list-step__title">
+      <span class="p-list-step__bullet">4</span>
+      Fourth step
+    </h3>
+    <p class="p-list-step__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed purus lorem, dictum vel dolor eu, tincidunt suscipit magna. Suspendisse dignissim nisl vitae turpis iaculis, ut tempor enim gravida.</p>
+  </li>
+
+  <li class="p-list-step__item col-8">
+    <h3 class="p-list-step__title">
+      <span class="p-list-step__bullet">5</span>
+      Last but not least Last but not least Last but not least
+    </h3>
+    <p class="p-list-step__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed purus lorem, dictum vel dolor eu, tincidunt suscipit magna. Suspendisse dignissim nisl vitae turpis iaculis, ut tempor enim gravida.</p>
+  </li>
+</ol>

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -191,6 +191,7 @@
   }
 }
 
+
 @mixin vf-p-stepped-list-detailed {
   .p-stepped-list--detailed {
     list-style: none;
@@ -243,7 +244,9 @@
         margin-right: 1rem;
         position: absolute;
         top: 2.25rem;
+      }
     }
+  }
 }
 
 // Adaptor class `is-split` to split the items of a list into two columns

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -2,20 +2,20 @@
 
 // Default list styling
 // Mixin for basic styled lists
-@mixin list {
+@mixin vf-list {
   list-style: none;
   margin-left: 0;
   padding-left: 0;
 }
 
 // Mixin for list items
-@mixin list-item {
+@mixin vf-list-item {
   margin-top: 0;
   padding-bottom: .63rem;
   padding-top: .63rem;
 }
 
-@mixin list-item-divided {
+@mixin vf-list-item-divided {
   border-bottom: 1px dotted $color-mid-light;
 
   &:last-of-type,
@@ -25,7 +25,7 @@
 }
 
 // Mixin for inline list items
-@mixin inline-list-item {
+@mixin vf-inline-list-item {
   display: inline;
   list-style: none;
   margin-right: 1.25rem;
@@ -43,6 +43,7 @@
   @include vf-p-inline-list;
   @include vf-p-inline-list-middot;
   @include vf-p-stepped-list;
+  @include vf-p-stepped-list-detailed;
 }
 
 @function svg-tick($color) {
@@ -56,7 +57,7 @@
 // List styling using list class
 @mixin vf-p-list {
   .p-list {
-    @include list;
+    @include vf-list;
 
     &__item {
       margin-top: .6667rem;
@@ -67,11 +68,11 @@
 // A list with separators between items
 @mixin vf-p-list-divided {
   .p-list--divided {
-    @include list;
+    @include vf-list;
 
     .p-list__item {
-      @include list-item;
-      @include list-item-divided;
+      @include vf-list-item;
+      @include vf-list-item-divided;
     }
   }
 }
@@ -97,7 +98,7 @@
     padding-left: 0;
 
     &__item {
-      @include inline-list-item;
+      @include vf-inline-list-item;
     }
   }
 }
@@ -109,7 +110,7 @@
     padding-left: 0;
 
     .p-inline-list__item {
-      @include inline-list-item;
+      @include vf-inline-list-item;
       position: relative;
 
       &::after {
@@ -184,6 +185,63 @@
       @media only screen and (max-width: $breakpoint-large) {
         position: absolute;
         top: -5px;
+      }
+    }
+  }
+}
+
+@mixin vf-p-stepped-list-detailed {
+  .p-stepped-list--detailed {
+    list-style: none;
+    padding: 0 2rem 0 3rem;
+
+    @media (max-width: $grid-max-width) {
+      margin-top: 2.5rem;
+    }
+
+    .p-list-step__item {
+      margin-bottom: 3rem;
+
+      @media (min-width: $breakpoint-medium) {
+        display: flex;
+        margin: 0;
+
+        > * {
+          width: 50%;
+        }
+      }
+    }
+
+    .p-list-step__title {
+
+      @media (min-width: $breakpoint-medium) {
+        padding-top: 2.75rem;
+      }
+
+    }
+
+    .p-list-step__content {
+      background: $color-x-light;
+      color: $color-x-dark;
+      margin-left: -4rem;
+      margin-right: -2rem;
+      margin-top: 2.5rem;
+      padding: 1.3333rem;
+
+      @media (min-width: $breakpoint-medium) {
+        border-bottom: 1px solid $color-light;
+        margin: .25rem 0 0;
+        padding: 2.5rem;
+      }
+    }
+
+    @media (min-width: $breakpoint-medium) {
+      .p-list-step__bullet {
+        left: -$grid-gutter-width * 3;
+        margin-left: 0;
+        margin-right: 1rem;
+        position: absolute;
+        top: 2.25rem;
       }
     }
   }


### PR DESCRIPTION
## Done
Ported the list stepped detailed pattern from the brochure theme with its docs and example.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/lists/lists-stepped-detailed/
- Check it looks the same as https://vanilla-framework.github.io/vanilla-brochure-theme/examples/patterns/lists/stepped-list-detailed/
- Check example and docs are ok

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1213
