### PR TITLE
Add p-muted-heading to docs

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -93,6 +93,9 @@ navigation:
   - location: patterns/media-object.md
     title: Media object
 
+  - location: patterns/muted-heading.md
+    title: Muted heading
+
   - location: patterns/navigation.md
     title: Navigation
 
@@ -113,7 +116,7 @@ navigation:
 
   - location: patterns/table-expanding.md
     title: Table expanding
-  
+
   - location: patterns/modal.md
     title: Modal
 
@@ -122,7 +125,7 @@ navigation:
 
   - location: patterns/tooltips.md
     title: Tooltips
-    
+
 
 
 - title: Utilities

--- a/docs/en/patterns/muted-heading.md
+++ b/docs/en/patterns/muted-heading.md
@@ -5,9 +5,9 @@ title: Muted heading
 
 ## Muted heading
 
-Muted heading can label a list of icons.
+A Muted heading can be used to introduce a collection of icons or images.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/muted-heading/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/headings/muted/"
   class="js-example">
   View example of the pattern muted heading
 </a>

--- a/examples/patterns/headings/muted.html
+++ b/examples/patterns/headings/muted.html
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Headings / Muted
+category: _patterns
+---
+
+<h4 class="p-muted-heading">Muted heading</h4>


### PR DESCRIPTION
## Done

Add p-muted-heading to docs

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Import this branch into your local vf.io 
- Verify that `.p-muted-header` displays correctly

## Details

Fixes #1328 