### PR TITLE
1433: Update table v-spacing to $sp-small to match design spec

### DIFF
--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -11,7 +11,7 @@
 
   th,
   td {
-    padding: $sp-medium 0;
+    padding: $sp-small 0;
   }
 
   td {


### PR DESCRIPTION
## Done

- Updated base_tables.scss vertical spacing from 1rem to 0.75rem to match design [spec](https://github.com/ubuntudesign/vanilla-design/blob/master/Table/table.md)
## QA

- Pull code
- Run `./run serve --watch`
- Open the following pages:
- http://0.0.0.0:8101/vanilla-framework/examples/base/table/
- http://0.0.0.0:8101/vanilla-framework/examples/patterns/tables/table-expanding/
- http://0.0.0.0:8101/vanilla-framework/examples/patterns/tables/table-mobile-card/
- http://0.0.0.0:8101/vanilla-framework/examples/patterns/tables/table-sortable/
- Check that the cells in each of the table variants (i.e. `<td>` elements) has a padding-top and padding-bottom of 0.75rem, as per [spec](https://github.com/ubuntudesign/vanilla-design/blob/master/Table/table.md)

## Details

Fixes #1433 
