### PR TITLE
Removed unnecessary additonal padding from large media object.

### DIFF
--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -68,7 +68,6 @@
 
     &--large {
       display: flex;
-      padding: $sp-xx-large 0;
 
       .p-media-object__image {
         flex-shrink: 0;


### PR DESCRIPTION
## Done

Removed unnecessary additonal padding from large media object

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Go to Media Object - Large example
- Pattern should use default vanilla margins (no additional padding).

## Details

As part of #1343 review additional padding was added to large variant of media object pattern.

It caused a bug where media pattern had unnecessary double spacing when used inside of a stripe pattern:

<img width="1017" alt="screen shot 2017-09-19 at 15 12 59" src="https://user-images.githubusercontent.com/83575/30594221-9bc162a8-9d4d-11e7-81b7-0414bfa1ec12.png">

This PR removes unnecessary additional padding and let's media object use default values of Vanilla spacing defined in horizontal rhythm rules:

<img width="1005" alt="screen shot 2017-09-19 at 15 14 00" src="https://user-images.githubusercontent.com/83575/30594256-c199eb94-9d4d-11e7-866c-c66d2c5ce87e.png">

NOTE:

Because of #1338 adding `.u-no-margin--bottom` is needed in some context to avoid unexpected bottom margin.
