### PR TITLE
Set the default header to full width

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -67,7 +67,7 @@ navigation:
     title: Contextual menu
 
   - location: patterns/divider.md
-    title: Contextual menu
+    title: Divider
 
   - location: patterns/footer.md
     title: Footer

--- a/docs/en/patterns/navigation.md
+++ b/docs/en/patterns/navigation.md
@@ -15,10 +15,8 @@ Note: You can constrain the width of the navigation to match the
 `$grid-max-width` by placing everything inside the header element within a
 `.row` wrapper.
 
-Note: To make the navigation full width you should just remove the `row` element
-from the mark up presented below.
-
-The background color of a navigation pattern can be set via the `$color-navigation-background` variable.
+The background color of a navigation pattern can be set via the
+`$color-navigation-background` variable.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/navigation/default/"
     class="js-example">
@@ -31,7 +29,10 @@ menu by adjusting the `$breakpoint-navigation-threshold` in
 
 # Sidebar Navigation
 
-Vanilla also allows you to use a sidebar navigation, with menu items collapsing under section titles in an accordion. This example code will expand to fill the space available to it so it needs to be used in conjunction with the grid to set the layout. This pattern includes a tagline which sits next to the logo.
+Vanilla also allows you to use a sidebar navigation, with menu items collapsing
+under section titles in an accordion. This example code will expand to fill the
+space available to it so it needs to be used in conjunction with the grid to
+set the layout. This pattern includes a tagline which sits next to the logo.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/navigation/sidebar/"
     class="js-example">

--- a/examples/patterns/navigation/default.html
+++ b/examples/patterns/navigation/default.html
@@ -5,25 +5,23 @@ category: _patterns
 ---
 
 <header id="navigation" class="p-navigation">
-  <div class="row">
-    <div class="p-navigation__banner">
-      <div class="p-navigation__logo">
-        <a class="p-navigation__link" href="#">
-          <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="" class="p-navigation__image" />
-        </a>
-      </div>
-      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+  <div class="p-navigation__banner">
+    <div class="p-navigation__logo">
+      <a class="p-navigation__link" href="#">
+        <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="" class="p-navigation__image" />
+      </a>
     </div>
-    <nav class="p-navigation__nav" role="menubar">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
-      <ul class="p-navigation__links" role="menu">
-        <li class="p-navigation__link" role="menuitem"><a href="#">Link1</a></li>
-        <li class="p-navigation__link" role="menuitem"><a href="#">Link2</a></li>
-        <li class="p-navigation__link" role="menuitem"><a href="#">Link3</a></li>
-      </ul>
-    </nav>
+    <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+    <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
   </div>
+  <nav class="p-navigation__nav" role="menubar">
+    <span class="u-off-screen">
+      <a href="#main-content">Jump to main content</a>
+    </span>
+    <ul class="p-navigation__links" role="menu">
+      <li class="p-navigation__link" role="menuitem"><a href="#">Link1</a></li>
+      <li class="p-navigation__link" role="menuitem"><a href="#">Link2</a></li>
+      <li class="p-navigation__link" role="menuitem"><a href="#">Link3</a></li>
+    </ul>
+  </nav>
 </header>


### PR DESCRIPTION
## Done
Set the default navigation pattern to full width and updated the documentation to describe how you can restrict the navigation width. Drive by to update the `Divider` in the documentation navigation.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/default/
- Check that the navigation is full width
- Check the documentation has a note about using `.row`

## Details
Fixes https://github.com/ubuntudesign/vanilla-design/issues/90
