### PR TITLE
Move 'Headings' component into 'Text' category on docs.vf.io

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -99,9 +99,6 @@ navigation:
   - location: patterns/divider.md
     title: Divider list
 
-  - location: base/typography.md
-    title: Headings
-
   - location: patterns/heading-icon.md
     title: Heading icon
 
@@ -134,6 +131,9 @@ navigation:
 
   - location: patterns/code-snippet.md
     title: Code snippet
+    
+  - location: base/typography.md
+    title: Typography
 
   - location: patterns/pull-quote.md
     title: Quotes


### PR DESCRIPTION
## Done

- Updated metadata.yaml to fix issue [here](https://github.com/vanilla-framework/vanilla-framework/issues/1482) from multiple raised bugs
- Links remain the same just moving Headings component to sit under Text category
- Updated title from Headings back to Typography

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- [Add additional steps]

## Additonal
- @nottrobin or @WillMoggridge to create/share demo of PR so I can review before going live
