### PR TITLE
Remove !important from animations util

### DIFF
--- a/scss/_utilities_animations.scss
+++ b/scss/_utilities_animations.scss
@@ -1,7 +1,7 @@
 /// Animations
 @mixin vf-u-animations {
   .u-animation--spin {
-    animation: spin map-get($animation-duration, sleepy) infinite linear !important;
+    animation: spin map-get($animation-duration, sleepy) infinite linear;
   }
 
   @keyframes spin {


### PR DESCRIPTION
This is because Percy, the visual regression tool, needs to be able to override this rule to provide accurate test results.

## Done

Remove !important from animations util

## QA

- Check that Percy returns no regressions on this PR.

## Details

Fixes #1323 