### PR TITLE
Remove the nesting before headings with siblings

### DIFF
--- a/scss/_base_vertical-spacing.scss
+++ b/scss/_base_vertical-spacing.scss
@@ -60,19 +60,19 @@
         margin-top: $sp-x-large;
       }
     }
+  }
 
-    + h2,
-    + .p-heading--two,
-    + h3,
-    + .p-heading--three,
-    + h4,
-    + .p-heading--four {
-      + * {
-        margin-top: $sp-x-small;
+  h2,
+  .p-heading--two,
+  h3,
+  .p-heading--three,
+  h4,
+  .p-heading--four {
+    + * {
+      margin-top: $sp-x-small;
 
-        @media screen and (min-width: #{$breakpoint-large}) {
-          margin-top: $sp-medium;
-        }
+      @media screen and (min-width: #{$breakpoint-large}) {
+        margin-top: $sp-medium;
       }
     }
   }


### PR DESCRIPTION
## Done
Fix the spacing between headers and p's.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/headings/
- Copy the following mark up into the page:
```html
<div class="p-strip--light is-bordered is-deep">
  <div class="row p-divider">
    <div class="col-6 p-divider__block">
      <div class="row">
        <div class="u-equal-height">
          <div class="col-4">
          <h3><a href="https://www.ubuntu.com" class="p-link--external">Explore ubuntu.com</a></h3>
          <p>On ubuntu.com you’ll find more information about the platform, our services, our management tools and our partner&nbsp;programs.</p>
        </div>
          <div class="col-2 u-vertically-center u-hide--small">
          <img src="https://assets.ubuntu.com/v1/83d13882-image-footer-ubuntu.svg" alt="Ubuntu logo">
        </div>
        </div>
      </div>
    </div>
    <div class="col-3 p-divider__block">
      <h3><a href="/services">Learn more about services&nbsp;›</a></h3>
      <p>Leading organisations all over the world turn to us for our management services and consultancy.</p>
    </div>
    <div class="col-3 p-divider__block">
      <h3><a href="/partners">Learn more about partners&nbsp;›</a></h3>
      <p>We help the biggest names in hardware, software and cloud to optimise, extend and deliver Ubuntu at scale.</p>
    </div>
  </div>
</div>
```
- Check that it fixes the issue in the links issue

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1279

