### PR TITLE
1238 port tooltips pattern

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -98,6 +98,9 @@ navigation:
   - location: patterns/table-expanding.md
     title: Table expanding
 
+  - location: patterns/tooltips.md
+    title: Tooltips
+
 - title: Utilities
   children:
 

--- a/docs/en/patterns/tooltips.md
+++ b/docs/en/patterns/tooltips.md
@@ -1,0 +1,18 @@
+---
+title: Tooltips
+table_of_contents: true
+---
+
+# Tooltips
+
+Tooltips are text labels that appear when the user hovers over, focuses on, or touches an element on the screen. Can be used to provide
+information of concepts/terms/actions that are not self explanatory or well known. Can be introduced to provide information of a disabled
+actionable element, e.g. for disabled buttons provide information why why they are disabled.
+
+Avoid using tooltips to provide instructions or guidance. They shouldn't be used to show rich information including images and formatted
+text and avoid placing over plain text or other places where they are not discoverable.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/tooltips/"
+    class="js-example">
+    View example of the tooltips pattern
+</a>

--- a/docs/en/patterns/tooltips.md
+++ b/docs/en/patterns/tooltips.md
@@ -5,12 +5,9 @@ table_of_contents: true
 
 # Tooltips
 
-Tooltips are text labels that appear when the user hovers over, focuses on, or touches an element on the screen. Can be used to provide
-information of concepts/terms/actions that are not self explanatory or well known. Can be introduced to provide information of a disabled
-actionable element, e.g. for disabled buttons provide information why why they are disabled.
+Tooltips are text labels that appear when the user hovers over, focuses on, or touches an element on the screen. Can be used to provide information of concepts/terms/actions that are not self explanatory or well known. Can be introduced to provide information of a disabled actionable element, e.g. for disabled buttons provide information why why they are disabled.
 
-Avoid using tooltips to provide instructions or guidance. They shouldn't be used to show rich information including images and formatted
-text and avoid placing over plain text or other places where they are not discoverable.
+Avoid using tooltips to provide instructions or guidance. They shouldn't be used to show rich information including images and formatted text and avoid placing over plain text or other places where they are not discoverable.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/tooltips/"
     class="js-example">

--- a/examples/patterns/tooltips.html
+++ b/examples/patterns/tooltips.html
@@ -16,23 +16,25 @@ category: _patterns
   Bottom right tooltip
   <span class="p-tooltip__message" role="tooltip" id="btm-rgt">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Consequuntur, laborum.</span>
 </button>
+<button class="p-tooltip p-tooltip--left" aria-describedby="left">
+  Left tooltip
+  <span class="p-tooltip__message" role="tooltip" id="left">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Corrupti earum nesciunt&#xa;temporibus, aut iste voluptates obcaecati.</span>
+</button>
+<br />
+<br />
+<button class="p-tooltip p-tooltip--right" aria-describedby="rght">
+  Right tooltip
+  <span class="p-tooltip__message" role="tooltip" id="rght">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Consequuntur, laborum.</span>
+</button>
 <button class="p-tooltip p-tooltip--top-left" aria-describedby="tp-lft">
   Top left tooltip
   <span class="p-tooltip__message" role="tooltip" id="tp-lft">Lorem ipsum dolor sit amet.</span>
 </button>
 <button class="p-tooltip p-tooltip--top-center" aria-describedby="tp-cntr">
   Top center tooltip
-  <span class="p-tooltip__message" role="tooltip" id="tp-cntr">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Corrupti earum nesciunt&#xa;temporibus, aut iste voluptates obcaecati&#xa;quibusdam aliquam possimus unde eos, rem!&#xa;Doloribus, praesentium amet.</span>
+  <span class="p-tooltip__message" role="tooltip" id="tp-cntr">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Corrupti earum nesciunt</span>
 </button>
 <button class="p-tooltip p-tooltip--top-right" aria-describedby="tp-rght">
   Top right tooltip
   <span class="p-tooltip__message" role="tooltip" id="tp-rght">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Consequuntur, laborum.</span>
-</button>
-<button class="p-tooltip p-tooltip--left" aria-describedby="left">
-  Left tooltip
-  <span class="p-tooltip__message" role="tooltip" id="left">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Corrupti earum nesciunt&#xa;temporibus, aut iste voluptates obcaecati&#xa;quibusdam aliquam possimus unde eos, rem!&#xa;Doloribus, praesentium amet.</span>
-</button>
-<button class="p-tooltip p-tooltip--right" aria-describedby="rght">
-  Right tooltip
-  <span class="p-tooltip__message" role="tooltip" id="rght">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Consequuntur, laborum.</span>
 </button>

--- a/examples/patterns/tooltips.html
+++ b/examples/patterns/tooltips.html
@@ -1,0 +1,38 @@
+---
+layout: default
+title: Tooltips
+category: _patterns
+---
+
+<button class="p-tooltip" aria-describedby="default-tooltip">
+  Bottom left tooltip
+  <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Lorem ipsum dolor sit amet.</span>
+</button>
+<button class="p-tooltip p-tooltip--btm-center" aria-describedby="btm-cntr">
+  Bottom center tooltip
+  <span class="p-tooltip__message" role="tooltip" id="btm-cntr">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Corrupti earum nesciunt&#xa;temporibus, aut iste voluptates obcaecati&#xa;quibusdam aliquam possimus unde eos, rem!&#xa;Doloribus, praesentium amet.</span>
+</button>
+<button class="p-tooltip p-tooltip--btm-right" aria-describedby="btm-rgt">
+  Bottom right tooltip
+  <span class="p-tooltip__message" role="tooltip" id="btm-rgt">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Consequuntur, laborum.</span>
+</button>
+<button class="p-tooltip p-tooltip--top-left" aria-describedby="tp-lft">
+  Top left tooltip
+  <span class="p-tooltip__message" role="tooltip" id="tp-lft">Lorem ipsum dolor sit amet.</span>
+</button>
+<button class="p-tooltip p-tooltip--top-center" aria-describedby="tp-cntr">
+  Top center tooltip
+  <span class="p-tooltip__message" role="tooltip" id="tp-cntr">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Corrupti earum nesciunt&#xa;temporibus, aut iste voluptates obcaecati&#xa;quibusdam aliquam possimus unde eos, rem!&#xa;Doloribus, praesentium amet.</span>
+</button>
+<button class="p-tooltip p-tooltip--top-right" aria-describedby="tp-rght">
+  Top right tooltip
+  <span class="p-tooltip__message" role="tooltip" id="tp-rght">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Consequuntur, laborum.</span>
+</button>
+<button class="p-tooltip p-tooltip--left" aria-describedby="left">
+  Left tooltip
+  <span class="p-tooltip__message" role="tooltip" id="left">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Corrupti earum nesciunt&#xa;temporibus, aut iste voluptates obcaecati&#xa;quibusdam aliquam possimus unde eos, rem!&#xa;Doloribus, praesentium amet.</span>
+</button>
+<button class="p-tooltip p-tooltip--right" aria-describedby="rght">
+  Right tooltip
+  <span class="p-tooltip__message" role="tooltip" id="rght">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Consequuntur, laborum.</span>
+</button>

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -12,7 +12,7 @@
       display: none;
       font-size: .875rem;
       left: 0;
-      line-height: 1.25rem;
+      line-height: 1.5;
       max-width: 330px;
       min-width: 155px;
       padding: $sp-x-small $sp-small;

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -1,0 +1,202 @@
+@import 'settings';
+
+@mixin vf-p-tooltips {
+  .p-tooltip {
+    position: relative;
+
+    &__message {
+      @extend .p-card--highlighted;
+      background-color: $color-dark;
+      border: 0;
+      color: $color-x-light;
+      display: none;
+      font-size: .875rem;
+      left: 0;
+      line-height: 1.25rem;
+      max-width: 330px;
+      min-width: 155px;
+      padding: $sp-x-small $sp-small;
+      position: absolute;
+      text-align: left;
+      text-decoration: initial;
+      top: 100%;
+      transform: translateX(0%) translateY(13px);
+      white-space: pre;
+      z-index: 1;
+
+      &::before {
+        border: {
+          bottom: 8px solid $color-dark;
+          left: 8px solid transparent;
+          right: 8px solid transparent;
+        }
+        bottom: 100%;
+        content: '';
+        height: 0;
+        left: $sp-small;
+        pointer-events: none;
+        position: absolute;
+        width: 0;
+      }
+    }
+
+    &:focus,
+    &:hover {
+
+      .p-tooltip__message {
+        display: inline;
+        text-decoration: initial;
+      }
+    }
+
+    // Bottom center tooltip
+    &--btm-center {
+
+      .p-tooltip__message {
+        bottom: inherit;
+        left: 50%;
+        top: 100%;
+        transform: translateX(-50%) translateY(13px);
+
+        &::before {
+          left: 50%;
+          transform: translateX(-50%);
+        }
+      }
+    }
+
+    // Bottom right tooltip
+    &--btm-right {
+
+      .p-tooltip__message {
+        bottom: inherit;
+        left: initial;
+        right: 0;
+        top: 100%;
+        transform: translateY(13px);
+
+        &::before {
+          left: initial;
+          right: $sp-small;
+        }
+      }
+    }
+
+    // Top left tooltip
+    &--top-left {
+
+      .p-tooltip__message {
+        bottom: 100%;
+        left: 0;
+        top: initial;
+        transform: translateX(0%) translateY(-13px);
+
+        &::before {
+          border: {
+            bottom: 8px solid transparent;
+            left: 8px solid transparent;
+            right: 8px solid transparent;
+            top: 8px solid $color-dark;
+          }
+          bottom: -1rem;
+          left: $sp-small;
+        }
+      }
+    }
+
+    // Top center tooltip
+    &--top-center {
+
+      .p-tooltip__message {
+        bottom: 100%;
+        left: 50%;
+        top: initial;
+        transform: translateX(-50%) translateY(-13px);
+
+        &::before {
+          border: {
+            bottom: 8px solid transparent;
+            left: 8px solid transparent;
+            right: 8px solid transparent;
+            top: 8px solid $color-dark;
+          }
+          bottom: -1rem;
+          left: 50%;
+          transform: translateX(-50%);
+        }
+      }
+    }
+
+    // Top right tooltip
+    &--top-right {
+
+      .p-tooltip__message {
+        bottom: 100%;
+        left: initial;
+        right: 0;
+        top: initial;
+        transform: translateX(0%) translateY(-13px);
+
+        &::before {
+          border: {
+            bottom: 8px solid transparent;
+            left: 8px solid transparent;
+            right: 8px solid transparent;
+            top: 8px solid $color-dark;
+          }
+          bottom: -1rem;
+          left: initial;
+          right: $sp-small;
+        }
+      }
+    }
+
+    // Right tooltip
+    &--right {
+
+      .p-tooltip__message {
+        bottom: inherit;
+        left: 100%;
+        top: 50%;
+        transform: translateX(14px) translateY(-50%);
+
+        &::before {
+          border: {
+            bottom: 8px solid transparent;
+            left: 8px solid transparent;
+            right: 8px solid $color-dark;
+            top: 8px solid transparent;
+          }
+          bottom: inherit;
+          left: 0;
+          top: 50%;
+          transform: translateX(-16px) translateY(-50%);
+        }
+      }
+    }
+
+    // Left tooltip
+    &--left {
+
+      .p-tooltip__message {
+        bottom: inherit;
+        left: -16px;
+        top: 50%;
+        transform: translateX(-100%) translateY(-50%);
+
+        &::before {
+          border: {
+            bottom: 8px solid transparent;
+            left: 8px solid $color-dark;
+            right: 8px solid transparent;
+            top: 8px solid transparent;
+          }
+          bottom: inherit;
+          left: 100%;
+          top: 50%;
+          transform: translateX(0) translateY(-50%);
+        }
+      }
+    }
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -23,6 +23,7 @@
 'patterns_notifications',
 'patterns_pull-quotes',
 'patterns_strip',
+'patterns_tooltips',
 'patterns_form-validation';
 
 // Utilities
@@ -62,6 +63,7 @@
   @include vf-p-navigation;
   @include vf-p-links;
   @include vf-p-lists;
+  @include vf-p-tooltips;
   @include vf-p-inline-images;
   @include vf-p-notification;
   @include vf-p-pull-quotes;


### PR DESCRIPTION
## Done

- Porting over the tooltips SCSS from Vanilla dashboard theme
- Creating examples and documentation content

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- View tooltips pattern http://0.0.0.0:8101/vanilla-framework/examples/patterns/tooltips/

## Details

Fixes #1238 
