### PR TITLE
1434: Fix middot centering (use em instead of rem)

### DIFF
--- a/examples/patterns/lists/lists-mid-dot.html
+++ b/examples/patterns/lists/lists-mid-dot.html
@@ -5,7 +5,13 @@ category: _patterns
 ---
 
 <ul class="p-inline-list--middot">
-  <li class="p-inline-list__item">Lorem</li>
-  <li class="p-inline-list__item">Ipsum</li>
-  <li class="p-inline-list__item">Dolor</li>
+  <li class="p-inline-list__item">
+    Lorem
+  </li>
+  <li class="p-inline-list__item">
+    Ipsum
+  </li>
+  <li class="p-inline-list__item">
+    Dolor
+  </li>
 </ul>

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -119,16 +119,17 @@ $numbered-bullet-margin-right: 1rem;
 
     .p-inline-list__item {
       @include vf-inline-list-item;
+      margin-right: 1.25em;
       position: relative;
 
       &::after {
         color: $color-mid-dark;
         content: '\00b7';
-        font-size: 1.4rem;
+        font-size: 1.4em;
         line-height: 0;
         position: absolute;
-        right: -$sp-medium;
-        top: .55rem;
+        right: -.5em;
+        top: .4em;
       }
 
       &:hover::after {


### PR DESCRIPTION
## Done

- Made dots in `.p-inline-list--middot` centred for all font-sizes by changing rems to ems

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/lists/lists-mid-dot/
- Check that the dots are properly centred between the list items
- Change the font-size and check that the dots properly scale and remain centred

## Details

Fixes #1434 