### PR TITLE
Fix strip example imports

### DIFF
--- a/docs/en/patterns/strip.md
+++ b/docs/en/patterns/strip.md
@@ -24,7 +24,7 @@ A `.p-strip` container should always be the parent of a `.row` (from the [Grid p
 The purpose of the strip accent pattern displays content with a highlighted
 site accent strip style.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework//examples/patterns/strip/accent/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/strip/accent/"
   class="js-example">
   View example of the pattern strip accent
 </a>
@@ -37,7 +37,7 @@ This pattern allows for an image background to be appear as a background on a st
 You can also add the classes '.is-light' and '.is-dark' to the strips to describe the background image.
 These classes will then override the text color to ensure it remains visible.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework//examples/patterns/strip/image/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/strip/image/"
   class="js-example">
   View example of the pattern strip image
 </a>
@@ -47,7 +47,7 @@ This pattern is used to add a dividing border at the bottom of the strip.
 
 **Note** This should be used when two strips of the same type are used after each other.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework//examples/patterns/strip/is-bordered/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/strip/is-bordered/"
   class="js-example">
   View example of the pattern strip is-bordered
 </a>
@@ -55,7 +55,7 @@ This pattern is used to add a dividing border at the bottom of the strip.
 ## Strip is-deep
 This state gives the strip larger vertical padding.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework//examples/patterns/strip/deep/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/strip/deep/"
   class="js-example">
   View example of the pattern strip is-deep
 </a>
@@ -63,7 +63,7 @@ This state gives the strip larger vertical padding.
 ## Strip is-shallow
 This state gives the strip smaller vertical padding.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework//examples/patterns/strip/shallow/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/strip/shallow/"
   class="js-example">
   View example of the pattern strip is-shallow
 </a>


### PR DESCRIPTION
Fixes #1325

## Done

Remove double slash from strip example import links

## QA

- Pull code
- Run `./run serve --watch`
- Jump into docs.vf.io and import this branch
- Run docs
- Check all strip examples display correctly

## Details

Fixes #1325 
