### PR TITLE
Adding SCSS, html examples and docs for the expanding table.

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -95,6 +95,9 @@ navigation:
   - location: patterns/strip.md
     title: Strip
 
+  - location: patterns/table-expanding.md
+    title: Table expanding
+
 - title: Utilities
   children:
 
@@ -134,4 +137,3 @@ navigation:
 - location: https://vanillaframework.io/
   title: vanillaframework.io
   external: true
-

--- a/docs/en/patterns/table-expanding.md
+++ b/docs/en/patterns/table-expanding.md
@@ -1,0 +1,17 @@
+---
+collection: patterns
+title: Table expanding
+---
+
+## Table expanding
+
+Using `.p-table-expanding` in conjunction with the `<table>` element will allow expanding and hidden table cells which take up the full width of the table row element.
+
+This pattern should be used when a table requires configuration fields (add, edit). Expandable rows can also be used to supply additional information not visible on the table row.
+
+Using `p-table-expanding__panel` it can be hidden using the `aria-hidden` attribute. The table must contain all table cells required.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/tables/table-expanding"
+  class="js-example">
+  View example of the expanding table pattern
+</a>

--- a/examples/patterns/tables/table-expanding.html
+++ b/examples/patterns/tables/table-expanding.html
@@ -1,0 +1,169 @@
+---
+layout: default
+title: Table expanding
+category: _patterns
+---
+
+<table class="p-table-expanding" role="grid">
+    <thead>
+        <tr role="row">
+            <th scope="col" id="t-name" aria-sort="none">Name</th>
+            <th scope="col" id="t-users" aria-sort="none" class="u-align--right">Users</th>
+            <th scope="col" id="t-units" aria-sort="none" class="u-align--right">Units</th>
+            <th scope="col" id="t-revenue" aria-sort="none" class="u-align--right">Actions</th>
+            <th class="u-hide"><!-- empty cell required for validation --></th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr role="row">
+            <td role="rowheader" aria-label="Name">Grape</td>
+            <td role="gridcell" aria-label="Users" class="u-align--right">8</td>
+            <td role="gridcell" aria-label="Units" class="u-align--right">19</td>
+            <td role="gridcell" class="u-align--right">
+                <button class="u-toggle" aria-controls="#expanded-row" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">Show</button>
+            </td>
+            <td id="expanded-row" class="p-table-expanding__panel" aria-hidden="true">
+                <div class="row">
+                    <div class="col-6">
+                        <h3>Expanding table cell</h3>
+                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates architecto ipsa dolorum eaque rem expedita inventore voluptas odit aspernatur alias molestias facere, eum accusamus dolor, assumenda. Eaque, id! Dolorem perferendis reprehenderit eum, odio minima ad commodi earum non, iste suscipit.</p>
+                    </div>
+                    <div class="col-6">
+                        <img src="http://placehold.it/1024x325" alt="">
+                    </div>
+                </div>
+            </td>
+        </tr>
+        <tr role="row">
+            <td role="rowheader" aria-label="Name">Melon</td>
+            <td role="gridcell" aria-label="Users" class="u-align--right">12</td>
+            <td role="gridcell" aria-label="Units" class="u-align--right">23</td>
+            <td role="gridcell" class="u-align--right">
+                <button class="u-toggle" aria-controls="#expanded-row-2" aria-expanded="false">Show</button>
+            </td>
+            <td id="expanded-row-2" class="p-table-expanding__panel" aria-hidden="true">
+                <div class="row">
+                    <div class="col-6">
+                        <h3>Expanding table cell</h3>
+                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates architecto ipsa dolorum eaque rem expedita inventore voluptas odit aspernatur alias molestias facere, eum accusamus dolor, assumenda. Eaque, id! Dolorem perferendis reprehenderit eum, odio minima ad commodi earum non, iste suscipit.</p>
+                    </div>
+                    <div class="col-6">
+                        <img src="http://placehold.it/1024x325" alt="">
+                    </div>
+                </div>
+            </td>
+        </tr>
+        <tr role="row">
+            <td role="rowheader" aria-label="Name">Apple</td>
+            <td role="gridcell" aria-label="Users" class="u-align--right">9</td>
+            <td role="gridcell" aria-label="Units" class="u-align--right">17</td>
+            <td role="gridcell" class="u-align--right">
+                <button class="u-toggle" aria-controls="#expanded-row-3" aria-expanded="false">Show</button>
+            </td>
+            <td id="expanded-row-3" class="p-table-expanding__panel" aria-hidden="true">
+                <div class="row">
+                    <div class="col-6">
+                        <h3>Expanding table cell</h3>
+                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates architecto ipsa dolorum eaque rem expedita inventore voluptas odit aspernatur alias molestias facere, eum accusamus dolor, assumenda. Eaque, id! Dolorem perferendis reprehenderit eum, odio minima ad commodi earum non, iste suscipit.</p>
+                    </div>
+                    <div class="col-6">
+                        <img src="http://placehold.it/1024x325" alt="">
+                    </div>
+                </div>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+<h2>Example JavaScript</h2>
+<pre><code>
+(function() {
+    /**
+     * Toggle target elements with aria controls, hidden and expanded
+     *
+     * @param {String} toggleCtrl
+     *
+     * @example
+     * &lt;button class="u-toggle" aria-controls="#menu" aria-expanded="false"&gt;Toggle&lt;/button&gt;
+     * &lt;div id="menu" aria-hidden="true"&gt;
+     *     &lt;p&gt;Example menu&lt;/p&gt;
+     * &lt;/div&gt;
+     */
+
+    function toggle(toggleCtrl) {
+
+        // Select all toggle control elements
+        var t = document.querySelectorAll(toggleCtrl);
+
+        // Loop through all toggle control elements
+        for(i = 0; i < t.length; i++) {
+
+            // Set click event to each toggle control element
+            t[i].addEventListener('click', function(event) {
+
+                // Get toggle aria-control target
+                var target = document.querySelector(
+                    this.getAttribute('aria-controls'));
+
+                // If target hidden is already true set to fale and toggle
+                // control expanded to be true / false
+                if (target.getAttributeNode("aria-hidden").value == 'true') {
+                    this.setAttribute('aria-expanded', 'true');
+                    target.setAttribute('aria-hidden', 'false');
+                } else {
+                    this.setAttribute('aria-expanded', 'false');
+                    target.setAttribute('aria-hidden', 'true');
+                }
+            });
+        }
+    }
+
+    toggle('.u-toggle');
+})()
+</code></pre>
+
+<script>
+(function() {
+    /**
+     * Toggle target elements with aria controls, hidden and expanded
+     *
+     * @param {String} toggleCtrl
+     *
+     * @example
+     * <button class="u-toggle" aria-controls="#menu" aria-expanded="false">Toggle</button>
+     * <div id="menu" aria-hidden="true">
+     *     <p>Example menu</p>
+     * </div>
+     */
+
+    function toggle(toggleCtrl) {
+
+        // Select all toggle control elements
+        var t = document.querySelectorAll(toggleCtrl);
+
+        // Loop through all toggle control elements
+        for(i = 0; i < t.length; i++) {
+
+            // Set click event to each toggle control element
+            t[i].addEventListener('click', function(event) {
+
+                // Get toggle aria-control target
+                var target = document.querySelector(
+                    this.getAttribute('aria-controls'));
+
+                // If target hidden is already true set to fale and toggle
+                // control expanded to be true / false
+                if (target.getAttributeNode("aria-hidden").value == 'true') {
+                    this.setAttribute('aria-expanded', 'true');
+                    target.setAttribute('aria-hidden', 'false');
+                } else {
+                    this.setAttribute('aria-expanded', 'false');
+                    target.setAttribute('aria-hidden', 'true');
+                }
+            });
+        }
+    }
+
+    toggle('.u-toggle');
+})()
+</script>

--- a/examples/patterns/tables/table-expanding.html
+++ b/examples/patterns/tables/table-expanding.html
@@ -75,53 +75,6 @@ category: _patterns
     </tbody>
 </table>
 
-<h2>Example JavaScript</h2>
-<pre><code>
-(function() {
-    /**
-     * Toggle target elements with aria controls, hidden and expanded
-     *
-     * @param {String} toggleCtrl
-     *
-     * @example
-     * &lt;button class="u-toggle" aria-controls="#menu" aria-expanded="false"&gt;Toggle&lt;/button&gt;
-     * &lt;div id="menu" aria-hidden="true"&gt;
-     *     &lt;p&gt;Example menu&lt;/p&gt;
-     * &lt;/div&gt;
-     */
-
-    function toggle(toggleCtrl) {
-
-        // Select all toggle control elements
-        var t = document.querySelectorAll(toggleCtrl);
-
-        // Loop through all toggle control elements
-        for(i = 0; i < t.length; i++) {
-
-            // Set click event to each toggle control element
-            t[i].addEventListener('click', function(event) {
-
-                // Get toggle aria-control target
-                var target = document.querySelector(
-                    this.getAttribute('aria-controls'));
-
-                // If target hidden is already true set to fale and toggle
-                // control expanded to be true / false
-                if (target.getAttributeNode("aria-hidden").value == 'true') {
-                    this.setAttribute('aria-expanded', 'true');
-                    target.setAttribute('aria-hidden', 'false');
-                } else {
-                    this.setAttribute('aria-expanded', 'false');
-                    target.setAttribute('aria-hidden', 'true');
-                }
-            });
-        }
-    }
-
-    toggle('.u-toggle');
-})()
-</code></pre>
-
 <script>
 (function() {
     /**

--- a/scss/_patterns_table-expanding.scss
+++ b/scss/_patterns_table-expanding.scss
@@ -1,0 +1,56 @@
+@import 'settings';
+
+@mixin vf-p-table-expanding {
+  .p-table-expanding {
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: space-between;
+
+    tbody {
+      margin: 0;
+    }
+
+    tr {
+      display: flex;
+      flex: {
+        flow: row;
+        wrap: wrap;
+      }
+      margin: 0;
+      width: 100%;
+
+      + tr {
+        margin: 0;
+      }
+    }
+
+    th,
+    td {
+      align-self: baseline;
+      display: flex;
+      flex: {
+        basis: 0;
+        flow: row nowrap;
+        grow: 1;
+      }
+      margin: 0;
+      word-break: break-word;
+
+      &.p-table-expanding__panel {
+        border-top: 1px solid $color-mid-light;
+        flex-basis: 100%;
+        max-width: 100%;
+
+        &[aria-hidden="true"] {
+          display: none;
+        }
+
+        .row {
+          max-width: 100%;
+          padding: 0;
+          width: 100%;
+        }
+      }
+    }
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -24,6 +24,7 @@
 'patterns_notifications',
 'patterns_pull-quotes',
 'patterns_strip',
+'patterns_table-expanding',
 'patterns_form-validation';
 
 // Utilities
@@ -68,6 +69,7 @@
   @include vf-p-notification;
   @include vf-p-pull-quotes;
   @include vf-p-strip;
+  @include vf-p-table-expanding;
   @include vf-p-form-validation;
   // Utilities
   @include vf-u-clearfix;


### PR DESCRIPTION
## Done

- Ports over the expanding table pattern.
- Creates html and docs

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Open table expanding a view the component

## Details

Fixes #1234 