### PR TITLE
Remove specific color from p-heading-icon

### DIFF
--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -3,8 +3,6 @@
 @mixin vf-p-heading-icon {
 
   .p-heading-icon {
-
-    color: $color-dark;
     margin-bottom: $sp-x-large;
 
     @media (min-width: $breakpoint-medium) {


### PR DESCRIPTION
Fixes #1272

## Done

Remove the specific color style rule from .p-heading-icon as it does not specify a background color. This means that if a strip has a dark background and has set a light text color, using this pattern does not override it.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- There should be no Percy changes
- Edit the strip accent pattern to use this markup and verify text is legible:

```
<section class="p-strip--accent">
  <div class="row">
    <h2>.p-strip--accent</h2>
  </div>
  <div class="row">
    <div class="col-12">
     <div class="p-heading-icon">
  <div class="p-heading-icon__header">
    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a4d31b28-icon-quote.svg">
    <h3 class="p-heading-icon__title">Lorem ipsum dolor</h3>
  </div>
  <p>sit amet, consectetur adipisicing elit. Enim excepturi, repudiandae blanditiis odio perferendis voluptatibus dolorum, dicta illum quae ipsa voluptatum, sunt quasi? Nulla reiciendis magnam nostrum aliquam, beatae doloribus.</p>
</div>
    </div>
  </div>
</section>

```

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
