### PR TITLE
Add trailing slash to table expanding import

### DIFF
--- a/docs/en/patterns/table-expanding.md
+++ b/docs/en/patterns/table-expanding.md
@@ -11,7 +11,7 @@ This pattern should be used when a table requires configuration fields (add, edi
 
 Using `p-table-expanding__panel` it can be hidden using the `aria-hidden` attribute. The table must contain all table cells required.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/tables/table-expanding"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/tables/table-expanding/"
   class="js-example">
   View example of the expanding table pattern
 </a>


### PR DESCRIPTION
## Done
Add trailing slash to table expanding import

## QA
- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check table expanding displays in docs

## Details

Fixes #1326