### PR TITLE
Port the image position util from brochure theme

### DIFF
--- a/docs/en/utilities/image-position.md
+++ b/docs/en/utilities/image-position.md
@@ -1,0 +1,51 @@
+---
+collection: utilities
+title: Image position
+---
+
+## Image position
+
+Image position is a utility to position an image within a parent container. In
+most cases it would be a strip. This only affects medium and large screen sizes.
+
+### Position bottom
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/image-position/bottom/"
+  class="js-example">
+  View example of the utilities image position bottom
+</a>
+
+### Position top
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/image-position/top/"
+  class="js-example">
+  View example of the utilities image position top
+</a>
+
+### Position top right
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/image-position/top-right/"
+  class="js-example">
+  View example of the utilities image position top right
+</a>
+
+### Position top left
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/image-position/top-left/"
+  class="js-example">
+  View example of the utilities image position top left
+</a>
+
+### Position bottom right
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/image-position/bottom-right/"
+  class="js-example">
+  View example of the utilities image position bottom right
+</a>
+
+### Position bottom left
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/image-position/bottom-left/"
+  class="js-example">
+  View example of the utilities image position bottom left
+</a>

--- a/examples/utilities/image-position/bottom-left.html
+++ b/examples/utilities/image-position/bottom-left.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Image position / Bottom left
+category: _patterns
+---
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom u-image-position--left" />
+    </div>
+    <div class="col-6">
+      <h2>Image position - bottom left</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+  </div>
+</section>

--- a/examples/utilities/image-position/bottom-right.html
+++ b/examples/utilities/image-position/bottom-right.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Image position / Bottom right
+category: _patterns
+---
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>Image position - bottom right</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom u-image-position--right" />
+    </div>
+  </div>
+</section>

--- a/examples/utilities/image-position/bottom.html
+++ b/examples/utilities/image-position/bottom.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Image position / Bottom
+category: _patterns
+---
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>Image position - bottom</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom" />
+    </div>
+  </div>
+</section>

--- a/examples/utilities/image-position/left.html
+++ b/examples/utilities/image-position/left.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Image position / Left
+category: _patterns
+---
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--left" />
+    </div>
+    <div class="col-6">
+      <h2>Image position - left</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+  </div>
+</section>

--- a/examples/utilities/image-position/right.html
+++ b/examples/utilities/image-position/right.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Image position / Right
+category: _patterns
+---
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>Image position - right</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--right" />
+    </div>
+  </div>
+</section>

--- a/examples/utilities/image-position/top-left.html
+++ b/examples/utilities/image-position/top-left.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Image position / Top left
+category: _patterns
+---
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top u-image-position--left" />
+    </div>
+    <div class="col-6">
+      <h2>Image position - top left</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+  </div>
+</section>

--- a/examples/utilities/image-position/top-right.html
+++ b/examples/utilities/image-position/top-right.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Image position / Top right
+category: _patterns
+---
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>Image position - top right</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top u-image-position--right" />
+    </div>
+  </div>
+</section>

--- a/examples/utilities/image-position/top.html
+++ b/examples/utilities/image-position/top.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Image position / Top
+category: _patterns
+---
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>Image position - top</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top" />
+    </div>
+  </div>
+</section>

--- a/scss/_utilities_image-position.scss
+++ b/scss/_utilities_image-position.scss
@@ -1,0 +1,33 @@
+// Create utility class for positioning images at top or bottom of the section
+
+@mixin vf-u-image-position {
+  .u-image-position {
+    @media (min-width: $breakpoint-medium) {
+      position: relative;
+
+      [class*='col-'] {
+        position: static;
+      }
+
+      &--top {
+        position: absolute;
+        top: 0;
+      }
+
+      &--bottom {
+        bottom: 0;
+        position: absolute;
+      }
+
+      &--left {
+        left: 0;
+        position: absolute;
+      }
+
+      &--right {
+        position: absolute;
+        right: 0;
+      }
+    }
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -67,6 +67,7 @@
 'utilities_vertically-center',
 'utilities_show',
 'utilities_hide',
+'utilities_image-position',
 'utilities_visibility';
 
 // Include all the CSS
@@ -115,6 +116,7 @@
   @include vf-u-margin-collapse;
   @include vf-u-padding-collapse;
   @include vf-u-hide;
+  @include vf-u-image-position;
   @include vf-u-show;
   @include vf-u-off-screen;
   @include vf-u-vertically-center;


### PR DESCRIPTION
## Done
Migrated the `image-position` util from brochure theme with its accompanying docs and examples.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Go through the image-position util examples and check they do what they say on the tin

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1215
