### PR TITLE
1438: Fix spin animation link in docs

### DIFF
--- a/docs/en/utilities/spin.md
+++ b/docs/en/utilities/spin.md
@@ -7,7 +7,7 @@ table_of_contents: true
 
 Animate an element by spinning with the follow utility class.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/animation/spin/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/animations/spin/"
     class="js-example">
     View example of the spin animation utility
 </a>


### PR DESCRIPTION
## Done

- Fixed spin example link in the spin.md file, which should allow the documentation builder to embed the example on the [docs page](https://docs.vanillaframework.io/en/utilities/spin)

## QA

- Pull code
- Build a static docs page using `documentation-builder`
- Add the script `<script src="https://assets.ubuntu.com/v1/7db7c898-example-1.0.5.js"></script>` to the bottom of docs/build/en/utilities/spin.html and open it in a browser
- Check that the spinner example and accompanying code is shown

## Details

Fixes #1438 

## Screenshots

**Page should look like this:**
![screenshot](https://user-images.githubusercontent.com/25733845/33265160-75e4c114-d368-11e7-8779-eea4a8a352ad.png)
