### PR TITLE
Set the height of the navigation logo

### DIFF
--- a/examples/patterns/navigation/light.html
+++ b/examples/patterns/navigation/light.html
@@ -9,7 +9,7 @@ category: _patterns
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="#">
-          Vanilla
+          <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="" class="p-navigation__image" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -226,6 +226,11 @@
       }
     }
 
+    &__image {
+      float: left;
+      height: $sp-x-large;
+    }
+
     &__link {
       border-bottom: 0; // For when this class is applied to an <a> directly
       display: block;


### PR DESCRIPTION
## Done
Set the navigation logo to a set height.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/light/
- Check that the logo image is `32px` and has `8px` top and bottom height

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1037
