### PR TITLE
Remove the border bottom from the last item of a split list

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -75,6 +75,10 @@
       @include vf-list-item;
       @include vf-list-item-divided;
     }
+
+    &.is-split .p-list__item:last-of-type {
+      border-bottom: 1px dotted $color-mid-light;
+    }
   }
 }
 
@@ -270,10 +274,6 @@
         .p-list__item {
           width: calc(50% - .5rem);
         }
-      }
-
-      .p-list__item:last-of-type {
-        border-bottom: 1px dotted $color-mid-light;
       }
 
       &:nth-child(2n-1) {


### PR DESCRIPTION
## Done
Remove the border-bottom from the last item of a split list

## QA

- Pull code
- Run `./run serve --watch`
- Add the following to the `lists-split` example:
```html
<ul class="p-list is-split">
  <li class="p-list__item is-ticked">Lorem</li>
  <li class="p-list__item is-ticked">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean nec ipsum augue. Ut arcu erat, lacinia sit amet justo quis. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</li>
  <li class="p-list__item is-ticked">Dolor</li>
  <li class="p-list__item is-ticked">Aenean nec ipsum augue. Ut arcu erat, lacinia sit amet justo quis.</li>
  <li class="p-list__item is-ticked">Ipsum</li>
  <li class="p-list__item is-ticked">Ut arcu erat, lacinia sit amet justo quis.</li>
</ul>
```
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/lists/lists-split/
- Check all the borders are correct unlike the codepen example: https://codepen.io/anthonydillon/pen/ZXYBEe

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1337
