### PR TITLE
Increase threshold for text color contrast in navigation pattern

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -12,7 +12,7 @@
     @include navigation-pattern(
       $background-color: $color-navigation-background,
       $border-color: if(lightness($color-navigation-background) > 50, $color-mid-light, transparent),
-      $text-color: if(lightness($color-navigation-background) > 50, $color-dark, $color-light)
+      $text-color: if(lightness($color-navigation-background) > 70, $color-dark, $color-light)
     );
   }
 }


### PR DESCRIPTION
## Done

Increase threshold for text color contrast in navigation pattern

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Verify navigations pattern display correctly

## Details

Fixes #1373 
