### PR TITLE
1276: Fix external link icon wrapping

### DIFF
--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -1,57 +1,7 @@
 @import 'settings';
 
-@mixin vf-external-link-icon($color) {
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 16 16' %3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='#{$color}' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='#{$color}' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='#{$color}' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E");
-}
-
-// Link style patterns
 @mixin vf-p-links {
   .p-link {
-    // Used for links point at a different domain
-    &--external {
-
-      &.p-link--strong::after {
-        @include vf-external-link-icon(currentColor);
-      }
-
-      &.p-link--soft {
-        &::after {
-          @include vf-external-link-icon(vf-url-friendly-color($color-dark));
-        }
-
-        &:hover::after {
-          @include vf-external-link-icon(vf-url-friendly-color($color-link));
-        }
-      }
-
-      &.p-link--inverted {
-        &::after {
-          @include vf-external-link-icon(vf-url-friendly-color($color-light));
-        }
-
-        &:visited::after {
-          @include vf-external-link-icon(vf-url-friendly-color(darken($color-light, 10%)));
-        }
-      }
-
-      &::after {
-        @include vf-external-link-icon(vf-url-friendly-color($color-link));
-        background-repeat: no-repeat;
-        content: '';
-        display: inline-block;
-        height: 1em;
-        margin: 0 0 0 .25em;
-        vertical-align: top;
-        width: 1em;
-      }
-    }
-
-    @include deprecate('2.0.0', 'This class is no longer required as links now use text-decoration') {
-      &--no-underline {
-        border: 0;
-      }
-    }
-
     &--soft {
       color: $color-dark;
 
@@ -97,6 +47,14 @@
     }
   }
 
+  @supports (mask-size: 1em) {
+    @include vf-mask-supported;
+  }
+
+  @supports not (mask-size: 1em) {
+    @include vf-mask-unsupported;
+  }
+
   .p-top {
     border-bottom: 1px dotted $color-mid-light;
     clear: both;
@@ -113,4 +71,121 @@
       top: -.725rem;
     }
   }
+}
+
+// For browsers that support CSS masks
+@mixin vf-mask-supported {
+  .p-link {
+    // Used for links point at a different domain
+    &--external {
+      &::after {
+        -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E") no-repeat 50% 50%; // sass-lint:disable-line no-vendor-prefixes
+        background-color: currentColor;
+        content: '';
+        display: inline-block;
+        height: .7em;
+        margin: 0 0 0 .25em;
+        mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E") no-repeat 50% 50%;
+        mask-size: cover;
+        vertical-align: top;
+        width: .7em;
+      }
+    }
+
+    @include deprecate('2.0.0', 'This class is no longer required as links now use text-decoration') {
+      &--no-underline {
+        border: 0;
+      }
+    }
+  }
+}
+
+// For browsers that don't support CSS masks
+@mixin vf-mask-unsupported {
+  .p-link {
+    // Used for links that point to a different domain
+    &--external {
+      @include vf-external-link-icon(vf-url-friendly-color($color-link));
+      background-position: top right;
+      background-repeat: no-repeat;
+      background-size: .75em;
+      margin-top: -.25em;
+      padding: .25em 1em 0 0;
+
+      &.p-link--strong,
+      &.p-link--soft,
+      &.sidebar__link {
+        @include vf-external-link-icon(vf-url-friendly-color($color-dark));
+      }
+
+      &.p-link--soft:hover,
+      &.sidebar__link:hover {
+        @include vf-external-link-icon(vf-url-friendly-color($color-link));
+      }
+
+      &.p-link--inverted {
+        @include vf-external-link-icon(vf-url-friendly-color($color-light));
+
+        &:visited {
+          @include vf-external-link-icon(vf-url-friendly-color(darken($color-light, 10%)));
+        }
+      }
+
+      &.sidebar__link {
+        display: inline-block;
+        padding: 0 1em 1em 0;
+      }
+    }
+
+    @include deprecate('2.0.0', 'This class is no longer required as links now use text-decoration') {
+      &--no-underline {
+        border: 0;
+      }
+    }
+  }
+
+  // Manual overrides of .p-link--external within other elements
+  .p-button {
+    .p-link--external,
+    &--neutral .p-link--external,
+    &--base .p-link--external {
+      @include vf-external-link-icon(vf-url-friendly-color($color-dark));
+      padding-top: 0;
+    }
+
+    &--positive .p-link--external {
+      @include vf-external-link-icon(vf-url-friendly-color(vf-contrast-text-color($color-positive)));
+      padding-top: 0;
+    }
+
+    &--negative .p-link--external {
+      @include vf-external-link-icon(vf-url-friendly-color(vf-contrast-text-color($color-negative)));
+      padding-top: 0;
+    }
+
+    &--brand .p-link--external {
+      @include vf-external-link-icon(vf-url-friendly-color(vf-contrast-text-color($color-brand)));
+      padding-top: 0;
+    }
+  }
+
+  .p-strip--dark * .p-link--external.p-link--soft,
+  .p-strip--accent * .p-link--external.p-link--soft,
+  .p-strip--image.is-dark * .p-link--external.p-link--soft {
+    @include vf-external-link-icon(vf-url-friendly-color($color-x-light));
+
+    &:hover {
+      @include vf-external-link-icon(vf-url-friendly-color($color-link));
+    }
+  }
+
+  .p-strip--dark * .p-link--external.p-link--strong,
+  .p-strip--accent * .p-link--external.p-link--strong,
+  .p-strip--image.is-dark * .p-link--external.p-link--strong {
+    @include vf-external-link-icon(vf-url-friendly-color($color-x-light));
+  }
+}
+
+@mixin vf-external-link-icon($color) {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='0.75em' height='0.75em' viewBox='0 0 16 16' %3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='#{$color}' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='#{$color}' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='#{$color}' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E");
 }

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -79,16 +79,11 @@
     // Used for links point at a different domain
     &--external {
       &::after {
-        -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E") no-repeat 50% 50%; // sass-lint:disable-line no-vendor-prefixes
         background-color: currentColor;
         content: '';
-        display: inline-block;
-        height: .7em;
         margin: 0 0 0 .25em;
-        mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E") no-repeat 50% 50%;
-        mask-size: cover;
-        vertical-align: top;
-        width: .7em;
+        mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' %3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E") no-repeat 0 0 / cover;
+        padding-right: .75em;
       }
     }
 


### PR DESCRIPTION
## Done

- Created separate mixins for browsers that do and don't support CSS masks (IE is a special case that doesn't support the `@supports` conditional, and therefore has no icon. I think this is fine, and much better than a random block)
- Fixed external link icon wrapping in both versions
- Fixed `<br>` tag misalignment in both versions

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/templates/external-links/
- Check that the external link icon wraps with the last word in the link, rather than by itself
- In Firefox, check that the icon is still next to the text when followed by a `<br>` tag
- Browser test the colours of the icon matching the text

## Details
Fixes #1276, fixes #1426 

## Screenshots
**Before:**
![screenshot](https://user-images.githubusercontent.com/25733845/33275535-06438d2c-d38b-11e7-9219-6e53018bda9a.png)

**After:**
![screenshot](https://user-images.githubusercontent.com/25733845/33275591-2287903c-d38b-11e7-8e6c-2efe9e778686.png)
