### PR TITLE
Increase the font-size of the tabs pattern

### DIFF
--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -58,7 +58,6 @@
     &__link {
       color: $color-x-dark;
       display: inline-block;
-      font-size: .875rem;
       padding: $sp-small;
 
       &:visited,


### PR DESCRIPTION
## Done
Remove the font-size of the tab items which sets it to 16px by default.

## QA
- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/tabs/
- Check that the font is `16px`

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1407