### PR TITLE
Remove CSS mask, use icon mixin instead

### DIFF
--- a/docs/en/patterns/links.md
+++ b/docs/en/patterns/links.md
@@ -14,9 +14,6 @@ The `.p-link--external` class should be used on hyperlinks that go to a differen
     View example of the external link pattern
 </a>
 
-!!! Note:
-    The `p-link--external` class makes use of the fairly new [CSS Masks](http://www.caniuse.com/#search=mask). For support in more browsers you should run your CSS through [an autoprefixer](https://www.npmjs.com/package/autoprefixer) before deploying.
-
 ## Soft link
 
 The `.p-link--soft` class should be used on hyperlinks where many links are grouped together, such as a link cloud.

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -7,14 +7,12 @@
     &--external {
 
       &::after {
-        -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E") no-repeat 50% 50%; // sass-lint:disable-line no-vendor-prefixes
-        background-color: currentColor;
+        @include vf-icon-external-link($color-link);
+        background-size: .7em .7em;
         content: '';
         display: inline-block;
         height: .7em;
         margin: 0 0 0 .25em;
-        mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E") no-repeat 50% 50%;
-        mask-size: cover;
         vertical-align: top;
         width: .7em;
       }
@@ -46,6 +44,10 @@
     &--strong {
       color: $color-dark;
       font-weight: 400;
+
+      &::after {
+        @include vf-icon-external-link($color-dark);
+      }
 
       &:visited {
         color: $color-dark;


### PR DESCRIPTION
## Done

Remove CSS mask, use icon mixin instead

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/links/links-external/
- See that external links now match the spec

## Details


## Screenshots

<img width="735" alt="screen shot 2017-10-20 at 09 41 05" src="https://user-images.githubusercontent.com/505570/31812463-f3c817ae-b57a-11e7-9094-4b8e455123b1.png">
