### PR TITLE
Add a note about the need for an autoprefixer

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -32,3 +32,4 @@ Easings
 mixin
 dialog
 javascript
+autoprefixer

--- a/docs/en/patterns/links.md
+++ b/docs/en/patterns/links.md
@@ -14,7 +14,7 @@ The `.p-link--external` class should be used on hyperlinks that go to a differen
     View example of the external link pattern
 </a>
 
-!!! Note: 
+!!! Note:
     The `p-link--external` class makes use of the fairly new [CSS Masks](http://www.caniuse.com/#search=mask). For support in more browsers you should run your CSS through [an autoprefixer](https://www.npmjs.com/package/autoprefixer) before deploying.
 
 ## Soft link

--- a/docs/en/patterns/links.md
+++ b/docs/en/patterns/links.md
@@ -14,6 +14,9 @@ The `.p-link--external` class should be used on hyperlinks that go to a differen
     View example of the external link pattern
 </a>
 
+!!! Note: 
+    The `p-link--external` class makes use of the fairly new [CSS Masks](http://www.caniuse.com/#search=mask). For support in more browsers you should run your CSS through [an autoprefixer](https://www.npmjs.com/package/autoprefixer) before deploying.
+
 ## Soft link
 
 The `.p-link--soft` class should be used on hyperlinks where many links are grouped together, such as a link cloud.


### PR DESCRIPTION
The need for autoprefixing surprised me. So I'm adding documentation about it.

## QA

``` bash
documentation-builder --source-folder docs
xdg-open build/en/patterns/links.html || open build/en/patterns/links.html
```

Look at the documentation - check there's a note under `p-link-external` about autoprefixer.