### PR TITLE
Added p-form-help-text, updated stacked and inline examples

### DIFF
--- a/examples/patterns/forms/form-help-text.html
+++ b/examples/patterns/forms/form-help-text.html
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Forms / Help text
+category: _patterns
+---
+
+<form>
+  <label for="exampleTextInputHelp">Username</label>
+  <input class="p-form-validation__input" type="text" id="exampleTextInputHelp" placeholder="Placeholder text" />
+  <p class="p-form-help-text">
+    Lowercase alphanumeric characters and - only.
+  </p>
+</form>

--- a/examples/patterns/forms/form-inline.html
+++ b/examples/patterns/forms/form-inline.html
@@ -35,11 +35,11 @@ category: _patterns
     <label for="address-inline" class="p-form__label">Address line 1</label>
     <div class="p-form__control u-clearfix">
       <input type="text" id="address-inline" class="p-form-validation__input" required aria-invalid="true" aria-describedby="input-error-message-inline">
-      <p class="p-form-help-text">
-          Make sure you know your address
-        </p>
       <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
         <strong>Error:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+      </p>
+      <p class="p-form-help-text">
+        Make sure you know your address
       </p>
     </div>
   </div>

--- a/examples/patterns/forms/form-inline.html
+++ b/examples/patterns/forms/form-inline.html
@@ -20,3 +20,28 @@ category: _patterns
   </div>
   <button class="p-button--positive">Add details</button>
 </form>
+
+<form class="p-form p-form--inline">
+  <div class="p-form__group">
+    <label for="username-inline" class="p-form__label">Username</label>
+    <div class="p-form__control u-clearfix">
+      <input type="text" id="uername-inline" class="p-form__control" required>
+      <p class="p-form-help-text">
+        Lowercase alphanumeric characters and - only.
+      </p>
+    </div>
+  </div>
+  <div class="p-form__group p-form-validation is-error">
+    <label for="address-inline" class="p-form__label">Address line 1</label>
+    <div class="p-form__control u-clearfix">
+      <input type="text" id="address-inline" class="p-form-validation__input" required aria-invalid="true" aria-describedby="input-error-message-inline">
+      <p class="p-form-help-text">
+          Make sure you know your address
+        </p>
+      <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
+        <strong>Error:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+      </p>
+    </div>
+  </div>
+  <button class="p-button--positive">Add details</button>
+</form>

--- a/examples/patterns/forms/form-stacked.html
+++ b/examples/patterns/forms/form-stacked.html
@@ -11,6 +11,27 @@ category: _patterns
       <input type="text" id="full-name-stacked" required>
     </div>
   </div>
+  <div class="p-form__group">
+    <label for="username-stacked" class="p-form__label">Username</label>
+    <div class="p-form__control">
+        <input type="text" id="username-stacked">
+        <p class="p-form-help-text">
+            Lowercase alphanumeric characters and - only.
+        </p>
+    </div>
+  </div>
+  <div class="p-form__group p-form-validation is-error">
+      <label for="username-stacked-error" class="p-form__label">Username</label>
+      <div class="p-form__control">
+          <input type="text" id="username-stacked-error" class="p-form-validation__input" aria-invalid="true" aria-describedby="username-error-message-stacked">
+          <p class="p-form-help-text">
+              Lowercase alphanumeric characters and - only.
+          </p>
+          <p class="p-form-validation__message" id="username-error-message-stacked" role="alert">
+            <strong>Error:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+          </p>
+      </div>
+    </div>
   <div class="p-form__group p-form-validation is-error">
     <label for="address-stacked" class="p-form__label">Address line 1</label>
     <div class="p-form__control">

--- a/examples/patterns/forms/form-stacked.html
+++ b/examples/patterns/forms/form-stacked.html
@@ -24,11 +24,11 @@ category: _patterns
       <label for="username-stacked-error" class="p-form__label">Username</label>
       <div class="p-form__control">
           <input type="text" id="username-stacked-error" class="p-form-validation__input" aria-invalid="true" aria-describedby="username-error-message-stacked">
-          <p class="p-form-help-text">
-              Lowercase alphanumeric characters and - only.
-          </p>
           <p class="p-form-validation__message" id="username-error-message-stacked" role="alert">
             <strong>Error:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+          </p>
+          <p class="p-form-help-text">
+            Lowercase alphanumeric characters and - only.
           </p>
       </div>
     </div>

--- a/scss/_patterns_form-help-text.scss
+++ b/scss/_patterns_form-help-text.scss
@@ -1,0 +1,9 @@
+@import 'settings';
+
+@mixin vf-p-form-help-text {
+  .p-form-help-text {
+    color: $color-mid-dark;
+    font-size: .875rem;
+    margin-top: $sp-x-small;
+  }
+}

--- a/scss/_patterns_forms.scss
+++ b/scss/_patterns_forms.scss
@@ -89,7 +89,8 @@
           margin: 0;
         }
 
-        .p-form-validation__message {
+        .p-form-validation__message,
+        .p-form-help-text {
           clear: both;
           margin-top: $sp-xx-small;
           min-width: 100%; // Sets the width to the minimum width of the parent

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -36,6 +36,7 @@
 'patterns_switch',
 'patterns_table-sortable',
 'patterns_form-validation',
+'patterns_form-help-text',
 'patterns_forms',
 'patterns_tooltips',
 'patterns_table-expanding',
@@ -99,6 +100,7 @@
   @include vf-p-tabs;
   @include vf-p-table-expanding;
   @include vf-p-form-validation;
+  @include vf-p-form-help-text;
   @include vf-p-forms;
   @include vf-p-pagination;
   // Utilities


### PR DESCRIPTION
## Done

Added .p-form-help-text, based on spec here: https://github.com/ubuntudesign/vanilla-design/tree/master/Forms.

## QA

- Pull code
- Run `./run serve --watch`
- Visit:
 - http://0.0.0.0:8101/vanilla-framework/examples/patterns/forms/form-help-text/
 - http://0.0.0.0:8101/vanilla-framework/examples/patterns/forms/form-inline/
 - http://0.0.0.0:8101/vanilla-framework/examples/patterns/forms/form-stacked/
- Ensure all forms look OK.

## Details

https://github.com/vanilla-framework/vanilla-framework/issues/1447

## Screenshots

<img width="688" alt="screen shot 2017-11-24 at 11 50 50" src="https://user-images.githubusercontent.com/479384/33209456-c4a848be-d10d-11e7-919b-fc58ab8433df.png">

