### PR TITLE
Adding SCSS, examples and docs for table sorting.

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -95,6 +95,9 @@ navigation:
   - location: patterns/strip.md
     title: Strip
 
+  - location: patterns/table-sortable.md
+    title: Table sortable
+
 - title: Utilities
   children:
 
@@ -134,4 +137,3 @@ navigation:
 - location: https://vanillaframework.io/
   title: vanillaframework.io
   external: true
-

--- a/docs/en/patterns/table-sortable.md
+++ b/docs/en/patterns/table-sortable.md
@@ -1,0 +1,13 @@
+---
+collection: patterns
+title: Table sortable
+---
+
+## Table sortable
+
+Using the class `p-table--sortable` and assigning `role="columnheader"` and `aria-sort` to each `<th>` element will show each table column to be sortable. With javascript toggling between `ascending` and `descending` for the `aria-sort` attribute it will change the chevron icon in that direction.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/tables/table-sortable/"
+  class="js-example">
+  View example of the table sortable pattern
+</a>

--- a/examples/patterns/tables/table-sortable.html
+++ b/examples/patterns/tables/table-sortable.html
@@ -1,0 +1,152 @@
+---
+layout: default
+title: Table sortable
+category: _patterns
+---
+
+<table class="p-table--sortable" role="grid">
+  <thead>
+    <tr role="row">
+      <th scope="col" role="columnheader" id="t-name" aria-sort="none">Name</th>
+      <th scope="col" role="columnheader" id="t-users" aria-sort="none" class="u-align--right">Users</th>
+      <th scope="col" role="columnheader" id="t-units" aria-sort="none" class="u-align--right">Units</th>
+      <th scope="col" role="columnheader" id="t-revenue" aria-sort="none" class="u-align--right">Revenue</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr role="row">
+      <td role="rowheader">Grape</td>
+      <td role="gridcell" class="u-align--right">8</td>
+      <td role="gridcell" class="u-align--right">19</td>
+      <td role="gridcell" class="u-align--right">$70</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader">Melon</td>
+      <td role="gridcell" class="u-align--right">12</td>
+      <td role="gridcell" class="u-align--right">23</td>
+      <td role="gridcell" class="u-align--right">$99</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader">Apple</td>
+      <td role="gridcell" class="u-align--right">9</td>
+      <td role="gridcell" class="u-align--right">17</td>
+      <td role="gridcell" class="u-align--right">$120</td>
+    </tr>
+  </tbody>
+</table>
+
+<script>
+  (function() {
+    /**
+     * Sort a table by the column specified.
+     *
+     * @param {HTMLTableElement} table
+     * @param {Number} col
+     */
+    function sortTable(table, col) {
+      // For readability set the scope to the header.
+      var header = this;
+
+      // Helper 'contant'.
+      var SORTABLE_STATES = {
+        none: 0,
+        ascending: -1,
+        descending: 1,
+        ORDER: ['none', 'ascending', 'descending']
+      };
+
+      // Based on the current aria-sort, get the next state.
+      var newOrder = SORTABLE_STATES.ORDER.indexOf(header.getAttribute('aria-sort')) + 1;
+      newOrder = newOrder > SORTABLE_STATES.ORDER.length - 1 ? 0 : newOrder;
+      newOrder = SORTABLE_STATES.ORDER[newOrder];
+      var currentSort = table.querySelectorAll('[aria-sort]');
+
+      // Reset all header sorts.
+      for (var i = 0, ii = currentSort.length; i < ii; i += 1) {
+        currentSort[i].setAttribute('aria-sort', 'none');
+      }
+
+      // Set the new header sort.
+      header.setAttribute('aria-sort', newOrder);
+
+      // Get the direction of the sort and assume only one tbody.
+      // For this example only assume one tbody.
+      var direction = SORTABLE_STATES[newOrder];
+      var body = table.tBodies[0];
+
+      // Convert the HTML element list to an array.
+      var newRows = Array.prototype.slice.call(body.rows, 0);
+
+      // If the direction is 0 - aria-sort="none".
+      if (direction === 0) {
+        // Reset to the default order.
+        newRows.sort(function (a, b) {
+          return  a.getAttribute('data-index') - b.getAttribute('data-index');
+        });
+      } else {
+        newRows.sort(function (a, b) {
+          // Trim the cell contents.
+          var c = a.cells[col].textContent.trim();
+          var d = b.cells[col].textContent.trim();
+
+          // If the content contains a number, parse it as a number.
+          // This is very crude and should not be considered production ready.
+          if (c.replace(/[^0-9]/gi, '') !== '' && !isNaN(c.replace(/[^0-9]/gi, ''))) {
+            c = parseInt(c.replace(/[^0-9]/gi, ''));
+            // Ascending for numbers and the alphabet are opposite.
+            direction *= -1;
+          }
+          if (d.replace(/[^0-9]/gi, '') !== '' && !isNaN(d.replace(/[^0-9]/gi, ''))) {
+            d = parseInt(d.replace(/[^0-9]/gi, ''));
+            // Ascending for numbers and the alphabet are opposite.
+            direction *= -1;
+          }
+
+          // Based on the direction, do the sort.
+          if (direction === 1) {
+            return c < d;
+          } else {
+            return c > d;
+          }
+        });
+      }
+      // Append each row into the table, replacing the current elements.
+      for(var i = 0, ii = body.rows.length; i < ii; i += 1) {
+        body.appendChild(newRows[i]);
+      }
+    }
+
+    /**
+     * Create a sortable table from a table.
+     * @param {HTMLTableElement} table
+     */
+    function createSortableTable(table) {
+      // Select sortable column headers.
+      var clickableHeaders = table.querySelectorAll('[role="columnheader"][aria-sort]');
+      // For this example, assume only one tbody.
+      var rows = table.tBodies[0].rows;
+      // Set an index for the default order.
+      for (var row = 0, totalRows = rows.length; row < totalRows; row += 1) {
+        rows[row].setAttribute('data-index', row);
+      }
+
+      // Attach the click event for each header.
+      for (var i = 0, ii = clickableHeaders.length; i < ii; i += 1) {
+        // Ensure we bind the event to the header and pass the table and column.
+        clickableHeaders[i].addEventListener('click', sortTable.bind(clickableHeaders[i], table, i));
+      }
+    }
+
+    /**
+     * Make all --sortable tables on the page sortable.
+     */
+    function createSortableTables() {
+      var tables = document.querySelectorAll('table.p-table--sortable');
+      for (var i = 0, ii = tables.length; i < ii; i += 1) {
+        createSortableTable(tables[i]);
+      }
+    }
+
+    createSortableTables();
+  })()
+</script>

--- a/scss/_patterns_table-sortable.scss
+++ b/scss/_patterns_table-sortable.scss
@@ -1,0 +1,46 @@
+@import 'settings';
+
+@mixin vf-p-table-sortable {
+
+  %heading-icon {
+    background: {
+      image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' height='4' width='10' viewBox='0 0 10 4'%3E%3Cpath d='M3.637 3.138c-.518-.365-1.052-.778-1.6-1.238C1.486 1.44.946.948.414.423.273.283.135.14 0 0h1.54c.305.29.62.57.948.846.138.116.277.23.417.34.163.13.328.257.495.38.085.062.17.123.257.184.397.282.935.626 1.315.848h.054c.38-.222.918-.566 1.315-.848.4-.28.79-.583 1.17-.904C7.837.57 8.153.29 8.457 0h1.54c-.134.14-.272.282-.414.422C9.05.948 8.51 1.442 7.963 1.9c-.55.46-1.084.873-1.602 1.238S5.39 3.79 5 4c-.39-.21-.845-.497-1.363-.862z' fill='%23888' fill-rule='evenodd'/%3E%3C/svg%3E");
+      position: center;
+      repeat: no-repeat;
+      size: 100%;
+    }
+    content: '';
+    display: inline-block;
+    height: .4rem;
+    margin-left: $sp-x-small;
+    vertical-align: middle;
+    width: $sp-medium;
+  }
+
+  .p-table--sortable {
+    table-layout: fixed;
+
+    th[role="columnheader"] {
+
+      &[aria-sort] {
+        align-items: center;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+
+      &[aria-sort="ascending"]::after {
+        @extend %heading-icon;
+      }
+
+      &[aria-sort="descending"]::after {
+        @extend %heading-icon;
+        transform: rotate(180deg);
+      }
+
+      &[aria-sort]:hover {
+        color: $color-link;
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -24,6 +24,7 @@
 'patterns_notifications',
 'patterns_pull-quotes',
 'patterns_strip',
+'patterns_table-sortable',
 'patterns_form-validation';
 
 // Utilities
@@ -68,6 +69,7 @@
   @include vf-p-notification;
   @include vf-p-pull-quotes;
   @include vf-p-strip;
+  @include vf-p-table-sortable;
   @include vf-p-form-validation;
   // Utilities
   @include vf-u-clearfix;


### PR DESCRIPTION
## Done

- Ports over the table sorting styles
- creates html examples and docs

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/

## Details

Fixes #1236 

