### PR TITLE
Update the light navigation to a white background

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -22,7 +22,7 @@
 @mixin navigation-light {
   .p-navigation--light {
     @include navigation-pattern(
-      $background-color: $color-light,
+      $background-color: $color-x-light,
       $border-color: $color-mid-light,
       $text-color: $color-dark
     );


### PR DESCRIPTION
## Done
Update the light navigation to a white background

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/light/
- Check that the navigation is white

## Details
Fixes https://github.com/ubuntudesign/vanilla-design/issues/87
