### PR TITLE
Set inline-image styling to its general useage

### DIFF
--- a/scss/_patterns_inline-images.scss
+++ b/scss/_patterns_inline-images.scss
@@ -26,7 +26,14 @@
       }
 
       * {
-        width: 100%;
+        max-height: $sp-xxx-large;
+        max-width: 7rem;
+        width: auto;
+
+        @media only screen and (min-width: $breakpoint-medium) {
+          max-height: 5.5rem;
+          max-width: 9rem;
+        }
       }
     }
 

--- a/scss/_patterns_inline-images.scss
+++ b/scss/_patterns_inline-images.scss
@@ -28,7 +28,7 @@
       * {
         max-height: $sp-xxx-large;
         max-width: 7rem;
-        width: auto;
+        width: 100%;
 
         @media only screen and (min-width: $breakpoint-medium) {
           max-height: 5.5rem;


### PR DESCRIPTION
## Done
Update the styling of the inline-images pattern to match the common usage across our sites. We currently copy a "hack" for inline-images between sites and this branch means it can stop.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/inline-images/
- Check that it looks ok
- Check the code matches the hack that is being copied around: https://github.com/canonical-websites/www.ubuntu.com/blob/b788fd6162c2f86fd5408ddd09a3c2940d5a3550/static/sass/_pattern_inline-images.scss#L23

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1168
