### PR TITLE
Add font-smoothing back

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -103,6 +103,15 @@
     }
   }
 
+  * {
+    // sass-lint:disable no-vendor-prefixes
+    // These vendor prefixes are unique and cannot be added by autoprefixer
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    // sass-lint:enable no-vendor-prefixes
+    font-smoothing: subpixel-antialiased;
+  }
+
   html {
     font-size: $font-base-size;
   }

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -109,7 +109,9 @@
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
     // sass-lint:enable no-vendor-prefixes
+    // sass-lint:disable no-misspelled-properties
     font-smoothing: subpixel-antialiased;
+    // sass-lint:enable no-misspelled-properties
   }
 
   html {


### PR DESCRIPTION
## Done
Add back the font smoothing for Macs

## QA

- Check the code is the same as was removed here:
https://github.com/vanilla-framework/vanilla-framework/commit/4da454bc79e64b08e8975b6ffca0abc45c8b9dd7#diff-835de81767074b6c90941c47335f0fd9L106
