### PR TITLE
1423: Fix accordion example not closing on click

### DIFF
--- a/examples/patterns/accordion.html
+++ b/examples/patterns/accordion.html
@@ -28,74 +28,46 @@ category: _patterns
 </aside>
 
 <script>
-(function() {
-    /**
-     * Toggle target elements with aria controls, hidden and expanded
-     *
-     * @param {String} tabCtrl
-     *
-     * @example
-     * <button class="p-accordion__tab" id="status-tab" role="tab" aria-controls="#status" aria-expanded="false" aria-selected="false">Status</button>
-     * <section class="p-accordion__panel" id="status" role="tabpanel" aria-hidden="true" aria-labelledby="status-tab">
-     *     <p>Closed panel</p>
-     * </section>
-     */
+  (function() {
+
     function accordionToggles(tabCtrl) {
+      let toggles = Array.prototype.slice.call(
+        document.querySelectorAll(tabCtrl)
+      );
 
-        /**
-         * Toggle function
-         * @param {Element} toggle
-         * @property {Boolean} open
-         */
-        function toggle (toggle, open) {
-          var button = toggle.getAttribute('aria-controls');
-          var panel = document.querySelector(button);
+      function toggle (toggle, open) {
+        let button = toggle.getAttribute('aria-controls');
+        let panel = document.querySelector(button);
 
-          if (open === true) {
-              panel.setAttribute('aria-hidden', false);
-              toggle.setAttribute('aria-expanded', true);
-          } else {
-              panel.setAttribute('aria-hidden', true);
-              toggle.setAttribute('aria-expanded', false);
+        if (open) {
+          panel.setAttribute('aria-hidden', false);
+          toggle.setAttribute('aria-expanded', true);
+        } else {
+          panel.setAttribute('aria-hidden', true);
+          toggle.setAttribute('aria-expanded', false);
+        }
+      }
+
+      function toggleAll (event) {
+        let target = event.target;
+
+        // Filter through all toggles and toggle visiblity
+        toggles.forEach(panel => {
+          if (panel !== target) {
+            toggle(panel);
           }
-        }
-
-        /**
-         * Toggle all function
-         * @event event
-         */
-        function toggleAll (event) {
-            var target = event.target;
-
-            // Filter through all toggles and toggle visiblity
-            toggles.filter(function (toggle) {
-                return toggle !== target;
-            }).forEach(toggle);
-
-            // Target toggle to be shown
-            toggle(target, true);
-        }
-
-        // Select all toggle control elements
-        /**
-         * @param {Object[]} toggles
-         * @param {String} tabCtrl
-         */
-        var toggles = Array.prototype.slice.call(
-          document.querySelectorAll(tabCtrl)
-        );
-
-        // Set click event to each toggle control element
-        /**
-         * Triggers a toggleAll function
-         * @param {element} toggle
-         * @fires toggleAll
-         */
-        toggles.forEach(function (toggle) {
-            toggle.addEventListener('click', toggleAll);
         });
+
+        // Target toggle to be shown
+        let targetOpen = target.getAttribute('aria-expanded');
+        targetOpen === 'true' ? toggle(target, false) : toggle(target, true);
+      }
+
+      toggles.forEach(toggle => {
+        toggle.addEventListener('click', toggleAll);
+      });
     }
 
     accordionToggles('.p-accordion__tab');
-})()
+  })()
 </script>


### PR DESCRIPTION
## Done

- Fixed the [accordion example](https://vanilla-framework.github.io/vanilla-framework/examples/patterns/accordion/) not allowing an open panel to close on click. This should by extension fix the example on the [docs page](https://docs.vanillaframework.io/en/patterns/accordion)

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/accordion/
- Check that you can close an open panel
- Remove `<li>` elements so there's only one left on the page and check if it works

## Details

Fixes #1423 