### PR TITLE
Edit metadata.yaml to update/reorder categories on docs.vf.io

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -24,7 +24,7 @@ navigation:
   - location: patterns/grid.md
     title: Grid
 
-- location: patterns/strip.md
+  - location: patterns/strip.md
     title: Strip
 
   - location: settings/layout-settings.md
@@ -78,7 +78,7 @@ navigation:
   - location: patterns/contextual-menu.md
     title: Contextual menu
 
-- location: patterns/footer.md
+  - location: patterns/footer.md
     title: Footer
 
   - location: patterns/navigation.md

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -3,13 +3,13 @@ navigation:
 - title: Basics
   children:
 
- - location: settings/color-settings.md
+  - location: settings/color-settings.md
     title: Color
 
- - location: settings/font-settings.md
+  - location: settings/font-settings.md
     title: Font
 
-- location: base/reset.md
+  - location: base/reset.md
     title: Reset
 
   - location: settings/spacing-settings.md
@@ -33,38 +33,38 @@ navigation:
 - title: One-off layout
   children:
 
-   - location: utilities/align.md
-      title: Alignment
+  - location: utilities/align.md
+    title: Alignment
 
-    - location: utilities/clearfix.md
-      title: Clearfix
+  - location: utilities/clearfix.md
+    title: Clearfix
 
-    - location: utilities/equal-height.md
-      title: Equal height
+  - location: utilities/equal-height.md
+    title: Equal height
 
-   - location: utilities/floats.md
-      title: Floats
+  - location: utilities/floats.md
+    title: Floats
 
-    - location: utilities/hide.md
-      title: Hide
+  - location: utilities/hide.md
+    title: Hide
 
-    - location: utilities/image-position.md
-      title: Image position
+  - location: utilities/image-position.md
+    title: Image position
 
-    - location: utilities/margin-collapse.md
-      title: Margin collapse
+  - location: utilities/margin-collapse.md
+    title: Margin collapse
 
-    - location: utilities/off-screen.md
-      title: Off-screen elements
+  - location: utilities/off-screen.md
+    title: Off-screen elements
 
-    - location: utilities/padding-collapse.md
-      title: Padding collapse
+  - location: utilities/padding-collapse.md
+    title: Padding collapse
 
-    - location: utilities/show.md
-      title: Show
+  - location: utilities/show.md
+    title: Show
 
-   - location: utilities/vertically-center.md
-      title: Vertically center
+  - location: utilities/vertically-center.md
+    title: Vertically center
 
 - title: Navigation
   children:
@@ -84,13 +84,13 @@ navigation:
   - location: patterns/navigation.md
     title: Global navigation
 
-   - location: patterns/tabs.md
+  - location: patterns/tabs.md
     title: Tabs
 
 - title: Page structure
   children:
 
-    - location: patterns/card.md
+  - location: patterns/card.md
     title: Cards
 
   - location: patterns/divider.md
@@ -162,10 +162,10 @@ navigation:
   - location: patterns/switch.md
     title: Switch
 
- - location: base/table.md
+  - location: base/table.md
     title: Table
 
- - location: patterns/table-sortable.md
+  - location: patterns/table-sortable.md
     title: Table sortable
 
   - location: patterns/table-expanding.md
@@ -187,13 +187,13 @@ navigation:
     title: Assets
 
   - location: utilities/embedded-media.md
-      title: Embedded media
+    title: Embedded media
 
- - location: patterns/icons.md
+  - location: patterns/icons.md
     title: Icons
 
-    - location: utilities/spin.md
-      title: Spin
+  - location: utilities/spin.md
+    title: Spin
    
 - location: https://vanillaframework.io/
   title: vanillaframework.io

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -1,165 +1,48 @@
 navigation:
 
-- title: Settings
+- title: Basics
   children:
 
-  - location: settings/animation-settings.md
-    title: Animations
-
-  - location: settings/assets-settings.md
-    title: Assets
-
-  - location: settings/breakpoint-settings.md
-    title: Breakpoints
-
-  - location: settings/color-settings.md
+ - location: settings/color-settings.md
     title: Color
 
-  - location: settings/font-settings.md
+ - location: settings/font-settings.md
     title: Font
 
-  - location: settings/layout-settings.md
-    title: Layout
+- location: base/reset.md
+    title: Reset
 
   - location: settings/spacing-settings.md
     title: Spacing
 
-- title: Base
+- title: Global layout 
   children:
 
-  - location: base/code.md
-    title: Code
-
-  - location: base/forms.md
-    title: Forms
-
-  - location: base/reset.md
-    title: Reset
-
-  - location: base/table.md
-    title: Table
-
-  - location: base/typography.md
-    title: Typography
-
-- title: Patterns
-  children:
-
-  - location: patterns/accordion.md
-    title: Accordion
-
-  - location: patterns/breadcrumbs.md
-    title: Breadcrumbs
-
-  - location: patterns/buttons.md
-    title: Buttons
-
-  - location: patterns/card.md
-    title: Card
-
-  - location: patterns/code-numbered.md
-    title: Code numbered
-
-  - location: patterns/code-snippet.md
-    title: Code snippet
-
-  - location: patterns/contextual-menu.md
-    title: Contextual menu
-
-  - location: patterns/divider.md
-    title: Divider
-
-  - location: patterns/footer.md
-    title: Footer
-
-  - location: patterns/forms.md
-    title: Forms
-
-  - location: patterns/form-validation.md
-    title: Form validation
+  - location: settings/breakpoint-settings.md
+    title: Breakpoints
 
   - location: patterns/grid.md
     title: Grid
 
-  - location: patterns/heading-icon.md
-    title: Heading icon
-
-  - location: patterns/icons.md
-    title: Icon sets
-
-  - location: patterns/images.md
-    title: Images
-
-  - location: patterns/inline-images.md
-    title: Inline images
-
-  - location: patterns/links.md
-    title: Links
-
-  - location: patterns/lists.md
-    title: Lists
-
-  - location: patterns/list-tree.md
-    title: List tree
-
-  - location: patterns/matrix.md
-    title: Matrix
-
-  - location: patterns/media-object.md
-    title: Media object
-
-  - location: patterns/modal.md
-    title: Modal
-
-  - location: patterns/muted-heading.md
-    title: Muted heading
-
-  - location: patterns/navigation.md
-    title: Navigation
-
-  - location: patterns/notification.md
-    title: Notification
-
-  - location: patterns/pull-quote.md
-    title: Pull quote
-
-  - location: patterns/strip.md
+- location: patterns/strip.md
     title: Strip
 
-  - location: patterns/switch.md
-    title: Switch
+  - location: settings/layout-settings.md
+    title: Structure
 
-  - location: patterns/table-sortable.md
-    title: Table sortable
-
-  - location: patterns/table-expanding.md
-    title: Table expanding
-
-  - location: patterns/table-mobile-card.md
-    title: Table mobile card
-
-  - location: patterns/tabs.md
-    title: Tabs
-
-  - location: patterns/tooltips.md
-    title: Tooltips
-
-- title: Utilities
+- title: One-off layout
   children:
 
-    - location: utilities/align.md
-      title: Align
+   - location: utilities/align.md
+      title: Alignment
 
     - location: utilities/clearfix.md
       title: Clearfix
 
-    - location: utilities/embedded-media.md
-      title: Embedded media
-
     - location: utilities/equal-height.md
       title: Equal height
 
-    - location: utilities/floats.md
+   - location: utilities/floats.md
       title: Floats
 
     - location: utilities/hide.md
@@ -172,7 +55,7 @@ navigation:
       title: Margin collapse
 
     - location: utilities/off-screen.md
-      title: Off screen
+      title: Off-screen elements
 
     - location: utilities/padding-collapse.md
       title: Padding collapse
@@ -180,12 +63,138 @@ navigation:
     - location: utilities/show.md
       title: Show
 
-    - location: utilities/spin.md
-      title: Spin
-
-    - location: utilities/vertically-center.md
+   - location: utilities/vertically-center.md
       title: Vertically center
 
+- title: Navigation
+  children:
+
+  - location: patterns/accordion.md
+    title: Accordion
+
+  - location: patterns/breadcrumbs.md
+    title: Breadcrumbs
+
+  - location: patterns/contextual-menu.md
+    title: Contextual menu
+
+- location: patterns/footer.md
+    title: Footer
+
+  - location: patterns/navigation.md
+    title: Global navigation
+
+   - location: patterns/tabs.md
+    title: Tabs
+
+- title: Page structure
+  children:
+
+    - location: patterns/card.md
+    title: Cards
+
+  - location: patterns/divider.md
+    title: Divider list
+
+  - location: base/typography.md
+    title: Headings
+
+  - location: patterns/heading-icon.md
+    title: Heading icon
+
+  - location: patterns/images.md
+    title: Images
+
+  - location: patterns/inline-images.md
+    title: Inline images
+
+  - location: patterns/lists.md
+    title: Lists
+
+  - location: patterns/matrix.md
+    title: Matrix
+
+  - location: patterns/media-object.md
+    title: Media object
+
+  - location: patterns/muted-heading.md
+    title: Muted heading
+
+- title: Text
+  children:
+
+  - location: base/code.md
+    title: Code
+
+  - location: patterns/code-numbered.md
+    title: Code numbered
+
+  - location: patterns/code-snippet.md
+    title: Code snippet
+
+  - location: patterns/pull-quote.md
+    title: Quotes
+
+- title: Interactive elements
+  children:
+
+  - location: patterns/buttons.md
+    title: Buttons
+
+  - location: patterns/forms.md
+    title: Forms
+
+  - location: patterns/form-validation.md
+    title: Form validation
+
+  - location: patterns/links.md
+    title: Links
+
+  - location: patterns/list-tree.md
+    title: List tree
+
+  - location: patterns/modal.md
+    title: Modal
+
+  - location: patterns/notification.md
+    title: Notifications
+
+  - location: patterns/switch.md
+    title: Switch
+
+ - location: base/table.md
+    title: Table
+
+ - location: patterns/table-sortable.md
+    title: Table sortable
+
+  - location: patterns/table-expanding.md
+    title: Table expanding
+
+  - location: patterns/table-mobile-card.md
+    title: Table mobile card
+
+  - location: patterns/tooltips.md
+    title: Tooltips
+
+- title: Media
+  children:
+
+  - location: settings/animation-settings.md
+    title: Animations
+
+  - location: settings/assets-settings.md
+    title: Assets
+
+  - location: utilities/embedded-media.md
+      title: Embedded media
+
+ - location: patterns/icons.md
+    title: Icons
+
+    - location: utilities/spin.md
+      title: Spin
+   
 - location: https://vanillaframework.io/
   title: vanillaframework.io
   external: true


### PR DESCRIPTION
## Done

- Updated metadata.yaml to match work completed on new categorisation on docs.vf.io
- Links remain the same just a reorder and grouping of components
- Design issue found [here](https://github.com/ubuntudesign/vanilla-design/issues/118) which was the outcome from Documentation workshop

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/

## Additonal

- @nottrobin or @WillMoggridge to create/share demo of PR so I can review before going live.
