### PR TITLE
Port the strip pattern from brochure theme

### DIFF
--- a/docs/en/patterns/strip.md
+++ b/docs/en/patterns/strip.md
@@ -18,3 +18,52 @@ A `.p-strip` container should always be the parent of a `.row` (from the [Grid p
     class="js-example">
     View example of the strip dark pattern
 </a>
+
+
+## Strip accent
+The purpose of the strip accent pattern displays content with a highlighted
+site accent strip style.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework//examples/patterns/strip/accent/"
+  class="js-example">
+  View example of the pattern strip accent
+</a>
+
+## Strip image
+This pattern allows for an image background to be appear as a background on a strip.
+
+**Note:** Declare the background-image as an inline style attribute in the HTML markup.
+
+You can also add the classes '.is-light' and '.is-dark' to the strips to describe the background image.
+These classes will then override the text color to ensure it remains visible.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework//examples/patterns/strip/image/"
+  class="js-example">
+  View example of the pattern strip image
+</a>
+
+## Strip is-bordered
+This pattern is used to add a dividing border at the bottom of the strip.
+
+**Note** This should be used when two strips of the same type are used after each other.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework//examples/patterns/strip/is-bordered/"
+  class="js-example">
+  View example of the pattern strip is-bordered
+</a>
+
+## Strip is-deep
+This state gives the strip larger vertical padding.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework//examples/patterns/strip/deep/"
+  class="js-example">
+  View example of the pattern strip is-deep
+</a>
+
+## Strip is-shallow
+This state gives the strip smaller vertical padding.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework//examples/patterns/strip/shallow/"
+  class="js-example">
+  View example of the pattern strip is-shallow
+</a>

--- a/examples/patterns/strips/accent.html
+++ b/examples/patterns/strips/accent.html
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Strip / Accent
+category: _patterns
+---
+<section class="p-strip--accent">
+  <div class="row">
+    <h2>.p-strip--accent</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>

--- a/examples/patterns/strips/accent.html
+++ b/examples/patterns/strips/accent.html
@@ -5,7 +5,9 @@ category: _patterns
 ---
 <section class="p-strip--accent">
   <div class="row">
-    <h2>.p-strip--accent</h2>
+    <div class="col-12">
+      <h2>.p-strip--accent</h2>
+    </div>
   </div>
   <div class="row">
     <div class="col-6">

--- a/examples/patterns/strips/deep.html
+++ b/examples/patterns/strips/deep.html
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Strip / is-deep
+category: _patterns
+---
+<section class="p-strip--light is-deep">
+  <div class="row">
+    <h2>.p-strip is-deep</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>

--- a/examples/patterns/strips/deep.html
+++ b/examples/patterns/strips/deep.html
@@ -5,7 +5,9 @@ category: _patterns
 ---
 <section class="p-strip--light is-deep">
   <div class="row">
-    <h2>.p-strip is-deep</h2>
+    <div class="col-12">
+      <h2>.p-strip is-deep</h2>
+    </div>
   </div>
   <div class="row">
     <div class="col-6">

--- a/examples/patterns/strips/image.html
+++ b/examples/patterns/strips/image.html
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Strip / Image
+category: _patterns
+---
+
+<section class="p-strip--image is-light" style="background-image:url('https://assets.ubuntu.com/sites/ubuntu/latest/u/img/backgrounds/image-background-paper.png')">
+  <div class="row">
+    <h2>.p-strip--image (light)</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--image is-dark" style="background-image:url('https://assets.ubuntu.com/v1/62d597f6-background-grid.png')">
+  <div class="row">
+    <h2>.p-strip--image (dark)</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>

--- a/examples/patterns/strips/image.html
+++ b/examples/patterns/strips/image.html
@@ -6,7 +6,9 @@ category: _patterns
 
 <section class="p-strip--image is-light" style="background-image:url('https://assets.ubuntu.com/sites/ubuntu/latest/u/img/backgrounds/image-background-paper.png')">
   <div class="row">
-    <h2>.p-strip--image (light)</h2>
+    <div class="col-12">
+      <h2>.p-strip--image (light)</h2>
+    </div>
   </div>
   <div class="row">
     <div class="col-6">
@@ -20,7 +22,9 @@ category: _patterns
 
 <section class="p-strip--image is-dark" style="background-image:url('https://assets.ubuntu.com/v1/62d597f6-background-grid.png')">
   <div class="row">
-    <h2>.p-strip--image (dark)</h2>
+    <div class="col-12">
+      <h2>.p-strip--image (dark)</h2>
+      </div>
   </div>
   <div class="row">
     <div class="col-6">

--- a/examples/patterns/strips/is-bordered.html
+++ b/examples/patterns/strips/is-bordered.html
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Strip / is-bordered
+category: _patterns
+---
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h2>.p-strip is-bordered</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>

--- a/examples/patterns/strips/is-bordered.html
+++ b/examples/patterns/strips/is-bordered.html
@@ -5,7 +5,9 @@ category: _patterns
 ---
 <section class="p-strip is-bordered">
   <div class="row">
-    <h2>.p-strip is-bordered</h2>
+    <div class="col-12">
+      <h2>.p-strip is-bordered</h2>
+    </div>
   </div>
   <div class="row">
     <div class="col-6">

--- a/examples/patterns/strips/shallow.html
+++ b/examples/patterns/strips/shallow.html
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Strip / is-shallow
+category: _patterns
+---
+<section class="p-strip--light is-shallow">
+  <div class="row">
+    <h2>.p-strip is-shallow</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>

--- a/examples/patterns/strips/shallow.html
+++ b/examples/patterns/strips/shallow.html
@@ -5,7 +5,9 @@ category: _patterns
 ---
 <section class="p-strip--light is-shallow">
   <div class="row">
-    <h2>.p-strip is-shallow</h2>
+    <div class="col-12">
+      <h2>.p-strip is-shallow</h2>
+    </div>
   </div>
   <div class="row">
     <div class="col-6">

--- a/examples/patterns/strips/strips-dark.html
+++ b/examples/patterns/strips/strips-dark.html
@@ -6,6 +6,8 @@ category: _patterns
 
 <div class="p-strip--dark">
   <div class="row">
-    ...
+    <div class="col-12">
+      <p>This is a dark row</p>
+    </div>
   </div>
 </div>

--- a/examples/patterns/strips/strips-light.html
+++ b/examples/patterns/strips/strips-light.html
@@ -6,6 +6,8 @@ category: _patterns
 
 <div class="p-strip--light">
   <div class="row">
-    ...
+    <div class="col-12">
+      <p>This is a light row</p>
+    </div>
   </div>
 </div>

--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -34,3 +34,13 @@
     }
   }
 }
+
+// Returns the font color to be presented on the passed background-color
+// variable.
+@function determine-text-color($background-color) {
+  @if (lightness($background-color) > 50) {
+    @return $color-dark;
+  } @else {
+    @return $color-x-light;
+  }
+}

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -1,29 +1,90 @@
 @import 'settings';
 
-@mixin strip {
+@mixin vf-strip {
   @include external-link-color;
   clear: both;
   margin-top: 0;
   padding: $sp-x-large 0;
   width: 100%;
+
+  @media only screen and (min-width: $breakpoint-large) {
+    padding: 4rem 0;
+  }
 }
 
-// Full width strip pattern
 @mixin vf-p-strip {
+  @include vf-p-strip-default;
+  @include vf-p-strip-accent;
+  @include vf-p-strip-image;
+  @include vf-p-strip-bordered;
+  @include vf-p-strip-shallow;
+  @include vf-p-strip-deep;
+}
 
+@mixin vf-p-strip-default {
   .p-strip {
-    @include strip;
+    @include vf-strip;
     background-color: transparent;
 
     &--light {
-      @include strip;
+      @include vf-strip;
       background-color: $color-light;
     }
 
     &--dark {
-      @include strip;
+      @include vf-strip;
       background-color: $color-dark;
       color: $color-light;
+    }
+  }
+}
+
+@mixin vf-p-strip-accent {
+  .p-strip--accent {
+    @include vf-strip;
+    background-color: $color-accent-background;
+    color: determine-text-color($color-accent-background);
+  }
+}
+
+@mixin vf-p-strip-image {
+  .p-strip--image {
+    @include vf-strip;
+    background-repeat: no-repeat;
+    background-size: cover;
+
+    &.is-light {
+      color: $color-x-dark;
+    }
+
+    &.is-dark {
+      color: $color-x-light;
+    }
+  }
+}
+
+@mixin vf-p-strip-bordered {
+  [class^='p-strip'].is-bordered {
+    border-bottom: 1px solid $color-mid-light;
+  }
+}
+
+@mixin vf-p-strip-shallow {
+  [class^='p-strip'].is-shallow {
+    padding: $sp-large 0;
+
+    @media only screen and (min-width: $breakpoint-large) {
+      padding: $sp-xx-large 0;
+    }
+  }
+}
+
+@mixin vf-p-strip-deep {
+  [class^='p-strip'].is-deep {
+    padding: $sp-xxx-large 0;
+
+    @media only screen and (min-width: $breakpoint-large) {
+      padding: 6rem 0;
     }
   }
 }

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -19,6 +19,9 @@ $color-information:      #335280 !default;
 
 $color-input-shadow:     rgba($color-x-dark, .12) !default;
 
+$color-accent: $color-brand !default;
+$color-accent-background: $color-accent !default;
+
 // for _patterns_grid-list.scss
 $grid-border-style:      1px dotted $color-mid-light !default;
 


### PR DESCRIPTION
## Done
Migrate the strip patterns from the brochure theme with their accompanied examples and docs.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check the strip variants are correct

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1214
