### PR TITLE
1380: Replace .p-link--external CSS masks with background-image mixins

### DIFF
--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -1,22 +1,48 @@
 @import 'settings';
 
+@mixin external-link-icon($color) {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 16 16' %3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='#{$color}' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='#{$color}' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='#{$color}' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E");
+}
+
 // Link style patterns
 @mixin vf-p-links {
   .p-link {
     // Used for links point at a different domain
     &--external {
 
+      &.p-link--strong::after {
+        @include external-link-icon(currentColor);
+      }
+
+      &.p-link--soft {
+        &::after {
+          @include external-link-icon(vf-url-friendly-color($color-dark));
+        }
+
+        &:hover::after {
+          @include external-link-icon(vf-url-friendly-color($color-link));
+        }
+      }
+
+      &.p-link--inverted {
+        &::after {
+          @include external-link-icon(vf-url-friendly-color($color-light));
+        }
+
+        &:visited::after {
+          @include external-link-icon(vf-url-friendly-color(darken($color-light, 10%)));
+        }
+      }
+
       &::after {
-        -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E") no-repeat 50% 50%; // sass-lint:disable-line no-vendor-prefixes
-        background-color: currentColor;
+        @include external-link-icon(vf-url-friendly-color($color-link));
+        background-repeat: no-repeat;
         content: '';
         display: inline-block;
-        height: .7em;
+        height: 1em;
         margin: 0 0 0 .25em;
-        mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E") no-repeat 50% 50%;
-        mask-size: cover;
         vertical-align: top;
-        width: .7em;
+        width: 1em;
       }
     }
 


### PR DESCRIPTION
## Done

- Replaced instances of CSS mask in `p-link--external` with a mixin for each colour the link can be

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/links/links-external/
- Check that the external links look good in all major browsers

## Details

Fixes #1380 

## Screenshots

Previously in IE11:
![screenshot](https://user-images.githubusercontent.com/25733845/33181258-70052c74-d067-11e7-80e5-5a0b834cd0ab.png)

