### PR TITLE
Remove the brochure theme docs link

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -125,12 +125,6 @@ navigation:
     - location: utilities/vertically-center.md
       title: Vertically center
 
-- title: Themes
-  children:
-
-    - location: vanilla-brochure-theme/index.md
-      title: Brochure theme
-
 - location: https://vanillaframework.io/
   title: vanillaframework.io
   external: true


### PR DESCRIPTION
## Done
Removed the themes section from the docs

## QA
- Pull code
- Switch over to your docs.vanillaframework.io branch
- Run `documentation-builder --source-folder '../vanilla-framework/docs' --output-path .` _replacing the source-folder with a path to your clone of vanilla-framework
- Open http://127.0.0.1:8543/en/
- Check there is no Themes section

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1240
