### PR TITLE
Decouple strips from external links

### DIFF
--- a/docs/en/patterns/links.md
+++ b/docs/en/patterns/links.md
@@ -28,7 +28,7 @@ The `.p-link--soft` class should be used on hyperlinks where many links are grou
 
 ## Strong link
 
-The `.p-link--strong` class should be used on hyperlinks that require emphasis.
+The `.p-link--strong` class should be used on hyperlinks that require emphasis or on a dark background.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/links/links-strong/"
     class="js-example">

--- a/examples/templates/external-links.html
+++ b/examples/templates/external-links.html
@@ -1,0 +1,96 @@
+---
+layout: default
+title: External links
+category: _templates
+---
+
+<div class="p-strip">
+  <div class="row">
+    <div class="col-12">
+      <p><a href="#">Plain link</a></p>
+      <p><a class="p-link--external">Plain external link</a></p>
+      <p><a class="p-link--external p-link--strong">Strong external link</a></p>
+      <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
+      <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
+      <p><a class="p-button--negative"><span class="p-link--external">External negative button</span></a></p>
+      <p><a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a></p>
+      <p><a class="p-button--base"><span class="p-link--external">External base button</span></a></p>
+    </div>
+  </div>
+</div>
+
+<section class="p-strip--dark">
+  <div class="row">
+    <div class="col-12">
+      <p><a href="#">Plain link</a></p>
+      <p><a class="p-link--external">Plain external link</a></p>
+      <p><a class="p-link--external p-link--strong">Strong external link</a></p>
+      <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
+      <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
+      <p><a class="p-button--negative"><span class="p-link--external">External negative button</span></a></p>
+      <p><a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a></p>
+      <p><a class="p-button--base"><span class="p-link--external">External base button</span></a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-12">
+      <p><a href="#">Plain link</a></p>
+      <p><a class="p-link--external">Plain external link</a></p>
+      <p><a class="p-link--external p-link--strong">Strong external link</a></p>
+      <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
+      <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
+      <p><a class="p-button--negative"><span class="p-link--external">External negative button</span></a></p>
+      <p><a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a></p>
+      <p><a class="p-button--base"><span class="p-link--external">External base button</span></a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--accent">
+  <div class="row">
+    <div class="col-12">
+      <p><a href="#">Plain link</a></p>
+      <p><a class="p-link--external">Plain external link</a></p>
+      <p><a class="p-link--external p-link--strong">Strong external link</a></p>
+      <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
+      <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
+      <p><a class="p-button--negative"><span class="p-link--external">External negative button</span></a></p>
+      <p><a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a></p>
+      <p><a class="p-button--base"><span class="p-link--external">External base button</span></a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--image is-light" style="background-image:url('https://assets.ubuntu.com/sites/ubuntu/latest/u/img/backgrounds/image-background-paper.png')">
+<div class="row">
+    <div class="col-12">
+      <p><a href="#">Plain link</a></p>
+      <p><a class="p-link--external">Plain external link</a></p>
+      <p><a class="p-link--external p-link--strong">Strong external link</a></p>
+      <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
+      <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
+      <p><a class="p-button--negative"><span class="p-link--external">External negative button</span></a></p>
+      <p><a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a></p>
+      <p><a class="p-button--base"><span class="p-link--external">External base button</span></a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--image is-dark" style="background-image:url('https://assets.ubuntu.com/v1/62d597f6-background-grid.png')">
+  <div class="row">
+    <div class="col-12">
+      <p><a href="#">Plain link</a></p>
+      <p><a class="p-link--external">Plain external link</a></p>
+      <p><a class="p-link--external p-link--strong">Strong external link</a></p>
+      <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
+      <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
+      <p><a class="p-button--negative"><span class="p-link--external">External negative button</span></a></p>
+      <p><a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a></p>
+      <p><a class="p-button--base"><span class="p-link--external">External base button</span></a></p>
+    </div>
+  </div>
+</section>
+

--- a/examples/templates/external-links.html
+++ b/examples/templates/external-links.html
@@ -7,8 +7,8 @@ category: _templates
 <div class="p-strip">
   <div class="row">
     <div class="col-12">
-      <p><a href="#">Plain link</a></p>
-      <p><a class="p-link--external">Plain external link</a></p>
+      <p><a href="#">Link</a></p>
+      <p><a class="p-link--external">External link</a></p>
       <p><a class="p-link--external p-link--strong">Strong external link</a></p>
       <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
       <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
@@ -22,8 +22,8 @@ category: _templates
 <section class="p-strip--dark">
   <div class="row">
     <div class="col-12">
-      <p><a href="#">Plain link</a></p>
-      <p><a class="p-link--external">Plain external link</a></p>
+      <p><a href="#">Link</a></p>
+      <p><a class="p-link--external">External link</a></p>
       <p><a class="p-link--external p-link--strong">Strong external link</a></p>
       <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
       <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
@@ -37,8 +37,8 @@ category: _templates
 <section class="p-strip--light">
   <div class="row">
     <div class="col-12">
-      <p><a href="#">Plain link</a></p>
-      <p><a class="p-link--external">Plain external link</a></p>
+      <p><a href="#">Link</a></p>
+      <p><a class="p-link--external">External link</a></p>
       <p><a class="p-link--external p-link--strong">Strong external link</a></p>
       <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
       <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
@@ -52,8 +52,8 @@ category: _templates
 <section class="p-strip--accent">
   <div class="row">
     <div class="col-12">
-      <p><a href="#">Plain link</a></p>
-      <p><a class="p-link--external">Plain external link</a></p>
+      <p><a href="#">Link</a></p>
+      <p><a class="p-link--external">External link</a></p>
       <p><a class="p-link--external p-link--strong">Strong external link</a></p>
       <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
       <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
@@ -67,8 +67,8 @@ category: _templates
 <section class="p-strip--image is-light" style="background-image:url('https://assets.ubuntu.com/sites/ubuntu/latest/u/img/backgrounds/image-background-paper.png')">
 <div class="row">
     <div class="col-12">
-      <p><a href="#">Plain link</a></p>
-      <p><a class="p-link--external">Plain external link</a></p>
+      <p><a href="#">Link</a></p>
+      <p><a class="p-link--external">External link</a></p>
       <p><a class="p-link--external p-link--strong">Strong external link</a></p>
       <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
       <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
@@ -82,8 +82,8 @@ category: _templates
 <section class="p-strip--image is-dark" style="background-image:url('https://assets.ubuntu.com/v1/62d597f6-background-grid.png')">
   <div class="row">
     <div class="col-12">
-      <p><a href="#">Plain link</a></p>
-      <p><a class="p-link--external">Plain external link</a></p>
+      <p><a href="#">Link</a></p>
+      <p><a class="p-link--external">External link</a></p>
       <p><a class="p-link--external p-link--strong">Strong external link</a></p>
       <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
       <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -96,4 +96,8 @@
       border-color: $button-disabled-border-color;
     }
   }
+
+  .p-link--external {
+    color: currentColor;
+  }
 }

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -44,15 +44,15 @@
     }
 
     &--strong {
-      color: $color-dark;
+      color: currentColor;
       font-weight: 400;
 
       &:visited {
-        color: $color-dark;
+        color: currentColor;
       }
 
       &:hover {
-        color: $color-link;
+        color: currentColor;
         text-decoration: underline;
       }
     }
@@ -86,9 +86,5 @@
       text-decoration: none;
       top: -.725rem;
     }
-  }
-
-  .p-link--external.p-link--strong {
-    color: $color-dark;
   }
 }

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -1,7 +1,6 @@
 @import 'settings';
 
 @mixin vf-strip {
-  @include vf-external-link-color;
   clear: both;
   margin-top: 0;
   padding: $sp-x-large 0;


### PR DESCRIPTION
## Done
Removed the cross-linking of strips and external links and used currentColor to use the strip color to style the external link. Created a layout to test all combinations of the external link.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/templates/external-links/
- Check that all external links are styled as expected.

_There is some issues with base button but that is out of scope for this issue_

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1378
