### PR TITLE
Added base icon layout to .p-icon

### DIFF
--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -123,6 +123,9 @@
   }
 
   .p-icon {
+    // Base layout only
+    @extend %icon;
+
     // Icon library
     // Plus icon
     &--plus {


### PR DESCRIPTION
- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/icons/icons-light/
- Modify one of the icon `i` tags by removing the `--[name]` prefix
- Ensure the `i` still has the correct size and background properties set

## Details

Implements https://github.com/vanilla-framework/vanilla-framework/issues/1432
