### PR TITLE
Remove redundant role attributes from examples

### DIFF
--- a/examples/patterns/footer.html
+++ b/examples/patterns/footer.html
@@ -4,9 +4,9 @@ title: Footer
 category: _patterns
 ---
 
-<footer class="p-footer" role="contentinfo">
+<footer class="p-footer">
   <p>&copy; 2017 Company name and logo are registered trademarks of Company Ltd.</p>
-  <nav class="p-footer__nav" role="navigation">
+  <nav class="p-footer__nav">
     <ul class="p-footer__links">
       <li class="p-footer__item">
         <a class="p-footer__link" href="#">Footer link 1</a>

--- a/examples/patterns/navigation/dark.html
+++ b/examples/patterns/navigation/dark.html
@@ -4,7 +4,7 @@ title: Navigation / Dark
 category: _patterns
 ---
 
-<header id="navigation" class="p-navigation" role="banner">
+<header id="navigation" class="p-navigation">
   <div class="row">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">

--- a/examples/patterns/navigation/light.html
+++ b/examples/patterns/navigation/light.html
@@ -4,7 +4,7 @@ title: Navigation / Default
 category: _patterns
 ---
 
-<header id="navigation" class="p-navigation--light" role="banner">
+<header id="navigation" class="p-navigation--light">
   <div class="row">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">


### PR DESCRIPTION
## Done

Remove redundant role attributes from navigation and footer examples as these will throw warnings from the [HTML validator](https://validator.w3.org/nu/)

See: https://validator.w3.org/nu/?acceptlanguage=&doc=https%3A%2F%2Fvanillaframework.io%2Faccessibility

## QA

- Sanity check code
