### PR TITLE
Remove the card placeholder from switch pattern

### DIFF
--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -37,9 +37,10 @@
     }
 
     &::before {
-      @extend %p-card--highlighted;
       @include animation($duration: slow);
       background-color: $color-x-light;
+      border-radius: 2px;
+      box-shadow: 0 1px 5px 1px transparentize($color-dark, .8);
       content: '';
       display: block;
       height: 100%;


### PR DESCRIPTION
## Done
Replaced the placeholder extend in the switch pattern with the few styling values that were required.

**Do not extend a placeholder on a pseudo selector - leads to madness**

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/card/card/
- Check that looks ok
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/switch/
- Check that looks ok

