### PR TITLE
1475: Fix list-tree expander icon

### DIFF
--- a/scss/_patterns_list-tree.scss
+++ b/scss/_patterns_list-tree.scss
@@ -77,8 +77,7 @@
 
       &[aria-hidden="false"]::after {
         @extend %list-tree-icon;
-        background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' height='15' width='15' viewBox='0 0 15 15'%3E%3Cdefs%3E%3Cpath id='a' d='M0 0h15v15H0z'/%3E%3C/defs%3E%3Cg fill-rule='evenodd' fill='none'%3E%3Cuse xlink:href='%23a' fill='%23FFF'/%3E%3Cpath stroke='%23888' d='M.5.5h14v14H.5z'/%3E%3Cpath fill='%23888' d='M4 8V7h7v1z'/%3E%3C/g%3E
-        %3C/svg%3E");
+        background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' height='15' width='15' viewBox='0 0 15 15'%3E%3Cdefs%3E%3Cpath id='a' d='M0 0h15v15H0z'/%3E%3C/defs%3E%3Cg fill-rule='evenodd' fill='none'%3E%3Cuse xlink:href='%23a' fill='%23FFF'/%3E%3Cpath stroke='%23888' d='M.5.5h14v14H.5z'/%3E%3Cpath fill='%23888' d='M4 8V7h7v1z'/%3E%3C/g%3E%3C/svg%3E");
         // At this point we need to push this icon above the --group icon.
         z-index: 1;
       }


### PR DESCRIPTION
## Done

- Combined the `background-image` for `p-list-tree[aria-hidden="false"]::after` into a single line, which will fix a parsing error in vanilla react

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/list-tree/
- Check that the list tree pattern still works fine

## Details

Fixes #1475 
