### PR TITLE
1427: Set breakpoint for 100% width on buttons to x-small

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -34,16 +34,16 @@
 
   & + & {
 
-    @media (max-width: $breakpoint-medium - 1) {
+    @media (max-width: $breakpoint-x-small - 1) {
       margin-top: $sp-medium;
     }
 
-    @media (min-width: $breakpoint-medium) {
+    @media (min-width: $breakpoint-x-small) {
       margin-left: $sp-medium;
     }
   }
 
-  @media only screen and (min-width: $breakpoint-medium) {
+  @media only screen and (min-width: $breakpoint-x-small) {
     width: auto;
   }
 


### PR DESCRIPTION
## Done

- Changed the breakpoint for 100% width on buttons from `$breakpoint-medium` (768px) to `$breakpoint-x-small` (460px) as per original [issue](https://github.com/vanilla-framework/vanilla-framework/issues/1427)

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Resize the browser window width to 460px (which is $breakpoint-x-small) and check that the button does not change
- Resize the browser window width to 459px and check that the button fills the width of the window

## Details

Fixes #1427 
