### PR TITLE
Remove large bottom margin from card header

### DIFF
--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -16,6 +16,10 @@
       max-height: $sp-x-large;
     }
   }
+
+  .p-card__title {
+    margin-top: 0;
+  }
 }
 
 %p-card--highlighted {


### PR DESCRIPTION
## Done

- Remove large bottom margin from card header

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/card/card/
- Ensure card pattern matches the spec

## Details

Fixes #1280
