### PR TITLE
1472: Build slider component

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -101,7 +101,9 @@ rules:
   no-color-literals: 1
   no-transition-all: 1
   no-universal-selectors: 0
-  no-vendor-prefixes: 1
+  no-vendor-prefixes:
+    - 1
+    - ignore-non-standard: true
 
   # Style guide
   property-sort-order: 1

--- a/docs/en/patterns/slider.md
+++ b/docs/en/patterns/slider.md
@@ -1,0 +1,26 @@
+---
+title: Slider
+table_of_contents: true
+---
+
+# Sliders
+
+You can apply the slider pattern on `input type="range"` elements.
+
+## Default slider
+
+The `p-slider` pattern allows a user to select from a specified range of values, where the precise value is not considered important.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/slider/slider/"
+    class="js-example">
+    View example of the slider pattern
+</a>
+
+## Slider with input
+
+The `p-slider__wrapper` and `p-slider__input` classes should be used when you want to provide a numeric representation of the slider value, as well as allow the user to specify a value.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/slider/slider-input/"
+    class="js-example">
+    View example of the slider pattern
+</a>

--- a/examples/patterns/slider/slider-input.html
+++ b/examples/patterns/slider/slider-input.html
@@ -1,0 +1,69 @@
+---
+layout: default
+title: Slider / Input
+category: _patterns
+---
+
+<div class="p-slider__wrapper">
+  <input class="p-slider" type="range" min="0" max="100" value="50" step="1" id="slider3">
+  <input class="p-slider__input" type="text" maxlength="3" id="slider3-input">
+</div>
+<div class="p-slider__wrapper">
+  <input class="p-slider" type="range" min="0" max="100" value="50" step="1" id="slider4" disabled>
+  <input class="p-slider__input" type="text" maxlength="3" id="slider4-input" disabled>
+</div>
+
+<script>
+  (function() {
+
+    function equaliseValues(receive, give) {
+      receive.value = give.value;
+      give.value = receive.value;
+    }
+
+    // Fix for Chrome and Safari as they don't support CSS slider progress
+    function renderSlider(slider, progressColour, emptyColour) {
+      if (browser === 'Chrome' || browser === 'Safari') {
+        var value = (slider.value - slider.min) / (slider.max - slider.min);
+        slider.style.backgroundImage = '-webkit-gradient(linear, left top, right top, color-stop('
+        + value + ', ' + progressColour + '), color-stop(' + value + ', ' + emptyColour + '))';
+      }
+    }
+
+    var browser;
+    /Edge/i.test(navigator.userAgent) ? browser = 'Edge' :
+    /Chrome/i.test(navigator.userAgent) ? browser = 'Chrome' :
+    /Safari/i.test(navigator.userAgent) ? browser = 'Safari' :
+    /NET/i.test(navigator.userAgent) ? browser = 'IE' :
+    browser = 'Other';
+    var progressColour = '#335280';
+    var emptyColour = '#fff';
+    var sliders = Array.prototype.slice.call(document.querySelectorAll('.p-slider'));
+
+    sliders.forEach(function(slider) {
+      var input = document.getElementById(slider.id + '-input');
+      renderSlider(slider, progressColour, emptyColour);
+
+      if (input) {
+        equaliseValues(input, slider);
+        input.oninput = function() {
+          if (!input.value) input.value = 0;
+          equaliseValues(slider, input);
+          renderSlider(slider, progressColour, emptyColour);
+        }
+      }
+
+      // Fix for IE as it doesn't support 'oninput'
+      if (browser === 'IE') {
+        slider.onchange = function() {
+          if (input) equaliseValues(input, slider)
+        }
+      } else {
+        slider.oninput = function() {
+          if (input) equaliseValues(input, slider);
+          renderSlider(slider, progressColour, emptyColour);
+        }
+      }
+    });
+  })();
+</script>

--- a/examples/patterns/slider/slider.html
+++ b/examples/patterns/slider/slider.html
@@ -1,0 +1,41 @@
+---
+layout: default
+title: Slider / Default
+category: _patterns
+---
+
+<input class="p-slider" type="range" min="0" max="100" value="50" step="1" id="slider1">
+<input class="p-slider" type="range" min="0" max="100" value="50" step="1" id="slider2" disabled>
+
+<script>
+  (function() {
+
+    // Fix for Chrome and Safari as they don't support CSS slider progress
+    function renderSlider(slider, progressColour, emptyColour) {
+      if (browser === 'Chrome' || browser === 'Safari') {
+        var value = (slider.value - slider.min) / (slider.max - slider.min);
+        slider.style.backgroundImage = '-webkit-gradient(linear, left top, right top, color-stop('
+        + value + ', ' + progressColour + '), color-stop(' + value + ', ' + emptyColour + '))';
+      }
+    }
+
+    var browser;
+    /Edge/i.test(navigator.userAgent) ? browser = 'Edge' :
+    /Chrome/i.test(navigator.userAgent) ? browser = 'Chrome' :
+    /Safari/i.test(navigator.userAgent) ? browser = 'Safari' :
+    /NET/i.test(navigator.userAgent) ? browser = 'IE' :
+    browser = 'Other';
+
+    var progressColour = '#335280';
+    var emptyColour = '#fff';
+    var sliders = Array.prototype.slice.call(document.querySelectorAll('.p-slider'));
+
+    sliders.forEach(function(slider) {
+      renderSlider(slider, progressColour, emptyColour);
+
+      slider.oninput = function() {
+        renderSlider(slider, progressColour, emptyColour);
+      }
+    });
+  })();
+</script>

--- a/scss/_patterns_slider.scss
+++ b/scss/_patterns_slider.scss
@@ -1,0 +1,149 @@
+@import 'settings';
+
+@mixin vf-p-slider {
+  $thumb-shadow: 0 0 2px 1px rgba(0, 0, 0, .2);
+  $thumb-size: 24px;
+  $thumb-radius: 2px;
+  $track-height: 5px;
+  $track-border-size: 1px;
+  $track-border: $track-border-size solid $color-mid-light;
+  $track-radius: 2px;
+
+  .p-slider {
+    appearance: none;
+    border-radius: $track-radius + 1;
+    margin: $sp-small 0;
+    padding: 0;
+    width: 100%;
+
+    // Chrome
+    &::-webkit-slider-runnable-track {
+      border: $track-border;
+      border-radius: $track-radius + 1;
+      height: $track-height + 1;
+    }
+
+    &::-webkit-slider-thumb {
+      appearance: none;
+      background: $color-x-light;
+      border: 0;
+      border-radius: $thumb-radius;
+      box-shadow: $thumb-shadow;
+      height: $thumb-size;
+      margin-top: ((-$thumb-size + $track-height) / 2) - $track-border-size;
+      width: $thumb-size;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+
+    // Firefox
+    &::-moz-range-track {
+      background: $color-x-light;
+      border: $track-border;
+      border-radius: $track-radius;
+      height: $track-height - 1;
+    }
+
+    &::-moz-range-progress {
+      background-color: $color-information;
+      border-radius: $track-radius;
+      height: $track-height - 1;
+    }
+
+    &::-moz-range-thumb {
+      background: $color-x-light;
+      border: 0;
+      border-radius: $thumb-radius;
+      box-shadow: $thumb-shadow;
+      height: $thumb-size;
+      width: $thumb-size;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+
+    &::-moz-focus-outer {
+      border: 0;
+    }
+
+    // IE
+    &::-ms-track {
+      background: transparent;
+      border-color: transparent;
+      border-width: $thumb-size / 2;
+      color: transparent;
+      height: $track-height + 1;
+      width: calc(100% - ($thumb-size / 2));
+    }
+
+    &::-ms-fill-lower {
+      background: $color-information;
+      border: $track-border;
+      border-radius: $track-radius;
+    }
+
+    &::-ms-fill-upper {
+      background: $color-x-light;
+      border: $track-border;
+      border-radius: $track-radius;
+    }
+
+    &::-ms-thumb {
+      background: $color-x-light;
+      border: 0;
+      border-radius: $thumb-radius;
+      box-shadow: $thumb-shadow;
+      height: $thumb-size;
+      margin: 0 2px;
+      width: $thumb-size;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+
+    &::-ms-tooltip {
+      display: none;
+    }
+
+    &:focus {
+      outline: none;
+
+      &::-webkit-slider-thumb {
+        outline: 1px solid $color-focus;
+        outline-offset: 2px;
+      }
+
+      &::-moz-range-thumb {
+        outline: 1px solid $color-focus;
+        outline-offset: 2px;
+      }
+
+      &::-ms-thumb {
+        outline: 1px solid $color-focus;
+        outline-offset: 2px;
+      }
+    }
+
+    &:disabled {
+      opacity: .5;
+    }
+
+    &__wrapper {
+      align-items: center;
+      display: inline-flex;
+      width: 100%;
+    }
+
+    &__input {
+      height: 2.625em;
+      margin: 0 0 0 $sp-medium;
+      min-width: 3.5em;
+      text-align: center;
+      width: 5%;
+    }
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -30,6 +30,7 @@
 'patterns_notifications',
 'patterns_pagination',
 'patterns_pull-quotes',
+'patterns_slider',
 'patterns_table-mobile-card',
 'patterns_tabs',
 'patterns_strip',
@@ -94,6 +95,7 @@
   @include vf-p-notification;
   @include vf-p-pull-quotes;
   @include vf-p-table-mobile-card;
+  @include vf-p-slider;
   @include vf-p-strip;
   @include vf-p-switch;
   @include vf-p-table-sortable;


### PR DESCRIPTION
## Done

- Built slider component as per #1455 
- Includes styling for Chrome, Firefox and IE/Edge browsers

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/slider/
- Check that the component matches the spec (#1455)
- Check that everything looks right in all browsers that we support ([link](https://github.com/canonical-webteam/practices/blob/master/coding/browser-support.md))

## Details

Fixes #1472 

## Notes
- Each browser has a different method of rendering `input type="range` with their own pseudo-selectors and therefore requires custom styling (and a slight change to the linter)
- IE and Edge have a bug where the input thumb's shadow is one(!) pixel to the right
- Chrome (webkit) does not support filled in progress bars for `input type="range"` in CSS, so in the example it is done with Javascript
