### PR TITLE
Interpolate variable in calc so it compiles correctly

### DIFF
--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -25,7 +25,7 @@
       &::after {
         position: absolute;
         right: $sp-small;
-        top: calc(50% - $sp-x-small);
+        top: calc(50% - #{$sp-x-small});
       }
     }
 


### PR DESCRIPTION
## Done

`$sp-x-small` variable inside `calc` in forms validation pattern was not compiling properly, so it needed to be interpolated.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check compiled styles of form validation pattern, $sp-x-small value should be compiled (not visible as variable).