### PR TITLE
Add Flask app to serve docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ env[23]/
 js/app.js.map
 
 /docs/build
+/docs/templates

--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,6 @@ destination: _jekyll/_site
 exclude: [
     "*.md", "*.scss", "node_modules", "package.json",
     "Gemfile", "Gemfile.lock", "gulpfile.js", "gulp",
-    "LICENSE", "run", 'vendor/bundle', "yarn.lock"
+    "LICENSE", "run", 'vendor/bundle', "yarn.lock", "docs"
 ]
 

--- a/docs/app.py
+++ b/docs/app.py
@@ -1,0 +1,115 @@
+# Core packages
+import os
+import re
+
+# External packages
+import flask
+
+# Local packages
+import routing
+
+
+application_root = ''
+base_dir = os.path.abspath(os.path.dirname(__file__))
+app = flask.Flask(
+    __name__,
+    root_path=base_dir,
+    static_folder=os.path.join(base_dir, 'static'),
+    template_folder=os.path.join(base_dir, 'templates'),
+)
+
+permanent_redirects_path = app.config.get(
+    'PERMANENT_REDIRECTS_FILEPATH',
+    'permanent-redirects.yaml'
+)
+redirects_path = app.config.get(
+    'REDIRECTS_FILEPATH',
+    'redirects.yaml'
+)
+permanent_redirect_map = routing.YamlRegexMap(permanent_redirects_path)
+redirect_map = routing.YamlRegexMap(redirects_path)
+
+
+# Ordered before_request processors
+# ===
+# The order of these functions must be preserved
+
+
+@app.before_request
+def apply_redirects():
+    """
+    Process the two mappings defined above
+    of permanent and temporary redirects to target URLs,
+    to send the appropriate redirect responses
+    """
+
+    permanent_redirect_url = permanent_redirect_map.get_target(
+        flask.request.path
+    )
+    if permanent_redirect_url:
+        return flask.redirect(permanent_redirect_url, code=301)
+
+    redirect_url = redirect_map.get_target(flask.request.path)
+    if redirect_url:
+        return flask.redirect(redirect_url)
+
+
+@app.before_request
+def strip_extensions():
+    """
+    Remove .html and index.html
+    """
+
+    index_match = re.match(r'^(.*/)index(.html)?$', flask.request.path)
+    html_match = re.match(r'^(.*[^/]).html$', flask.request.path)
+
+    if index_match:
+        return flask.redirect(index_match.group(1), code=301)
+    elif html_match:
+        return flask.redirect(html_match.group(1), code=301)
+
+
+@app.before_request
+def find_file_or_redirect():
+    """
+    If a file doesn't exist at the requested path, see if it exists at one
+    of the other paths, and redirect there if necessary
+    """
+
+    # Check the request is within this application
+    if not flask.request.path.startswith(application_root):
+        return
+
+    # Get a contextual request_path by stripping application_root
+    local_request_path = flask.request.path[len(application_root):]
+
+    template_finder = routing.TemplateFinder(app.template_folder)
+    file_path = routing.get_file(local_request_path)
+    preferred_languages = routing.requested_languages(flask.request)
+    if 'en' not in preferred_languages:
+        preferred_languages.append('en')
+    languages = template_finder.get_languages(preferred_languages)
+    versions = routing.get_versions(
+        app.config.get('VERSION_FILEPATH', 'versions')
+    )
+
+    if os.path.isfile(app.template_folder + file_path):
+        return flask.render_template(file_path)
+    else:
+        new_path = template_finder.find_alternate_path(
+            local_request_path,
+            languages,
+            versions
+        )
+
+        if new_path:
+            return flask.redirect(application_root + new_path)
+
+
+@app.route('/')
+def redirect_to_root():
+    """
+    Redirect homepage to application_root
+    """
+
+    return flask.redirect(application_root + '/')

--- a/docs/routing.py
+++ b/docs/routing.py
@@ -1,0 +1,271 @@
+# Core packages
+import os
+import re
+import yaml
+
+# External packages
+import pycountry
+import yamlordereddictloader
+
+
+# Helper functions
+# ===
+
+def is_language(code):
+    """
+    Check if a 2-letter language code is valid
+    """
+
+    try:
+        return bool(pycountry.languages.get(alpha_2=code))
+    except KeyError:
+        return False
+
+
+def requested_languages(flask_request):
+    """
+    Given a Flask request object, return a list of the preferred languages
+    """
+
+    accept_language = flask_request.headers.get('accept-language', '')
+    preferred_languages = []
+    for language in accept_language.split(','):
+        preferred_languages.append(language[:2])
+
+    return preferred_languages
+
+
+def get_versions(version_filepath):
+    """
+    Check if this repo has versions
+    """
+
+    if os.path.isfile(version_filepath):
+        with open(version_filepath) as version_file:
+            versions = list(filter(None, version_file.read().splitlines()))
+
+        if len(versions):
+            return versions
+
+
+def get_file(request_path):
+    """
+    Given a request_path, return the path where the file should be
+    """
+
+    if request_path.endswith('/'):
+        return request_path + '/index.html'
+    else:
+        return request_path + '.html'
+
+
+def is_version(version):
+    """
+    Check if a string is one of the available versions
+    """
+
+    versions = get_versions()
+
+    return versions and version in versions
+
+
+def split_path(request_path, languages, versions):
+    """
+    Given a URL path of the form:
+      (/{version})(/language)/remaining/path
+    and a list of valid versions and languages,
+    extract and return any versions and languages and the remaining URL path
+    """
+
+    # Try parsing languages and versions
+    url_parts = request_path.split('/')[1:]
+    language = None
+    version = None
+
+    for part in url_parts:
+        if languages and part in languages:
+            language = part
+            url_parts.remove(part)
+        elif versions and part in versions:
+            version = part
+            url_parts.remove(part)
+
+    return (language, version, "/" + "/".join(url_parts))
+
+
+class YamlRegexMap:
+    def __init__(self, filepath):
+        """
+        Given the path to a YAML file of RegEx mappings like:
+
+            hello/(?P<person>.*)?: "/say-hello?name={person}"
+            google/(?P<search>.*)?: "https://google.com/?q={search}"
+
+        Return a list of compiled Regex matches and destination strings:
+
+            [
+                (<regex>, "/say-hello?name={person}"),
+                (<regex>, "https://google.com/?q={search}"),
+            ]
+        """
+
+        self.matches = []
+
+        if os.path.isfile(filepath):
+            with open(filepath) as redirects_file:
+                lines = yaml.load(
+                    redirects_file,
+                    Loader=yamlordereddictloader.Loader
+                )
+
+                if lines:
+                    for url_match, target_url in lines.items():
+                        if url_match[0] != '/':
+                            url_match = '/' + url_match
+
+                        self.matches.append(
+                            (re.compile(url_match), target_url)
+                        )
+
+    def get_target(self, url_path):
+        for (match, target) in self.matches:
+            result = match.fullmatch(url_path)
+
+            if result:
+                parts = {}
+                for name, value in result.groupdict().items():
+                    parts[name] = value or ''
+                return target.format(**parts)
+
+
+class TemplateFinder:
+    """
+    Provides functions for matching URL paths to templates
+    """
+
+    def __init__(self, templates_dir):
+        """
+        Initialise the class with the path to the templates we should use
+        """
+
+        self.templates_dir = templates_dir
+
+    def get_languages(self, preferred_order=[]):
+        """
+        Find the available languages that exist as template folders
+        """
+
+        available_languages = []
+        top_folders = os.listdir(self.templates_dir)
+
+        for folder in top_folders:
+            if is_language(folder):
+                available_languages.append(folder)
+
+        weighted_languages = []
+
+        if available_languages and preferred_order:
+            for item in available_languages:
+                try:
+                    weight = preferred_order.index(item)
+                except ValueError:
+                    weight = available_languages.index(item) + len(
+                        preferred_order
+                    )
+
+                weighted_languages.append(
+                    (weight, item)
+                )
+
+            weighted_languages = sorted(weighted_languages)
+
+            available_languages = [item[1] for item in weighted_languages]
+
+        return available_languages
+
+    def try_alternate_path(self, path):
+        """
+        If the path is for a file, see if the directory exists instead.
+        If the path is for a directory, see if the file exists instead.
+        If the alternate exists, return it. Otherwise return None.
+        """
+
+        # Try the other URL form
+        if path.endswith('/'):
+            new_path = path.rstrip('/')
+            if os.path.isfile(self.templates_dir + get_file(new_path)):
+                return new_path
+        else:
+            new_path = path + '/'
+            if os.path.isfile(self.templates_dir + get_file(new_path)):
+                return new_path
+
+    def try_language_version_path(self, path, languages, versions):
+        """
+        Given a URL path that doesn't contain any language or version
+        information, and a list of possible languages and versions,
+        try adding each language and version to the URL until we find
+        an existing file, and then return the path for that file
+        """
+
+        # Build up language and version URLs
+        search_paths = []
+
+        if languages:
+            for language in languages:
+                search_paths.append("/" + language + path)
+
+        if versions:
+            new_paths = []
+            for version in versions:
+                search_paths.append("/" + version + path)
+
+                for search_path in search_paths:
+                    new_paths.append("/" + version + search_path)
+
+            search_paths += new_paths
+
+        for path in search_paths:
+            alt_path = path + '/'
+            if alt_path.endswith('//'):
+                alt_path = alt_path[:-2]
+
+            template = self.templates_dir + get_file(path)
+            alt_template = self.templates_dir + get_file(alt_path)
+
+            if os.path.isfile(template):
+                return path
+            elif os.path.isfile(alt_template):
+                return alt_path
+
+    def find_alternate_path(self, request_path, languages, versions):
+        """
+        For a request_path that doesn't match up to a file,
+        try our best to find a URL that does
+        """
+
+        alternate_path = self.try_alternate_path(request_path)
+
+        if alternate_path:
+            return alternate_path
+
+        (language, version, remaining_path) = split_path(
+            request_path, languages, versions
+        )
+
+        # If the URL contained a language or version, then
+        # we should limit the lists of possibilities
+        if language:
+            languages = [language]
+
+        if version:
+            versions = [version]
+
+        language_version_path = self.try_language_version_path(
+            remaining_path,
+            languages,
+            versions
+        )
+
+        if language_version_path:
+            return language_version_path

--- a/docs/template.html
+++ b/docs/template.html
@@ -1,0 +1,525 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    {% if tag_manager_code %}
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','{{ tag_manager_code }}');</script>
+    <!-- End Google Tag Manager -->
+    {% endif %}
+
+    <meta charset="UTF-8" />
+    <title>{{ title }} | {{ site_title if site_title else 'Documentation' }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="{{ site_favicon }}" type="image/x-icon" />
+    <style>
+      /* vanilla-docs-theme 1.6.0 */
+    .p-button,.p-button--base,.p-button--brand,.p-button--negative,.p-button--neutral,.p-button--positive,button{transition-duration:.165s;transition-property:background-color;transition-timing-function:cubic-bezier(.55,.055,.675,.19);border-radius:.125rem;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;display:inline-block;font-family:Ubuntu,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;font-size:1rem;font-smoothing:subpixel-antialiased;font-weight:300;line-height:1rem;outline:none;padding:.75rem 1.5rem;text-align:center;text-decoration:none;width:100%}@media (max-width:767px){.p-button+.p-button,.p-button+.p-button--base,.p-button+.p-button--brand,.p-button+.p-button--negative,.p-button+.p-button--neutral,.p-button+.p-button--positive,.p-button+button,.p-button--base+.p-button,.p-button--base+.p-button--base,.p-button--base+.p-button--brand,.p-button--base+.p-button--negative,.p-button--base+.p-button--neutral,.p-button--base+.p-button--positive,.p-button--base+button,.p-button--brand+.p-button,.p-button--brand+.p-button--base,.p-button--brand+.p-button--brand,.p-button--brand+.p-button--negative,.p-button--brand+.p-button--neutral,.p-button--brand+.p-button--positive,.p-button--brand+button,.p-button--negative+.p-button,.p-button--negative+.p-button--base,.p-button--negative+.p-button--brand,.p-button--negative+.p-button--negative,.p-button--negative+.p-button--neutral,.p-button--negative+.p-button--positive,.p-button--negative+button,.p-button--neutral+.p-button,.p-button--neutral+.p-button--base,.p-button--neutral+.p-button--brand,.p-button--neutral+.p-button--negative,.p-button--neutral+.p-button--neutral,.p-button--neutral+.p-button--positive,.p-button--neutral+button,.p-button--positive+.p-button,.p-button--positive+.p-button--base,.p-button--positive+.p-button--brand,.p-button--positive+.p-button--negative,.p-button--positive+.p-button--neutral,.p-button--positive+.p-button--positive,.p-button--positive+button,button+.p-button,button+.p-button--base,button+.p-button--brand,button+.p-button--negative,button+.p-button--neutral,button+.p-button--positive,button+button{margin-top:1rem}}@media (min-width:768px){.p-button+.p-button,.p-button+.p-button--base,.p-button+.p-button--brand,.p-button+.p-button--negative,.p-button+.p-button--neutral,.p-button+.p-button--positive,.p-button+button,.p-button--base+.p-button,.p-button--base+.p-button--base,.p-button--base+.p-button--brand,.p-button--base+.p-button--negative,.p-button--base+.p-button--neutral,.p-button--base+.p-button--positive,.p-button--base+button,.p-button--brand+.p-button,.p-button--brand+.p-button--base,.p-button--brand+.p-button--brand,.p-button--brand+.p-button--negative,.p-button--brand+.p-button--neutral,.p-button--brand+.p-button--positive,.p-button--brand+button,.p-button--negative+.p-button,.p-button--negative+.p-button--base,.p-button--negative+.p-button--brand,.p-button--negative+.p-button--negative,.p-button--negative+.p-button--neutral,.p-button--negative+.p-button--positive,.p-button--negative+button,.p-button--neutral+.p-button,.p-button--neutral+.p-button--base,.p-button--neutral+.p-button--brand,.p-button--neutral+.p-button--negative,.p-button--neutral+.p-button--neutral,.p-button--neutral+.p-button--positive,.p-button--neutral+button,.p-button--positive+.p-button,.p-button--positive+.p-button--base,.p-button--positive+.p-button--brand,.p-button--positive+.p-button--negative,.p-button--positive+.p-button--neutral,.p-button--positive+.p-button--positive,.p-button--positive+button,button+.p-button,button+.p-button--base,button+.p-button--brand,button+.p-button--negative,button+.p-button--neutral,button+.p-button--positive,button+button{margin-left:1rem}}@media only screen and (min-width:768px){.p-button,.p-button--base,.p-button--brand,.p-button--negative,.p-button--neutral,.p-button--positive,button{width:auto}}.p-button--base:active,.p-button--base:focus,.p-button--base:hover,.p-button--brand:active,.p-button--brand:focus,.p-button--brand:hover,.p-button--negative:active,.p-button--negative:focus,.p-button--negative:hover,.p-button--neutral:active,.p-button--neutral:focus,.p-button--neutral:hover,.p-button--positive:active,.p-button--positive:focus,.p-button--positive:hover,.p-button:active,.p-button:focus,.p-button:hover,button:active,button:focus,button:hover{text-decoration:none}.is--disabled.p-button,.is--disabled.p-button--base,.is--disabled.p-button--brand,.is--disabled.p-button--negative,.is--disabled.p-button--neutral,.is--disabled.p-button--positive,.p-button--base:disabled,.p-button--brand:disabled,.p-button--negative:disabled,.p-button--neutral:disabled,.p-button--positive:disabled,.p-button:disabled,button.is--disabled,button:disabled{cursor:not-allowed;opacity:.5}.p-breadcrumbs:after,.p-inline-images:after,.p-matrix__item:after,.p-navigation--dark:after,.p-navigation--light:after,.p-navigation:after,.u-clearfix:after{clear:both;content:"";display:block}html{font-family:sans-serif;line-height:1.15;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0}article,aside,footer,header,nav,section{display:block}h1{font-size:2em;margin:.67em 0}figcaption,figure,main{display:block}figure{margin:1em 40px}hr{box-sizing:content-box;overflow:visible}pre{font-family:monospace,monospace;font-size:1em}a{background-color:transparent;-webkit-text-decoration-skip:objects}a:active,a:hover{outline-width:0}abbr[title]{border-bottom:none;text-decoration:underline;text-decoration:underline dotted}b,strong{font-weight:inherit;font-weight:bolder}code,kbd,samp{font-family:monospace,monospace;font-size:1em}dfn{font-style:italic}mark{background-color:#ff0;color:#000}small{font-size:80%}sub,sup{font-size:75%}sub{bottom:-.25em}sup{top:-.5em}audio,video{display:inline-block}img{border-style:none}button,input,optgroup,select,textarea{font:inherit;margin:0}optgroup{font-weight:700}button,input{overflow:visible}button,select{text-transform:none}[type=reset],[type=submit],button,html [type=button]{-webkit-appearance:button}[type=button]::-moz-focus-inner,[type=reset]::-moz-focus-inner,[type=submit]::-moz-focus-inner,button::-moz-focus-inner{border-style:none;padding:0}[type=button]:-moz-focusring,[type=reset]:-moz-focusring,[type=submit]:-moz-focusring,button:-moz-focusring{outline:1px dotted ButtonText}fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}legend{box-sizing:border-box;color:inherit;display:table;max-width:100%;padding:0;white-space:normal}progress{display:inline-block;vertical-align:baseline}[type=checkbox],[type=radio]{box-sizing:border-box}[type=number]::-webkit-inner-spin-button,[type=number]::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}[type=search]::-webkit-search-cancel-button,[type=search]::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}details,menu{display:block}summary{display:list-item}canvas{display:inline-block}template{display:none}blockquote{border-left:2px solid #666}blockquote>cite{display:block}html{box-sizing:border-box}*,:after,:before{box-sizing:inherit}button{background-color:#fff;border-color:#cdcdcd;line-height:1rem}button,button:visited{color:#111}button:active,button:focus,button:hover{background-color:#f7f7f7;border-color:#cdcdcd}button.is--disabled:active,button.is--disabled:focus,button.is--disabled:hover,button:disabled:active,button:disabled:focus,button:disabled:hover{background-color:transparent;border-color:#cdcdcd}label{cursor:pointer;display:block;font-size:1rem;line-height:1.5}label.has-error{color:#c7162b}label.has-caution,label.has-warning{color:#f99b11}label.has-success{color:#0e8420}label.has-information{color:#335280}[type=color],[type=datatime-local],[type=date],[type=datetime],[type=email],[type=month],[type=number],[type=password],[type=search],[type=tel],[type=text],[type=time],[type=url],[type=week]{-webkit-appearance:textfield;-moz-appearance:textfield;appearance:textfield;background-color:#fff;border:1px solid #cdcdcd;border-radius:.125rem;box-shadow:inset 0 1px 2px rgba(0,0,0,.12);color:#111;font-family:Ubuntu,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;font-size:1rem;font-weight:300;outline:none;padding:.5rem .75rem;vertical-align:baseline;width:100%}[type=color]:active,[type=color]:focus,[type=datatime-local]:active,[type=datatime-local]:focus,[type=date]:active,[type=date]:focus,[type=datetime]:active,[type=datetime]:focus,[type=email]:active,[type=email]:focus,[type=month]:active,[type=month]:focus,[type=number]:active,[type=number]:focus,[type=password]:active,[type=password]:focus,[type=search]:active,[type=search]:focus,[type=tel]:active,[type=tel]:focus,[type=text]:active,[type=text]:focus,[type=time]:active,[type=time]:focus,[type=url]:active,[type=url]:focus,[type=week]:active,[type=week]:focus{border-color:#666;color:#111;outline:none}[type=color]::-webkit-input-placeholder,[type=datatime-local]::-webkit-input-placeholder,[type=date]::-webkit-input-placeholder,[type=datetime]::-webkit-input-placeholder,[type=email]::-webkit-input-placeholder,[type=month]::-webkit-input-placeholder,[type=number]::-webkit-input-placeholder,[type=password]::-webkit-input-placeholder,[type=search]::-webkit-input-placeholder,[type=tel]::-webkit-input-placeholder,[type=text]::-webkit-input-placeholder,[type=time]::-webkit-input-placeholder,[type=url]::-webkit-input-placeholder,[type=week]::-webkit-input-placeholder{color:#666;opacity:1}[type=color]:-ms-input-placeholder,[type=datatime-local]:-ms-input-placeholder,[type=date]:-ms-input-placeholder,[type=datetime]:-ms-input-placeholder,[type=email]:-ms-input-placeholder,[type=month]:-ms-input-placeholder,[type=number]:-ms-input-placeholder,[type=password]:-ms-input-placeholder,[type=search]:-ms-input-placeholder,[type=tel]:-ms-input-placeholder,[type=text]:-ms-input-placeholder,[type=time]:-ms-input-placeholder,[type=url]:-ms-input-placeholder,[type=week]:-ms-input-placeholder{color:#666;opacity:1}[type=color]::placeholder,[type=datatime-local]::placeholder,[type=date]::placeholder,[type=datetime]::placeholder,[type=email]::placeholder,[type=month]::placeholder,[type=number]::placeholder,[type=password]::placeholder,[type=search]::placeholder,[type=tel]::placeholder,[type=text]::placeholder,[type=time]::placeholder,[type=url]::placeholder,[type=week]::placeholder{color:#666;opacity:1}[type=color][disabled=disabled],[type=color][disabled],[type=datatime-local][disabled=disabled],[type=datatime-local][disabled],[type=date][disabled=disabled],[type=date][disabled],[type=datetime][disabled=disabled],[type=datetime][disabled],[type=email][disabled=disabled],[type=email][disabled],[type=month][disabled=disabled],[type=month][disabled],[type=number][disabled=disabled],[type=number][disabled],[type=password][disabled=disabled],[type=password][disabled],[type=search][disabled=disabled],[type=search][disabled],[type=tel][disabled=disabled],[type=tel][disabled],[type=text][disabled=disabled],[type=text][disabled],[type=time][disabled=disabled],[type=time][disabled],[type=url][disabled=disabled],[type=url][disabled],[type=week][disabled=disabled],[type=week][disabled]{cursor:not-allowed;opacity:.5}[type=color][readonly=readonly],[type=color][readonly],[type=datatime-local][readonly=readonly],[type=datatime-local][readonly],[type=date][readonly=readonly],[type=date][readonly],[type=datetime][readonly=readonly],[type=datetime][readonly],[type=email][readonly=readonly],[type=email][readonly],[type=month][readonly=readonly],[type=month][readonly],[type=number][readonly=readonly],[type=number][readonly],[type=password][readonly=readonly],[type=password][readonly],[type=search][readonly=readonly],[type=search][readonly],[type=tel][readonly=readonly],[type=tel][readonly],[type=text][readonly=readonly],[type=text][readonly],[type=time][readonly=readonly],[type=time][readonly],[type=url][readonly=readonly],[type=url][readonly],[type=week][readonly=readonly],[type=week][readonly]{color:#cdcdcd;cursor:default}[type=color][readonly=readonly]:active,[type=color][readonly=readonly]:focus,[type=color][readonly=readonly]:hover,[type=color][readonly]:active,[type=color][readonly]:focus,[type=color][readonly]:hover,[type=datatime-local][readonly=readonly]:active,[type=datatime-local][readonly=readonly]:focus,[type=datatime-local][readonly=readonly]:hover,[type=datatime-local][readonly]:active,[type=datatime-local][readonly]:focus,[type=datatime-local][readonly]:hover,[type=date][readonly=readonly]:active,[type=date][readonly=readonly]:focus,[type=date][readonly=readonly]:hover,[type=date][readonly]:active,[type=date][readonly]:focus,[type=date][readonly]:hover,[type=datetime][readonly=readonly]:active,[type=datetime][readonly=readonly]:focus,[type=datetime][readonly=readonly]:hover,[type=datetime][readonly]:active,[type=datetime][readonly]:focus,[type=datetime][readonly]:hover,[type=email][readonly=readonly]:active,[type=email][readonly=readonly]:focus,[type=email][readonly=readonly]:hover,[type=email][readonly]:active,[type=email][readonly]:focus,[type=email][readonly]:hover,[type=month][readonly=readonly]:active,[type=month][readonly=readonly]:focus,[type=month][readonly=readonly]:hover,[type=month][readonly]:active,[type=month][readonly]:focus,[type=month][readonly]:hover,[type=number][readonly=readonly]:active,[type=number][readonly=readonly]:focus,[type=number][readonly=readonly]:hover,[type=number][readonly]:active,[type=number][readonly]:focus,[type=number][readonly]:hover,[type=password][readonly=readonly]:active,[type=password][readonly=readonly]:focus,[type=password][readonly=readonly]:hover,[type=password][readonly]:active,[type=password][readonly]:focus,[type=password][readonly]:hover,[type=search][readonly=readonly]:active,[type=search][readonly=readonly]:focus,[type=search][readonly=readonly]:hover,[type=search][readonly]:active,[type=search][readonly]:focus,[type=search][readonly]:hover,[type=tel][readonly=readonly]:active,[type=tel][readonly=readonly]:focus,[type=tel][readonly=readonly]:hover,[type=tel][readonly]:active,[type=tel][readonly]:focus,[type=tel][readonly]:hover,[type=text][readonly=readonly]:active,[type=text][readonly=readonly]:focus,[type=text][readonly=readonly]:hover,[type=text][readonly]:active,[type=text][readonly]:focus,[type=text][readonly]:hover,[type=time][readonly=readonly]:active,[type=time][readonly=readonly]:focus,[type=time][readonly=readonly]:hover,[type=time][readonly]:active,[type=time][readonly]:focus,[type=time][readonly]:hover,[type=url][readonly=readonly]:active,[type=url][readonly=readonly]:focus,[type=url][readonly=readonly]:hover,[type=url][readonly]:active,[type=url][readonly]:focus,[type=url][readonly]:hover,[type=week][readonly=readonly]:active,[type=week][readonly=readonly]:focus,[type=week][readonly=readonly]:hover,[type=week][readonly]:active,[type=week][readonly]:focus,[type=week][readonly]:hover{border-color:#666;outline:none}[type=color].has-error,[type=color].has-error:focus,[type=datatime-local].has-error,[type=datatime-local].has-error:focus,[type=date].has-error,[type=date].has-error:focus,[type=datetime].has-error,[type=datetime].has-error:focus,[type=email].has-error,[type=email].has-error:focus,[type=month].has-error,[type=month].has-error:focus,[type=number].has-error,[type=number].has-error:focus,[type=password].has-error,[type=password].has-error:focus,[type=search].has-error,[type=search].has-error:focus,[type=tel].has-error,[type=tel].has-error:focus,[type=text].has-error,[type=text].has-error:focus,[type=time].has-error,[type=time].has-error:focus,[type=url].has-error,[type=url].has-error:focus,[type=week].has-error,[type=week].has-error:focus{border:1px solid #c7162b}[type=color].has-caution,[type=color].has-caution:focus,[type=color].has-warning,[type=color].has-warning:focus,[type=datatime-local].has-caution,[type=datatime-local].has-caution:focus,[type=datatime-local].has-warning,[type=datatime-local].has-warning:focus,[type=date].has-caution,[type=date].has-caution:focus,[type=date].has-warning,[type=date].has-warning:focus,[type=datetime].has-caution,[type=datetime].has-caution:focus,[type=datetime].has-warning,[type=datetime].has-warning:focus,[type=email].has-caution,[type=email].has-caution:focus,[type=email].has-warning,[type=email].has-warning:focus,[type=month].has-caution,[type=month].has-caution:focus,[type=month].has-warning,[type=month].has-warning:focus,[type=number].has-caution,[type=number].has-caution:focus,[type=number].has-warning,[type=number].has-warning:focus,[type=password].has-caution,[type=password].has-caution:focus,[type=password].has-warning,[type=password].has-warning:focus,[type=search].has-caution,[type=search].has-caution:focus,[type=search].has-warning,[type=search].has-warning:focus,[type=tel].has-caution,[type=tel].has-caution:focus,[type=tel].has-warning,[type=tel].has-warning:focus,[type=text].has-caution,[type=text].has-caution:focus,[type=text].has-warning,[type=text].has-warning:focus,[type=time].has-caution,[type=time].has-caution:focus,[type=time].has-warning,[type=time].has-warning:focus,[type=url].has-caution,[type=url].has-caution:focus,[type=url].has-warning,[type=url].has-warning:focus,[type=week].has-caution,[type=week].has-caution:focus,[type=week].has-warning,[type=week].has-warning:focus{border:1px solid #f99b11}[type=color].has-success,[type=color].has-success:focus,[type=datatime-local].has-success,[type=datatime-local].has-success:focus,[type=date].has-success,[type=date].has-success:focus,[type=datetime].has-success,[type=datetime].has-success:focus,[type=email].has-success,[type=email].has-success:focus,[type=month].has-success,[type=month].has-success:focus,[type=number].has-success,[type=number].has-success:focus,[type=password].has-success,[type=password].has-success:focus,[type=search].has-success,[type=search].has-success:focus,[type=tel].has-success,[type=tel].has-success:focus,[type=text].has-success,[type=text].has-success:focus,[type=time].has-success,[type=time].has-success:focus,[type=url].has-success,[type=url].has-success:focus,[type=week].has-success,[type=week].has-success:focus{border:1px solid #0e8420}[type=color].has-information,[type=color].has-information:focus,[type=datatime-local].has-information,[type=datatime-local].has-information:focus,[type=date].has-information,[type=date].has-information:focus,[type=datetime].has-information,[type=datetime].has-information:focus,[type=email].has-information,[type=email].has-information:focus,[type=month].has-information,[type=month].has-information:focus,[type=number].has-information,[type=number].has-information:focus,[type=password].has-information,[type=password].has-information:focus,[type=search].has-information,[type=search].has-information:focus,[type=tel].has-information,[type=tel].has-information:focus,[type=text].has-information,[type=text].has-information:focus,[type=time].has-information,[type=time].has-information:focus,[type=url].has-information,[type=url].has-information:focus,[type=week].has-information,[type=week].has-information:focus{border:1px solid #335280}[type=file]{outline:none;width:100%}[type=reset]{display:none}[type=search]{-webkit-appearance:none;-moz-appearance:none;appearance:none;border-radius:0}[type=search]::-webkit-search-results-decoration{display:none}[type=search]::-webkit-search-cancel-button{-webkit-appearance:searchfield-cancel-button;cursor:pointer}[type=checkbox],[type=radio]{float:left;height:1.5rem;margin-bottom:0;margin-right:1rem;outline:none;padding:0;vertical-align:middle;width:auto;min-height:1.5rem}[type=checkbox][disabled=disabled]+label,[type=checkbox][disabled]+label,[type=radio][disabled=disabled]+label,[type=radio][disabled]+label{cursor:not-allowed;opacity:.5}[type=checkbox]+label,[type=radio]+label{vertical-align:middle;width:100%}[type=submit]{background-color:#0e8420;color:#fff;padding:.75rem 1.5rem}[type=submit]:hover{background-color:#04280a;cursor:pointer}select{-webkit-appearance:textfield;-moz-appearance:textfield;appearance:textfield;background-color:#fff;border:1px solid #cdcdcd;border-radius:.125rem;box-shadow:inset 0 1px 2px rgba(0,0,0,.12);font-family:Ubuntu,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;font-size:1rem;font-weight:300;outline:none;padding:.5rem .75rem;vertical-align:baseline;width:100%;-webkit-appearance:none;-moz-appearance:none;appearance:none;background:#fff url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB4bWxuczpza2V0Y2g9Imh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaC9ucyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBoZWlnaHQ9IjRweCIgd2lkdGg9IjEwcHgiIHZlcnNpb249IjEuMSIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHZpZXdCb3g9IjAgMCAxMCA0Ij4gPHRpdGxlPmFjY29yZGlvbi1vcGVuPC90aXRsZT4gPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+IDxnIGlkPSJmaWx0ZXItcGFuZWwiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSIgZmlsbD0ibm9uZSI+ICA8ZyBpZD0iYWNjb3JkaW9uLW9wZW4iIGZpbGw9IiM4ODgiIHNrZXRjaDp0eXBlPSJNU0FydGJvYXJkR3JvdXAiPiAgIDxwYXRoIGlkPSJjaGV2cm9uIiBza2V0Y2g6dHlwZT0iTVNTaGFwZUdyb3VwIiBkPSJtNi4zNjEgMC44NjIzYzAuNTE4IDAuMzY1IDEuMDUyIDAuNzc4MSAxLjYwMSAxLjIzOCAwLjU0OSAwLjQ1ODUgMS4wODkgMC45NTE4IDEuNjIxIDEuNDc3MiAwLjE0MiAwLjE0MDQgMC4yODEgMC4yODIxIDAuNDE1IDAuNDIyNWgtMS41NDFjLTAuMzA0LTAuMjg4OC0wLjYyLTAuNTcwOS0wLjk0Ny0wLjg0NjMtMC4xMzc5LTAuMTE2MS0wLjI3NjgtMC4yMjk3LTAuNDE2OC0wLjM0MDgtMC4xNjM2LTAuMTI5Ny0wLjMyODYtMC4yNTU4LTAuNDk1NC0wLjM3ODMtMC4wODUyLTAuMDYyNS0wLjE3MDgtMC4xMjQxLTAuMjU2OC0wLjE4NDYtMC4zOTctMC4yODIxLTAuOTM1LTAuNjI1Ny0xLjMxNS0wLjg0NzZoLTAuMDU0Yy0wLjM4IDAuMjIxOS0wLjkxOCAwLjU2NTUtMS4zMTUgMC44NDc2LTAuMzk4IDAuMjgwNy0wLjc4OCAwLjU4MjktMS4xNjkgMC45MDM3LTAuMzI3IDAuMjc1NC0wLjY0MyAwLjU1NzUtMC45NDcgMC44NDYzaC0xLjU0MWMwLjEzNS0wLjE0MDQgMC4yNzMtMC4yODIxIDAuNDE1LTAuNDIyNSAwLjUzMi0wLjUyNTQgMS4wNzItMS4wMTg3IDEuNjIxLTEuNDc3MiAwLjU1LTAuNDU5OSAxLjA4My0wLjg3MyAxLjYwMS0xLjIzOCAwLjUxOS0wLjM2NDk3IDAuOTczLTAuNjUyNDEgMS4zNjItMC44NjIzIDAuMzkgMC4yMDk4OSAwLjg0NCAwLjQ5NzMzIDEuMzYyIDAuODYyM3oiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDQuOTk5IDIpIHJvdGF0ZSgxODApIHRyYW5zbGF0ZSgtNC45OTkgLTIpIi8+ICA8L2c+IDwvZz48L3N2Zz4=") no-repeat;background-position:top 1.3rem right 1.25rem;color:#111;line-height:1rem;margin-top:.5rem;min-height:48px;text-indent:.01px;text-overflow:""}select:active,select:focus{border-color:#666;color:#111;outline:none}select::-webkit-input-placeholder{color:#666;opacity:1}select:-ms-input-placeholder{color:#666;opacity:1}select::placeholder{color:#666;opacity:1}select[disabled=disabled],select[disabled]{cursor:not-allowed;opacity:.5}select[readonly=readonly],select[readonly]{color:#cdcdcd;cursor:default}select[readonly=readonly]:active,select[readonly=readonly]:focus,select[readonly=readonly]:hover,select[readonly]:active,select[readonly]:focus,select[readonly]:hover{border-color:#666;outline:none}select.has-error,select.has-error:focus{border:1px solid #c7162b}select.has-caution,select.has-caution:focus,select.has-warning,select.has-warning:focus{border:1px solid #f99b11}select.has-success,select.has-success:focus{border:1px solid #0e8420}select.has-information,select.has-information:focus{border:1px solid #335280}select:hover{cursor:pointer}select[multiple],select[size]{background-image:none;height:auto;padding:.35rem .8125rem}select[multiple] option,select[size] option{font-weight:300;margin:.5rem 0}textarea{-webkit-appearance:textfield;-moz-appearance:textfield;appearance:textfield;background-color:#fff;border:1px solid #cdcdcd;border-radius:.125rem;box-shadow:inset 0 1px 2px rgba(0,0,0,.12);color:#111;font-family:Ubuntu,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;font-size:1rem;font-weight:300;outline:none;padding:.5rem .75rem;vertical-align:baseline;width:100%;margin-top:.5rem;overflow:auto;vertical-align:top}textarea:active,textarea:focus{border-color:#666;color:#111;outline:none}textarea::-webkit-input-placeholder{color:#666;opacity:1}textarea:-ms-input-placeholder{color:#666;opacity:1}textarea::placeholder{color:#666;opacity:1}textarea[disabled=disabled],textarea[disabled]{cursor:not-allowed;opacity:.5}textarea[readonly=readonly],textarea[readonly]{color:#cdcdcd;cursor:default}textarea[readonly=readonly]:active,textarea[readonly=readonly]:focus,textarea[readonly=readonly]:hover,textarea[readonly]:active,textarea[readonly]:focus,textarea[readonly]:hover{border-color:#666;outline:none}textarea.has-error,textarea.has-error:focus{border:1px solid #c7162b}textarea.has-caution,textarea.has-caution:focus,textarea.has-warning,textarea.has-warning:focus{border:1px solid #f99b11}textarea.has-success,textarea.has-success:focus{border:1px solid #0e8420}textarea.has-information,textarea.has-information:focus{border:1px solid #335280}fieldset{background-color:#f7f7f7;border-radius:.125rem;color:#111;padding:.9375rem 1.25rem}fieldset+fieldset{margin-top:1.25rem}@media screen and (min-width:768px){fieldset+fieldset{margin-top:1.75rem}}@media screen and (min-width:1030px){fieldset+fieldset{margin-top:2rem}}fieldset h3{border-bottom:1px dotted #666;padding-bottom:.625rem}form+*{margin-top:.5rem}form *+input{margin-top:.75rem}form *+label{margin-top:1.25rem}form *+button,form *+button+label,form *+input[type=checkbox],form *+input[type=checkbox]+label,form *+input[type=radio],form *+input[type=radio]+label,form *+input[type=submit],form *+input[type=submit]+label{margin-top:1rem}code,kbd,samp{font-family:Ubuntu Mono,Consolas,Monaco,Courier,monospace;font-weight:300;text-align:left}code,pre{direction:ltr;-webkit-hyphens:none;-ms-hyphens:none;hyphens:none;line-height:1.5;margin-bottom:0;margin-top:0;-moz-tab-size:4;tab-size:4;white-space:pre-wrap;word-spacing:normal;word-wrap:break-word}code+code,code+pre,pre+code,pre+pre{margin-top:1.25rem}@media screen and (min-width:768px){code+code,code+pre,pre+code,pre+pre{margin-top:1.75rem}}@media screen and (min-width:1030px){code+code,code+pre,pre+code,pre+pre{margin-top:2rem}}pre{background-color:#f7f7f7;border:1px solid #666;border-radius:2px;color:#111;overflow:auto;padding:1rem;text-align:left;text-shadow:none}a{color:#007aa6;text-decoration:none}a:focus{outline:thin dotted #cdcdcd}a:hover{cursor:pointer;text-decoration:underline}a:visited{color:#005573}ol,ul{margin-left:1rem;padding-left:1rem}ol,ol ol,ol ul,ul,ul ol,ul ul{margin-bottom:0}nav ol,nav ul{list-style:none;list-style-image:none}ol li+li,ol li>ol,ol li>ul,ul li+li,ul li>ol,ul li>ul{margin-top:.5rem}li{margin:0 0 .5rem;padding:0}dl{margin-bottom:0}dt{border-top:1px dotted #666;font-size:1rem;font-weight:400;margin-top:1rem;padding-top:1rem}dt:first-of-type{border-top:0}dd{margin-left:20px;margin-top:.5rem}.p-heading--one{font-size:2rem;font-weight:300;line-height:1.2}@media only screen and (min-width:1030px){.p-heading--one{font-size:3rem;line-height:1.25}}.p-heading--two{font-size:1.75rem;font-weight:300;line-height:1.25}@media only screen and (min-width:1030px){.p-heading--two{font-size:2rem;line-height:1.25;font-size:2.25rem;line-height:1.167}}.p-heading--three{font-size:1.5rem;font-weight:300;line-height:1.154}@media only screen and (min-width:1030px){.p-heading--three{font-size:1.75rem;line-height:1.286}}.p-heading--four{font-size:1.375rem;font-weight:300;line-height:1.364}@media only screen and (min-width:1030px){.p-heading--four{font-size:1.5rem;line-height:1.25}}.p-heading--five{font-size:1.125rem;font-weight:300;line-height:1.264}@media only screen and (min-width:1030px){.p-heading--five{font-size:1.25rem;line-height:1.143}}.p-heading--six{font-size:1rem;font-weight:400;line-height:1.412}hr{border:0;border-top:1px solid #cdcdcd;height:0;margin:1rem 0}img{border:0}svg:not(:root){overflow:hidden}figure{margin-bottom:0;margin-left:0;width:100%}*+figure{margin-top:1.25rem}@media screen and (min-width:768px){*+figure{margin-top:1.75rem}}@media screen and (min-width:1030px){*+figure{margin-top:2rem}}figure caption,figure figcaption{display:block;font-style:italic;margin-top:.5rem;width:100%}audio,canvas,embed,iframe,object,video{display:block;margin:0 auto 20px;max-width:100%}audio:not([controls]){display:none;height:0}[hidden]{display:none}table{border:0;border-collapse:collapse;overflow-x:auto;width:100%}td,th{padding:1rem .75rem}td{font-weight:300;vertical-align:middle}td,thead th{text-align:left}thead th{border-collapse:separate;border-spacing:0 .5rem;font-weight:400}thead tr{border-bottom:1px solid #666}tbody tr{border-bottom:1px solid #cdcdcd}tbody th{font-weight:400;text-align:left}@font-face{font-family:Ubuntu;font-style:normal;font-weight:300;src:url(https://assets.ubuntu.com/v1/50afa266-ubuntu-l-webfont.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/0194407b-ubuntu-l-webfont.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:normal;font-weight:400;src:url(https://assets.ubuntu.com/v1/1cbafee5-ubuntu-r-webfont.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/81863185-ubuntu-r-webfont.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:italic;font-weight:300;src:url(https://assets.ubuntu.com/v1/abb07502-ubuntu-li-webfont.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/65fc9630-ubuntu-li-webfont.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:italic;font-weight:400;src:url(https://assets.ubuntu.com/v1/fca66073-ubuntu-ri-webfont.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/f0898c72-ubuntu-ri-webfont.woff) format("woff")}@font-face{font-family:Ubuntu Mono;font-style:normal;font-weight:300;src:url(https://assets.ubuntu.com/v1/871f7456-ubuntumono-r-webfont.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/8df3f408-ubuntumono-r-webfont.woff) format("woff")}@font-face{font-family:Ubuntu Mono;font-style:normal;font-weight:400;src:url(https://assets.ubuntu.com/v1/871f7456-ubuntumono-r-webfont.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/8df3f408-ubuntumono-r-webfont.woff) format("woff")}*{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;font-smoothing:subpixel-antialiased}html{font-size:16px}body{color:#111;font-weight:300;line-height:1.5}[class^=p-heading--],body,h1,h2,h3,h4,h5,h6{font-family:Ubuntu,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif}[class^=p-heading--],h1,h2,h3,h4,h5,h6{margin:0}h1+*{margin-top:1rem}@media screen and (min-width:1030px){h1+*{margin-top:1.5rem}}h5+*,h6+*{margin-top:.5rem}@media screen and (min-width:1030px){h5+*,h6+*{margin-top:.75rem}}p{margin-bottom:0}p+p{margin-top:1rem}@media screen and (min-width:1030px){p+p{margin-top:1.5rem}}button,input,select,textarea{font-family:Ubuntu,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif}h1{font-size:2rem;font-weight:300;line-height:1.2}@media only screen and (min-width:1030px){h1{font-size:3rem;line-height:1.25}}h2{font-size:1.75rem;font-weight:300;line-height:1.25}@media only screen and (min-width:1030px){h2{font-size:2rem;line-height:1.25;font-size:2.25rem;line-height:1.167}}h3{font-size:1.5rem;font-weight:300;line-height:1.154}@media only screen and (min-width:1030px){h3{font-size:1.75rem;line-height:1.286}}h4{font-size:1.375rem;font-weight:300;line-height:1.364}@media only screen and (min-width:1030px){h4{font-size:1.5rem;line-height:1.25}}h5{font-size:1.125rem;font-weight:300;line-height:1.264}@media only screen and (min-width:1030px){h5{font-size:1.25rem;line-height:1.143}}h6{font-size:1rem;font-weight:400;line-height:1.412}li{margin-bottom:0;margin-top:0;padding-bottom:0}li>ol,li>ul{padding-top:0}li>ol>li:last-of-type,li>ul>li:last-of-type{padding-bottom:0}blockquote{margin-bottom:0;margin-left:0;padding-left:1.5rem}blockquote>p{font-style:italic}blockquote>cite,blockquote>p{font-size:1rem;margin-top:.75rem}blockquote>cite{font-style:normal}strong{font-weight:400}small{font-size:.8125rem}sub,sup{font-size:.75rem;line-height:0;position:relative;vertical-align:baseline}sup{vertical-align:text-top}sub{vertical-align:text-bottom}*+*{margin-top:1.25rem}@media screen and (min-width:768px){*+*{margin-top:1.75rem}}@media screen and (min-width:1030px){*+*{margin-top:2rem}}*>p:first-child{margin-top:0}*+.p-heading--one,*+h1{margin-top:2rem}@media screen and (min-width:1030px){*+.p-heading--one,*+h1{margin-top:3.75rem}}*+.p-heading--five,*+.p-heading--four,*+.p-heading--six,*+.p-heading--three,*+.p-heading--two,*+h2,*+h3,*+h4,*+h5,*+h6{margin-top:1.5rem}@media screen and (min-width:1030px){*+.p-heading--five,*+.p-heading--four,*+.p-heading--six,*+.p-heading--three,*+.p-heading--two,*+h2,*+h3,*+h4,*+h5,*+h6{margin-top:2rem}}*+.p-heading--four+*,*+.p-heading--three+*,*+.p-heading--two+*,*+h2+*,*+h3+*,*+h4+*{margin-top:.5rem}@media screen and (min-width:1030px){*+.p-heading--four+*,*+.p-heading--three+*,*+.p-heading--two+*,*+h2+*,*+h3+*,*+h4+*{margin-top:1rem}}.row:first-of-type>:only-child:not([class^=col-]),.row:first-of-type>:only-child>:only-child:not([class^=col-]){margin-bottom:1.25rem;margin-top:0}@media screen and (min-width:768px){.row:first-of-type>:only-child:not([class^=col-]),.row:first-of-type>:only-child>:only-child:not([class^=col-]){margin-bottom:1.75rem}}@media screen and (min-width:1030px){.row:first-of-type>:only-child:not([class^=col-]),.row:first-of-type>:only-child>:only-child:not([class^=col-]){margin-bottom:2rem}}.row>:only-child:not([class^=col-]),.row>:only-child>:only-child:not([class^=col-]){margin-top:1.25rem}@media screen and (min-width:768px){.row>:only-child:not([class^=col-]),.row>:only-child>:only-child:not([class^=col-]){margin-top:1.75rem}}@media screen and (min-width:1030px){.row>:only-child:not([class^=col-]),.row>:only-child>:only-child:not([class^=col-]){margin-top:2rem}}.p-breadcrumbs{list-style:none;margin:0;padding:0;width:100%}.p-breadcrumbs__item{float:left;margin:0 0 .25rem .25rem;position:relative}.p-breadcrumbs__item:not(:first-of-type){text-indent:1rem}.p-breadcrumbs__item:not(:first-of-type):before{content:"\203A";left:-.75rem;position:absolute;top:0}.p-button{background-color:#fff;border-color:#cdcdcd}.p-button,.p-button:visited{color:#111}.p-button:active,.p-button:focus,.p-button:hover{background-color:#f7f7f7;border-color:#cdcdcd}.p-button.is--disabled:active,.p-button.is--disabled:focus,.p-button.is--disabled:hover,.p-button:disabled:active,.p-button:disabled:focus,.p-button:disabled:hover{background-color:#fff;border-color:#fff}.p-button--neutral{background-color:#fff;border-color:#cdcdcd;color:#111}.p-button--neutral:visited{color:#111}.p-button--neutral:active,.p-button--neutral:focus,.p-button--neutral:hover{background-color:#f7f7f7;border-color:#cdcdcd}.p-button--neutral.is--disabled:active,.p-button--neutral.is--disabled:focus,.p-button--neutral.is--disabled:hover,.p-button--neutral:disabled:active,.p-button--neutral:disabled:focus,.p-button--neutral:disabled:hover{background-color:transparent;border-color:#cdcdcd}.p-button--brand{background-color:#333;border-color:#333;color:#fff}.p-button--brand:visited{color:#fff}.p-button--brand:active,.p-button--brand:focus,.p-button--brand:hover{background-color:#1a1a1a;border-color:#1a1a1a}.p-button--brand.is--disabled:active,.p-button--brand.is--disabled:focus,.p-button--brand.is--disabled:hover,.p-button--brand:disabled:active,.p-button--brand:disabled:focus,.p-button--brand:disabled:hover{background-color:#333;border-color:#333}.p-button--positive{background-color:#0e8420;border-color:#0e8420;color:#fff}.p-button--positive:visited{color:#fff}.p-button--positive:active,.p-button--positive:focus,.p-button--positive:hover{background-color:#095615;border-color:#095615}.p-button--positive.is--disabled:active,.p-button--positive.is--disabled:focus,.p-button--positive.is--disabled:hover,.p-button--positive:disabled:active,.p-button--positive:disabled:focus,.p-button--positive:disabled:hover{background-color:#0e8420;border-color:#0e8420}.p-button--negative{background-color:#c7162b;border-color:#c7162b;color:#fff}.p-button--negative:visited{color:#fff}.p-button--negative:active,.p-button--negative:focus,.p-button--negative:hover{background-color:#991121;border-color:#991121}.p-button--negative.is--disabled:active,.p-button--negative.is--disabled:focus,.p-button--negative.is--disabled:hover,.p-button--negative:disabled:active,.p-button--negative:disabled:focus,.p-button--negative:disabled:hover{background-color:#c7162b;border-color:#c7162b}.p-button--base{background-color:transparent;border-color:transparent;color:#111}.p-button--base:visited{color:#111}.p-button--base:active,.p-button--base:focus,.p-button--base:hover{background-color:#f7f7f7;border-color:transparent}.p-button--base.is--disabled:active,.p-button--base.is--disabled:focus,.p-button--base.is--disabled:hover,.p-button--base:disabled:active,.p-button--base:disabled:focus,.p-button--base:disabled:hover{background-color:transparent;border-color:#cdcdcd}@media (max-width:768px){[class^=p-button].is-inline{margin-top:1.2rem}}@media (min-width:768px){[class^=p-button].is-inline{margin-left:.75rem;width:auto}}.p-card{background:#fff;border-radius:2px;color:#111;padding:1.25rem;border:1px solid #cdcdcd}.p-card__title{margin:0 0 .5rem}.p-card__content{margin-bottom:1rem;margin-top:0}.p-card__footer{border-top:1px solid #cdcdcd;margin-top:0;padding-top:1rem}.p-card__header{border-bottom:1px solid #cdcdcd;font-size:.75rem;margin-bottom:.75rem;padding-bottom:.75rem}.p-card__header>img{max-height:2rem}.p-card .p-card{margin-top:0}.p-card--highlighted{background:#fff;border-radius:2px;color:#111;padding:1.25rem;box-shadow:0 1px 5px 1px hsla(0,0%,7%,.2)}.p-card--highlighted__title{margin:0 0 .5rem}.p-card--highlighted__content{margin-bottom:1rem;margin-top:0}.p-card--highlighted__footer{border-top:1px solid #cdcdcd;margin-top:0;padding-top:1rem}.p-card--highlighted__header{border-bottom:1px solid #cdcdcd;font-size:.75rem;margin-bottom:.75rem;padding-bottom:.75rem}.p-card--highlighted__header>img{max-height:2rem}.p-code-numbered{background:#fff;color:#111;counter-reset:a;padding:1rem 0 0;position:relative}.p-code-numbered:before{background-color:#fff;width:4.5rem}.p-code-numbered .code-line{background:#f7f7f7;color:#111;display:block;margin:-1.5rem 0 0;padding:.5rem 1rem 0 5.5rem;position:relative}.p-code-numbered .code-line:first-child,.p-code-numbered .code-line:first-child:before{padding-top:1.25rem}.p-code-numbered .code-line:last-child,.p-code-numbered .code-line:last-child:before{padding-bottom:1rem}.p-code-numbered .code-line:before{background:#fff;border-right:1px solid #111;color:#666;content:counter(a);counter-increment:a;display:inline-block;height:9999px;left:0;margin-right:1rem;max-height:100%;padding:.5rem 1rem 1rem;pointer-events:none;position:absolute;text-align:right;top:0;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;width:4.5rem}.p-code-snippet{background-color:#fff;border:1px solid #666;border-radius:2px;color:#111;display:-ms-flexbox;display:flex;overflow:hidden;position:relative;transition:border .2s,background-color .2s;width:100%}.p-code-snippet__input{background-color:transparent;background-image:url('data:image/svg+xml;utf8, <svg xmlns="http://www.w3.org/2000/svg" width="16" height="15.999999" viewBox="0 0 16 15.999999"><g><g style="display:inline"><g style="display:inline"><path style="opacity:0.21171169;fill:none;stroke:none" d="M-.0000032.00002047h15.9999936v15.9999936H-.0000032z"/><path style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#808080;fill-opacity:1;stroke:none" d="M2.6660124 2.00000047c-1.77777926 0-2.6660156.0013069-2.6660156 2.0683594v8.8652346c0 2.067046.88823634 2.066406 2.6660156 2.066406h10.6679684c1.77778 0 2.666016.00064 2.666016-2.066406v-8.7988284c0-2.1333325-.888236-2.1347656-2.666016-2.1347656H2.6660124zm1.2792969 1.890625h1.1015625v1.1425781c.3388576.0282222.6418942.0778287.9101562.1484375.2682622.0635378.4794546.127873.6347657.1914063l-.2636719 1.046875c-.2047288-.0776578-.4480911-.1520607-.7304688-.2226563-.2753242-.0705955-.5930895-.1054687-.953125-.1054687-.381213 0-.6687661.0716995-.859375.2128906-.1906042.1341333-.2851562.3205247-.2851562.5605469 0 .141191.0275088.2605439.0839844.359375.0564755.0917777.1429083.1762529.2558594.2539062.1129509.0705956.2497361.1422952.4121093.2128906.1623688.0635334.3460569.1305764.5507813.2011719.2894399.1129555.560311.232304.8144531.359375.2612043.1200089.4871256.2661159.6777344.4355469.1906043.1623688.3394192.3561248.4453125.5820312.112951.2259022.1699219.4940697.1699218.8046878 0 .465928-.1441538.868173-.4335937 1.207031s-.7660922.557414-1.4296875.65625v1.324219H3.9453093v-1.292969c-.5082842-.035289-.9225545-.102332-1.2402344-.201172-.3106176-.105893-.5419546-.200441-.6972656-.285156l.359375-1.00586c.2259066.112956.4967733.214868.8144531.306641.3247377.091773.6921094.138672 1.1015625.138672.4871065 0 .8223128-.0717 1.0058594-.212891.1906088-.148248.2871094-.342004.2871094-.582031 0-.1623686-.0395298-.3038192-.1171875-.423828-.0776533-.1200133-.186934-.2265861-.328125-.3183594-.1411911-.0917733-.3101459-.1762485-.5078125-.2539062-.1906044-.0776533-.4037544-.157472-.6367188-.2421875-.2188488-.0776533-.4374056-.1667895-.65625-.265625-.2117866-.0988311-.4055469-.218184-.5820312-.359375-.1694311-.1482489-.3062161-.3245681-.4121094-.5292969-.1058933-.2047244-.1601563-.455451-.1601563-.7519531e-7-.4871065.146107-.9013768.4355469-1.2402344.2894444-.3459154.7339269-.5671801 1.3339844-.6660156v-1.1855469zm4.0546875 8.095703h3.990234v.996094h-3.990234v-.996094z"/></g></g></g></svg>');background-position:8px;background-repeat:no-repeat;border:0;box-shadow:inset 0 1px 2px 0 rgba(0,0,0,.12);color:#666;font-family:Ubuntu Mono,Consolas,Monaco,Courier,monospace;font-size:1em;font-weight:300;padding:8px 8px 8px 32px;width:100%}.p-code-snippet__action{background-color:#f7f7f7;background-image:url('data:image/svg+xml;utf8, <svg width="80" height="87" viewBox="0 0 80 87" xmlns="http://www.w3.org/2000/svg"><g fill="#666" fill-rule="evenodd"><path d="M52.934 9H69.23c2.36 0 4.23.265 5.805 1 1.574.733 2.834 2.06 3.58 3.738 1.49 3.355 1.33 7.46 1.383 13.067l.002.01v42.37l-.002.013c-.052 5.608.107 9.71-1.384 13.066-.745 1.678-2.005 3.003-3.58 3.737-1.574.735-3.444 1-5.804 1H20.768c-2.36 0-4.228-.265-5.803-1-1.574-.733-2.835-2.058-3.58-3.736-1.232-2.77-1.338-6.05-1.367-10.264h4.016c.082 4.27.29 7.142.89 8.535.36.828.757 1.3 1.678 1.74.92.44 2.385.725 4.484.725h47.828c2.1 0 3.563-.285 4.484-.726.92-.44 1.318-.91 1.677-1.74.717-1.656.873-5.403.925-11.11V26.548c-.052-5.69-.21-9.428-.925-11.082-.36-.828-.756-1.3-1.677-1.742-.92-.44-2.385-.723-4.484-.723H51.226c.908-1.126 1.518-2.5 1.708-4zm-15.87 0c.19 1.5.8 2.874 1.707 4H21.087c-2.1 0-3.563.283-4.484.723-.92.44-1.318.914-1.677 1.743-.715 1.653-.873 5.392-.925 11.08V54h-4V26.806c.052-5.61-.107-9.713 1.384-13.068.746-1.678 2.007-3.005 3.58-3.74C16.54 9.266 18.41 9 20.77 9h16.295z"/><path d="M56.99 9v12.005H33V9h8c0 2.234 1.764 4.002 3.995 4.002 2.232 0 4-1.768 4-4.002h7.996z" fill-rule="nonzero"/><path d="M52.998 7.998c0 4.395-3.606 8-8 8-4.393 0-7.998-3.605-7.998-8S40.605 0 45 0c4.392 0 7.998 3.603 7.998 7.998zm-4 0C49 5.766 47.233 4 45 4c-2.233 0-4 1.766-4 3.998s1.767 4 4 4c2.234 0 4-1.768 4-4z" fill-rule="nonzero"/><path d="M42 36h28v4H42zM42 48h28v4H42zM50 60h20v4H50z"/><path d="M22 50s10.67 5.13 20 12.524h-.002-.01-.003C32.145 70.152 22 75 22 75V50z" fill-rule="nonzero"/><path d="M0 58h22v10H0z"/></g></svg>');background-position:50%;background-repeat:no-repeat;background-size:1rem;border-radius:0;display:block;-ms-flex:1;flex:1;height:100%;padding:0;position:absolute;right:0;text-indent:-9999px;top:0;width:40px}.p-code-snippet__action,.p-code-snippet__action:hover{border-color:transparent;border-left:1px solid #666}.p-footer{font-size:.875rem;line-height:1.5;padding-bottom:1rem;padding-top:1rem}@media (min-width:768px){.p-footer{padding-bottom:1.5rem;padding-top:1.5rem}}.p-footer__copy{margin-bottom:0}.p-footer__links{margin:0;padding:.75rem 0 0}@media (min-width:768px){.p-footer__links{margin-top:0;padding-top:1rem}}.p-footer__nav{margin-top:0}.p-footer__item{display:block;margin-bottom:.25rem}@media (min-width:768px){.p-footer__item{display:inline-block}}.p-footer__item:last-child a:after{opacity:0}.p-footer__link{border-bottom:0;color:#111}.p-footer__link:visited{color:#000}.p-footer__link:hover{color:#007aa6}@media (min-width:768px){.p-footer__link{margin-right:1rem;position:relative}.p-footer__link:after{content:"\00b7";display:inline-block;font-size:1.5rem;position:absolute;right:-.75rem;top:-.65rem}}.p-footer__link:hover:after{color:#111}@media screen and (max-width:400px){@-ms-viewport{width:320px}}img{max-width:100%;height:auto}@media \0screen{img{width:auto}}.row{*zoom:1;margin-right:auto;margin-left:auto;max-width:1030px;padding-left:20px;padding-right:20px}.row:after,.row:before{display:table;content:" "}.row:after{clear:both}.row .row{margin-right:0;margin-left:0;max-width:none;padding-right:0;padding-left:0}.mobile-col-1,.mobile-col-2,.mobile-col-3{display:block;float:left;min-height:1px;position:relative;*margin-right:-1px;margin-left:4.61165%}.first-mobile-col,.row .mobile-col-1:first-child,.row .mobile-col-2:first-child,.row .mobile-col-3:first-child{margin-left:0}.mobile-col-1{width:21.54126%}.mobile-col-2{width:47.69417%}.mobile-col-3{width:73.84709%}@media screen and (min-width:620px){.tablet-col-1,.tablet-col-2,.tablet-col-3,.tablet-col-4,.tablet-col-5{display:block;float:left;min-height:1px;position:relative;*margin-right:-1px;margin-left:2.91262%}.first-tablet-col,.row .tablet-col-1:first-child,.row .tablet-col-2:first-child,.row .tablet-col-3:first-child,.row .tablet-col-4:first-child,.row .tablet-col-5:first-child{margin-left:0}.tablet-col-1{width:14.23948%}.tablet-col-2{width:31.39159%}.tablet-col-3{width:48.54369%}.tablet-col-4{width:65.69579%}.tablet-col-5{width:82.8479%}}@media screen and (min-width:768px){.col-1,.col-2,.col-3,.col-4,.col-5,.col-6,.col-7,.col-8,.col-9,.col-10,.col-11{display:block;float:left;min-height:1px;position:relative;*margin-right:-1px;margin-left:1.94175%}.first-col,.row .col-1:first-child,.row .col-2:first-child,.row .col-3:first-child,.row .col-4:first-child,.row .col-5:first-child,.row .col-6:first-child,.row .col-7:first-child,.row .col-8:first-child,.row .col-9:first-child,.row .col-10:first-child,.row .col-11:first-child{margin-left:0}.col-1{width:6.5534%}.col-2{width:15.04854%}.col-3{width:23.54369%}.col-4{width:32.03883%}.col-5{width:40.53398%}.col-6{width:49.02913%}.col-7{width:57.52427%}.col-8{width:66.01942%}.col-9{width:74.51456%}.col-10{width:83.00971%}.col-11{width:91.50485%}.prefix-1{padding-left:8.49515%}.prefix-2{padding-left:16.99029%}.prefix-3{padding-left:25.48544%}.prefix-4{padding-left:33.98058%}.prefix-5{padding-left:42.47573%}.prefix-6{padding-left:50.97087%}.prefix-7{padding-left:59.46602%}.prefix-8{padding-left:67.96117%}.prefix-9{padding-left:76.45631%}.prefix-10{padding-left:84.95146%}.prefix-11{padding-left:93.4466%}.suffix-1{padding-right:8.49515%}.suffix-2{padding-right:16.99029%}.suffix-3{padding-right:25.48544%}.suffix-4{padding-right:33.98058%}.suffix-5{padding-right:42.47573%}.suffix-6{padding-right:50.97087%}.suffix-7{padding-right:59.46602%}.suffix-8{padding-right:67.96117%}.suffix-9{padding-right:76.45631%}.suffix-10{padding-right:84.95146%}.suffix-11{padding-right:93.4466%}.push-1{left:8.49515%}.push-2{left:16.99029%}.push-3{left:25.48544%}.push-4{left:33.98058%}.push-5{left:42.47573%}.push-6{left:50.97087%}.push-7{left:59.46602%}.push-8{left:67.96117%}.push-9{left:76.45631%}.push-10{left:84.95146%}.push-11{left:93.4466%}.pull-1{right:8.49515%}.pull-2{right:16.99029%}.pull-3{right:25.48544%}.pull-4{right:33.98058%}.pull-5{right:42.47573%}.pull-6{right:50.97087%}.pull-7{right:59.46602%}.pull-8{right:67.96117%}.pull-9{right:76.45631%}.pull-10{right:84.95146%}.pull-11{right:93.4466%}.col-11 .col-1,.col-11 .col-2,.col-11 .col-3,.col-11 .col-4,.col-11 .col-5,.col-11 .col-6,.col-11 .col-7,.col-11 .col-8,.col-11 .col-9,.col-11 .col-10{margin-left:2.12202%}.col-11 .col-1{width:7.1618%}.col-11 .col-2{width:16.44562%}.col-11 .col-3{width:25.72944%}.col-11 .col-4{width:35.01326%}.col-11 .col-5{width:44.29708%}.col-11 .col-6{width:53.5809%}.col-11 .col-7{width:62.86472%}.col-11 .col-8{width:72.14854%}.col-11 .col-9{width:81.43236%}.col-11 .col-10{width:90.71618%}.col-10 .col-1,.col-10 .col-2,.col-10 .col-3,.col-10 .col-4,.col-10 .col-5,.col-10 .col-6,.col-10 .col-7,.col-10 .col-8,.col-10 .col-9{margin-left:2.33918%}.col-10 .col-1{width:7.89474%}.col-10 .col-2{width:18.12865%}.col-10 .col-3{width:28.36257%}.col-10 .col-4{width:38.59649%}.col-10 .col-5{width:48.83041%}.col-10 .col-6{width:59.06433%}.col-10 .col-7{width:69.29825%}.col-10 .col-8{width:79.53216%}.col-10 .col-9{width:89.76608%}.col-9 .col-1,.col-9 .col-2,.col-9 .col-3,.col-9 .col-4,.col-9 .col-5,.col-9 .col-6,.col-9 .col-7,.col-9 .col-8{margin-left:2.60586%}.col-9 .col-1{width:8.79479%}.col-9 .col-2{width:20.19544%}.col-9 .col-3{width:31.59609%}.col-9 .col-4{width:42.99674%}.col-9 .col-5{width:54.39739%}.col-9 .col-6{width:65.79805%}.col-9 .col-7{width:77.1987%}.col-9 .col-8{width:88.59935%}.col-8 .col-1,.col-8 .col-2,.col-8 .col-3,.col-8 .col-4,.col-8 .col-5,.col-8 .col-6,.col-8 .col-7{margin-left:2.94118%}.col-8 .col-1{width:9.92647%}.col-8 .col-2{width:22.79412%}.col-8 .col-3{width:35.66176%}.col-8 .col-4{width:48.52941%}.col-8 .col-5{width:61.39706%}.col-8 .col-6{width:74.26471%}.col-8 .col-7{width:87.13235%}.col-7 .col-1,.col-7 .col-2,.col-7 .col-3,.col-7 .col-4,.col-7 .col-5,.col-7 .col-6{margin-left:3.37553%}.col-7 .col-1{width:11.39241%}.col-7 .col-2{width:26.16034%}.col-7 .col-3{width:40.92827%}.col-7 .col-4{width:55.6962%}.col-7 .col-5{width:70.46414%}.col-7 .col-6{width:85.23207%}.col-6 .col-1,.col-6 .col-2,.col-6 .col-3,.col-6 .col-4,.col-6 .col-5{margin-left:3.9604%}.col-6 .col-1{width:13.36634%}.col-6 .col-2{width:30.69307%}.col-6 .col-3{width:48.0198%}.col-6 .col-4{width:65.34653%}.col-6 .col-5{width:82.67327%}.col-5 .col-1,.col-5 .col-2,.col-5 .col-3,.col-5 .col-4{margin-left:4.79042%}.col-5 .col-1{width:16.16766%}.col-5 .col-2{width:37.12575%}.col-5 .col-3{width:58.08383%}.col-5 .col-4{width:79.04192%}.col-4 .col-1,.col-4 .col-2,.col-4 .col-3{margin-left:6.06061%}.col-4 .col-1{width:20.45455%}.col-4 .col-2{width:46.9697%}.col-4 .col-3{width:73.48485%}.col-3 .col-1,.col-3 .col-2{margin-left:8.24742%}.col-3 .col-1{width:27.83505%}.col-3 .col-2{width:63.91753%}.col-2 .col-1{margin-left:12.90323%;width:43.54839%}}.row .center-col{float:none;margin-left:auto!important;margin-right:auto}@media screen and (max-width:619px){.hidden-mobile,.visible-desktop,.visible-tablet{display:none!important}}@media screen and (min-width:620px) and (max-width:767px){.hidden-tablet,.visible-desktop,.visible-mobile{display:none!important}}@media screen and (min-width:768px){.hidden-desktop,.visible-mobile,.visible-tablet{display:none!important}}.row,[class*=col-]{margin-top:0}@media screen and (max-width:767px){[class*=col-]+[class*=col-]{margin-top:20px}}[grid-demo] [class*=col-]{background:#cdcdcd;margin-bottom:1rem}[grid-outline] [class*=col-]{outline:1px solid #fff;padding:.25rem}.p-matrix{list-style:none;margin:0;padding:0}@media (min-width:620px){.p-matrix{display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap}}.p-matrix__item{border-top:1px dotted #666;display:-ms-flexbox;display:flex;-ms-flex-direction:row;flex-direction:row;margin-top:0;padding:1rem 0}.p-matrix__item:empty{display:none}.p-matrix__item:first-child{border-top:0}@media (min-width:620px){.p-matrix__item{border-right:1px dotted #666;border-top:1px dotted #666;margin-bottom:0;padding:1rem;width:33.333%}.p-matrix__item:empty{display:block}.p-matrix__item:first-child,.p-matrix__item:nth-child(3n+1){padding-left:0}.p-matrix__item:last-child,.p-matrix__item:nth-child(3n){padding-right:0}.p-matrix__item:nth-child(-n+3){border-top:0}.p-matrix__item:nth-child(2n){border-right:1px dotted #666;padding-right:1rem}.p-matrix__item:nth-child(3n){border-right:0;padding-right:0}}.p-matrix__content,.p-matrix__img{-ms-flex-item-align:start;align-self:flex-start;margin-top:0}.p-matrix__img{margin-right:1rem;max-width:3.75rem}.p-matrix__content{display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column;-ms-flex-pack:center;justify-content:center}.p-matrix__title{margin-bottom:.5rem;margin-top:0}.p-matrix__desc{margin-top:0}.p-matrix__link{border-top:0}.p-navigation--light{background-color:#f7f7f7;color:#111;margin-top:0;position:relative;width:100%;border-bottom:1px solid #cdcdcd}.p-navigation--light .row{padding:0}@media (max-width:768px){.p-navigation--light .p-navigation__banner{overflow:hidden;position:relative}}.p-navigation--light .p-navigation__link,.p-navigation--light .p-navigation__toggle--close,.p-navigation--light .p-navigation__toggle--open{color:#111}.p-navigation--light .p-navigation__link:hover,.p-navigation--light .p-navigation__toggle--close:hover,.p-navigation--light .p-navigation__toggle--open:hover{border-bottom:0;text-decoration:underline}.p-navigation--light .p-navigation__link:visited,.p-navigation--light .p-navigation__toggle--close:visited,.p-navigation--light .p-navigation__toggle--open:visited{color:#111}.p-navigation--light .p-navigation__toggle--close{display:none}.p-navigation--light .p-navigation__toggle--close,.p-navigation--light .p-navigation__toggle--open{margin:0;position:absolute;right:1rem;top:calc(50% - .75rem)}@media (min-width:769px){.p-navigation--light .p-navigation__toggle--close,.p-navigation--light .p-navigation__toggle--open{display:none}}.p-navigation--light .p-navigation__logo{font-size:1.375rem;font-weight:300;line-height:1.364;-ms-flex-align:center;align-items:center;display:-ms-flexbox;display:flex;float:left;margin:.75rem .5rem}@media only screen and (min-width:1030px){.p-navigation--light .p-navigation__logo{font-size:1.5rem;line-height:1.25}}@media (min-width:769px){.p-navigation--light .p-navigation__logo{margin:.5rem 1.25rem}}.p-navigation--light .p-navigation__link{border-bottom:0;display:block;margin-top:0}@media (min-width:769px){.p-navigation--light .p-navigation__link{display:block;float:left;width:auto}}.p-navigation--light .p-navigation__link,.p-navigation--light .p-navigation__link>a{border-bottom:0;display:block}.p-navigation--light .p-navigation__link:hover,.p-navigation--light .p-navigation__link>a:hover{text-decoration:none}.p-navigation--light .p-navigation__link:last-child{margin-bottom:0}.p-navigation--light .p-navigation__links{background-color:#cdcdcd;clear:both;margin:0;padding:0}@media (min-width:769px){.p-navigation--light .p-navigation__links{background-color:transparent;clear:none;float:left}}.p-navigation--light .p-navigation__links .p-navigation__link{border-left:1px solid #cdcdcd}@media (max-width:768px){.p-navigation--light .p-navigation__links .p-navigation__link{background-color:#f7f7f7;border-left:0;border-top:1px solid #cdcdcd;color:#111;text-align:left}.p-navigation--light .p-navigation__links .p-navigation__link:last-child{border-bottom:1px solid #cdcdcd}}.p-navigation--light .p-navigation__links .p-navigation__link>a,.p-navigation--light .p-navigation__links>a{color:#111;font-size:.875rem;padding:.84375rem .5rem}@media (min-width:769px){.p-navigation--light .p-navigation__links .p-navigation__link>a,.p-navigation--light .p-navigation__links>a{color:#111;padding-left:1.25rem;padding-right:1.25rem}}.p-navigation--light .p-navigation__links:last-of-type{border-right:1px solid #cdcdcd}@media (max-width:768px){.p-navigation--light .p-navigation__links:last-of-type{border-bottom:0;border-right:0}}.p-navigation--light .p-navigation__nav{display:none;margin-top:0}@media (min-width:769px){.p-navigation--light .p-navigation__nav{display:block}}.p-navigation--light:target .p-navigation__toggle--open{display:none}@media (max-width:768px){.p-navigation--light:target .p-navigation__toggle--close{display:inline-block}}.p-navigation--light:target .p-navigation__nav{display:block}.p-navigation--light:target .p-navigation__nav .p-navigation__link:last-child{border-bottom:0}.p-navigation,.p-navigation--dark{background-color:#111;color:#fff;margin-top:0;position:relative;width:100%}.p-navigation--dark .row,.p-navigation .row{padding:0}@media (max-width:768px){.p-navigation--dark .p-navigation__banner,.p-navigation .p-navigation__banner{overflow:hidden;position:relative}}.p-navigation--dark .p-navigation__link,.p-navigation--dark .p-navigation__toggle--close,.p-navigation--dark .p-navigation__toggle--open,.p-navigation .p-navigation__link,.p-navigation .p-navigation__toggle--close,.p-navigation .p-navigation__toggle--open{color:#fff}.p-navigation--dark .p-navigation__link:hover,.p-navigation--dark .p-navigation__toggle--close:hover,.p-navigation--dark .p-navigation__toggle--open:hover,.p-navigation .p-navigation__link:hover,.p-navigation .p-navigation__toggle--close:hover,.p-navigation .p-navigation__toggle--open:hover{border-bottom:0;text-decoration:underline}.p-navigation--dark .p-navigation__link:visited,.p-navigation--dark .p-navigation__toggle--close:visited,.p-navigation--dark .p-navigation__toggle--open:visited,.p-navigation .p-navigation__link:visited,.p-navigation .p-navigation__toggle--close:visited,.p-navigation .p-navigation__toggle--open:visited{color:#fff}.p-navigation--dark .p-navigation__toggle--close,.p-navigation .p-navigation__toggle--close{display:none}.p-navigation--dark .p-navigation__toggle--close,.p-navigation--dark .p-navigation__toggle--open,.p-navigation .p-navigation__toggle--close,.p-navigation .p-navigation__toggle--open{margin:0;position:absolute;right:1rem;top:calc(50% - .75rem)}@media (min-width:769px){.p-navigation--dark .p-navigation__toggle--close,.p-navigation--dark .p-navigation__toggle--open,.p-navigation .p-navigation__toggle--close,.p-navigation .p-navigation__toggle--open{display:none}}.p-navigation--dark .p-navigation__logo,.p-navigation .p-navigation__logo{font-size:1.375rem;font-weight:300;line-height:1.364;-ms-flex-align:center;align-items:center;display:-ms-flexbox;display:flex;float:left;margin:.75rem .5rem}@media only screen and (min-width:1030px){.p-navigation--dark .p-navigation__logo,.p-navigation .p-navigation__logo{font-size:1.5rem;line-height:1.25}}@media (min-width:769px){.p-navigation--dark .p-navigation__logo,.p-navigation .p-navigation__logo{margin:.5rem 1.25rem}}.p-navigation--dark .p-navigation__link,.p-navigation .p-navigation__link{border-bottom:0;display:block;margin-top:0}@media (min-width:769px){.p-navigation--dark .p-navigation__link,.p-navigation .p-navigation__link{display:block;float:left;width:auto}}.p-navigation--dark .p-navigation__link,.p-navigation--dark .p-navigation__link>a,.p-navigation .p-navigation__link,.p-navigation .p-navigation__link>a{border-bottom:0;display:block}.p-navigation--dark .p-navigation__link:hover,.p-navigation--dark .p-navigation__link>a:hover,.p-navigation .p-navigation__link:hover,.p-navigation .p-navigation__link>a:hover{text-decoration:none}.p-navigation--dark .p-navigation__link:last-child,.p-navigation .p-navigation__link:last-child{margin-bottom:0}.p-navigation--dark .p-navigation__links,.p-navigation .p-navigation__links{background-color:#cdcdcd;clear:both;margin:0;padding:0}@media (min-width:769px){.p-navigation--dark .p-navigation__links,.p-navigation .p-navigation__links{background-color:transparent;clear:none;float:left}}.p-navigation--dark .p-navigation__links .p-navigation__link,.p-navigation .p-navigation__links .p-navigation__link{border-left:1px solid #cdcdcd}@media (max-width:768px){.p-navigation--dark .p-navigation__links .p-navigation__link,.p-navigation .p-navigation__links .p-navigation__link{background-color:#f7f7f7;border-left:0;border-top:1px solid #cdcdcd;color:#111;text-align:left}.p-navigation--dark .p-navigation__links .p-navigation__link:last-child,.p-navigation .p-navigation__links .p-navigation__link:last-child{border-bottom:1px solid #cdcdcd}}.p-navigation--dark .p-navigation__links .p-navigation__link>a,.p-navigation--dark .p-navigation__links>a,.p-navigation .p-navigation__links .p-navigation__link>a,.p-navigation .p-navigation__links>a{color:#111;font-size:.875rem;padding:.84375rem .5rem}@media (min-width:769px){.p-navigation--dark .p-navigation__links .p-navigation__link>a,.p-navigation--dark .p-navigation__links>a,.p-navigation .p-navigation__links .p-navigation__link>a,.p-navigation .p-navigation__links>a{color:#fff;padding-left:1.25rem;padding-right:1.25rem}}.p-navigation--dark .p-navigation__links:last-of-type,.p-navigation .p-navigation__links:last-of-type{border-right:1px solid #cdcdcd}@media (max-width:768px){.p-navigation--dark .p-navigation__links:last-of-type,.p-navigation .p-navigation__links:last-of-type{border-bottom:0;border-right:0}}.p-navigation--dark .p-navigation__nav,.p-navigation .p-navigation__nav{display:none;margin-top:0}@media (min-width:769px){.p-navigation--dark .p-navigation__nav,.p-navigation .p-navigation__nav{display:block}}.p-navigation--dark:target .p-navigation__toggle--open,.p-navigation:target .p-navigation__toggle--open{display:none}@media (max-width:768px){.p-navigation--dark:target .p-navigation__toggle--close,.p-navigation:target .p-navigation__toggle--close{display:inline-block}}.p-navigation--dark:target .p-navigation__nav,.p-navigation:target .p-navigation__nav{display:block}.p-link--external:after{background-color:currentColor;content:"";display:inline-block;height:.7rem;margin:0 0 0 .25rem;-webkit-mask:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E") no-repeat 50% 50%;mask:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E") no-repeat 50% 50%;-webkit-mask-size:cover;mask-size:cover;vertical-align:top;width:.7rem}.p-link--no-underline{border:0}.p-link--soft{color:#111}.p-link--soft:visited{color:#111;text-decoration:none}.p-link--soft:hover{color:#007aa6}.p-link--soft.is-selected{font-weight:400}.p-link--strong{color:#111;font-weight:400}.p-link--strong:visited{color:#111}.p-link--strong:hover{color:#007aa6;text-decoration:underline}.p-link--inverted{color:#f7f7f7;font-weight:400}.p-link--inverted:hover{color:#f7f7f7}.p-link--inverted:visited{color:#dedede}.p-top{border-bottom:1px dotted #cdcdcd;clear:both;margin:20px 0}.p-top__link{background:#fff;color:#111;float:right;margin-right:5px;padding:0 5px;position:relative;text-decoration:none;top:-.725rem}.p-link--external.p-link--strong{color:#111}.p-list{list-style:none;margin-left:0;padding-left:0}.p-list__item{margin-top:.6667rem}.p-list--divided{list-style:none;margin-left:0;padding-left:0}.p-list--divided .p-list__item{margin-top:0;padding-bottom:.63rem;padding-top:.63rem;border-bottom:1px dotted #cdcdcd}.p-list--divided .p-list__item .last-item,.p-list--divided .p-list__item:last-of-type{border-bottom:0}.is-ticked{background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Ccircle fill='%23666' cx='7' cy='7' r='7'/%3E%3Cpath fill='%23fff' d='M6.1 10.813L2.41 8.105l1.184-1.613L5.9 8.187l4.393-4.394 1.414 1.414z'/%3E%3C/svg%3E");background-position:0 .3rem;background-repeat:no-repeat;padding-left:25px}.p-list--divided .is-ticked{background-position:0 1rem}.p-inline-list{margin-left:0;padding-left:0}.p-inline-list__item{display:inline;list-style:none;margin-right:1.25rem}.p-inline-list__item .last-item,.p-inline-list__item:last-of-type{margin-right:0}.p-inline-list--middot{margin-left:0;padding-left:0}.p-inline-list--middot .p-inline-list__item{display:inline;list-style:none;margin-right:1.25rem;position:relative}.p-inline-list--middot .p-inline-list__item .last-item,.p-inline-list--middot .p-inline-list__item:last-of-type{margin-right:0}.p-inline-list--middot .p-inline-list__item:after{color:#666;content:"\00b7";font-size:1.4rem;line-height:0;position:absolute;right:-1rem;top:.55rem}.p-inline-list--middot .p-inline-list__item:hover:after{color:#666}.p-inline-list--middot .p-inline-list__item .last-item:after,.p-inline-list--middot .p-inline-list__item:last-of-type:after{content:""}.p-list-step{list-style:none;margin-left:60px;padding:0}.p-list-step__title{margin-top:0;position:relative}.p-list-step__title+*{margin-top:0}.p-list-step__item{clear:both;margin-left:0;margin-top:1.5rem;width:100%}.p-list-step__item:first-child{margin-top:.75rem}@media only screen and (min-width:1030px){.p-list-step__item:first-child{margin-top:0}}.p-list-step__bullet{background-color:#666;border-radius:50%;color:#fff;display:inline-block;font-size:1.5rem;height:50px;line-height:50px;margin-bottom:.625rem;margin-left:-60px;margin-right:.34375rem;text-align:center;width:50px}@media only screen and (max-width:1030px){.p-list-step__bullet{position:absolute;top:-5px}}.p-inline-images{display:block;list-style:none;margin-left:0;padding-left:0;text-align:center}.p-inline-images__item{display:inline-block;margin:1.875rem;max-height:5.625rem;max-width:5.625rem;overflow:hidden;text-align:center;vertical-align:middle}@media (min-width:768px){.p-inline-images__item{margin:1.875rem;max-height:11.25rem;max-width:11.25rem}}.p-inline-images__item *{width:100%}.p-inline-images__img{display:inline-block;margin:2rem;max-width:6rem;text-align:center;vertical-align:middle;width:100%}@media (min-width:768px){.p-inline-images__img{margin:3rem;max-width:11.25rem}}.p-notification{background-color:#fff;border:0;border-color:#666;border-radius:.125rem;border-style:solid;border-top-width:3px;box-shadow:0 1px 5px 1px rgba(0,0,0,.2);color:#111;font-size:1rem;overflow:hidden;padding:.625rem;text-align:center;width:100%}.p-notification__response{background-position:0 4px;background-repeat:no-repeat;background-size:16px 16px;margin:0;text-align:left}.p-notification__status{font-weight:400;margin-right:.3125rem}.p-notification__action{border-bottom:0;margin-left:.3125rem}.p-notification--positive{background-color:#fff;border:0;border-color:#666;border-radius:.125rem;border-style:solid;border-top-width:3px;box-shadow:0 1px 5px 1px rgba(0,0,0,.2);color:#111;font-size:1rem;overflow:hidden;padding:.625rem;text-align:center;width:100%;border-color:#0e8420}.p-notification--positive .p-notification__response{background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg width='17' height='17' viewBox='0 0 17 17' xmlns='http://www.w3.org/2000/svg'%3E%3Cg transform='translate(1 1)' fill='none' fill-rule='evenodd'%3E%3Ccircle stroke='%230e8420' stroke-width='1.5' fill='%230e8420' cx='7.25' cy='7.25' r='7.25'/%3E%3Cpath fill='%23fff' d='M11.05 4.173l-.066.058L6.25 8.378l-2.776-2.38-.839.948L6.25 10.75l5.5-5.787-.7-.79z'/%3E%3C/g%3E%3C/svg%3E");padding-left:1.5rem}.p-notification--caution{background-color:#fff;border:0;border-color:#666;border-radius:.125rem;border-style:solid;border-top-width:3px;box-shadow:0 1px 5px 1px rgba(0,0,0,.2);color:#111;font-size:1rem;overflow:hidden;padding:.625rem;text-align:center;width:100%;border-color:#f99b11}.p-notification--caution .p-notification__response{background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg width='17' height='17' viewBox='0 0 17 17' xmlns='http://www.w3.org/2000/svg'%3E%3Cg transform='translate(1 1)' fill='none' fill-rule='evenodd'%3E%3Ccircle stroke='%23f99b11' stroke-width='1.5' fill='%23f99b11' cx='7.25' cy='7.25' r='7.25'/%3E%3Cpath d='M6.25 3.25v5h2v-5h-2zm0 6v2h2v-2h-2z' fill='%23fff'/%3E%3C/g%3E%3C/svg%3E");padding-left:1.5rem}.p-notification--negative{background-color:#fff;border:0;border-color:#666;border-radius:.125rem;border-style:solid;border-top-width:3px;box-shadow:0 1px 5px 1px rgba(0,0,0,.2);color:#111;font-size:1rem;overflow:hidden;padding:.625rem;text-align:center;width:100%;border-color:#c7162b}.p-notification--negative .p-notification__response{background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg width='16' height='17' viewBox='0 0 16 17' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M0 .362h16v16H0z'/%3E%3Ccircle stroke='%23c7162b' stroke-width='1.5' fill='%23c7162b' cx='8' cy='8.362' r='7.25'/%3E%3Cpath d='M5 5.362l6 6M11 5.362l-6 6' stroke='%23fff' stroke-width='1.5'/%3E%3C/g%3E%3C/svg%3E");padding-left:1.5rem}.p-notification--information{background-color:#fff;border:0;border-color:#666;border-radius:.125rem;border-style:solid;border-top-width:3px;box-shadow:0 1px 5px 1px rgba(0,0,0,.2);color:#111;font-size:1rem;overflow:hidden;padding:.625rem;text-align:center;width:100%;border-color:#335280}.p-pull-quote{border:0;margin:2rem 0 1rem;padding-left:2rem;padding-right:1.25rem;position:relative}@media (min-width:768px){.p-pull-quote{margin:1.5rem 0}}.p-pull-quote>p{font-size:1.5rem;font-weight:300;line-height:1.154;font-style:normal}@media only screen and (min-width:1030px){.p-pull-quote>p{font-size:1.75rem;line-height:1.286}}.p-pull-quote>p:first-of-type:before{color:#cdcdcd;display:inline-block;font-size:2.134rem;font-weight:700;line-height:1rem;max-width:1.25rem;content:"\201C\2002";margin-left:-1.5rem;padding-right:1.5rem;position:relative;top:.1rem}@media (min-width:768px){.p-pull-quote>p:first-of-type:before{font-size:2.5rem}}@media (min-width:1030px){.p-pull-quote>p:first-of-type:before{font-size:3rem}}@media (min-width:768px){.p-pull-quote>p:first-of-type:before{margin-left:-1.9rem;padding-right:1.9rem;top:.4rem}}.p-pull-quote>p:last-of-type{margin-bottom:0}.p-pull-quote>p:last-of-type:after{color:#cdcdcd;display:inline-block;font-size:2.134rem;font-weight:700;line-height:1rem;max-width:1.25rem;content:"\2002\201E";margin-left:.5rem;margin-top:-.5rem;position:absolute}@media (min-width:768px){.p-pull-quote>p:last-of-type:after{font-size:2.5rem}}@media (min-width:1030px){.p-pull-quote>p:last-of-type:after{font-size:3rem}}.p-pull-quote__citation{display:inline-block;font-size:1.25rem;font-style:italic;line-height:1.5;margin-top:.75rem;width:100%}.p-strip{clear:both;margin-top:0;padding:2rem 0;width:100%;background-color:transparent}.p-strip .p-link--external{color:inherit}.p-strip .p-link--external:after{background-color:currentColor}.p-strip--light{clear:both;margin-top:0;padding:2rem 0;width:100%;background-color:#f7f7f7}.p-strip--light .p-link--external{color:inherit}.p-strip--light .p-link--external:after{background-color:currentColor}.p-strip--dark{clear:both;margin-top:0;padding:2rem 0;width:100%;background-color:#111;color:#f7f7f7}.p-strip--dark .p-link--external{color:inherit}.p-strip--dark .p-link--external:after{background-color:currentColor}.p-form-validation{color:#111;line-height:1.5;margin-top:1.25rem;position:relative}.p-form-validation .p-form-validation__input{background-position:calc(100% - 1rem) .75rem;background-repeat:no-repeat;padding:.5rem 2.5rem .5rem .75rem}.p-form-validation .p-form-validation__icon{position:relative}.p-form-validation .p-form-validation__icon:after{position:absolute;right:.75rem;top:calc(0.5 - $sp-x-small)}.p-form-validation__message{font-size:.875rem;margin-top:.5rem}.is-error .p-form-validation__input{background-image:url(https://assets.ubuntu.com/v1/4b0cd7fc-icon-error.svg);border-color:#c7162b}.is-success .p-form-validation__input{background-image:url(https://assets.ubuntu.com/v1/94949185-icon-success.svg);border-color:#0e8420}.is-caution .p-form-validation__input{background-image:url(https://assets.ubuntu.com/v1/db30f04c-icon-caution.svg);border-color:#f99b11}.u-float--right{float:right!important}.u-float--left{float:left!important}.u-float-right{float:right!important}@media (max-width:620px){.u-float-right--small{float:right!important}}@media (min-width:768px) and (max-width:1030px){.u-float-right--medium{float:right!important}}@media (min-width:1030px){.u-float-right--large{float:right!important}}.u-float-left{float:left!important}@media (max-width:620px){.u-float-left--small{float:left!important}}@media (min-width:768px) and (max-width:1030px){.u-float-left--medium{float:left!important}}@media (min-width:1030px){.u-float-left--large{float:left!important}}.u-embedded-media{height:0;max-width:100%;overflow:hidden;padding-bottom:56.25%;position:relative}.u-embedded-media__element{height:100%;left:0;position:absolute;top:0;width:100%}@media only screen and (min-width:768px){.u-equal-height{display:-ms-flexbox;display:flex}}.u-align--center{-ms-flex-pack:center!important;justify-content:center!important;text-align:center!important}.u-align--left{-ms-flex-pack:start!important;justify-content:flex-start!important;text-align:left!important}.u-align--right{-ms-flex-pack:end!important;justify-content:flex-end!important;text-align:right!important}.u-no-margin{margin:0!important}.u-no-margin--top{margin-top:0!important}.u-no-margin--right{margin-right:0!important}.u-no-margin--bottom{margin-bottom:0!important}.u-no-margin--left{margin-left:0!important}.u-no-padding{padding:0!important}.u-no-padding--top{padding-top:0!important}.u-no-padding--right{padding-right:0!important}.u-no-padding--bottom{padding-bottom:0!important}.u-no-padding--left{padding-left:0!important}.u-hide{display:none!important}@media screen and (max-width:768px){.u-hide--small{display:none!important}}@media (min-width:768px) and (max-width:1030px){.u-hide--medium{display:none!important}}@media screen and (min-width:1030px){.u-hide--large{display:none!important}}.u-show{display:block!important}@media screen and (max-width:768px){.u-show--small{display:block!important}}@media (min-width:768px) and (max-width:1030px){.u-show--medium{display:block!important}}@media screen and (min-width:1030px){.u-show--large{display:block!important}}.u-off-screen{height:1px!important;left:-10000px!important;overflow:hidden!important;position:absolute!important;top:auto!important;width:1px!important}@media (min-width:768px){.u-vertically-center{-ms-flex-align:center!important;align-items:center!important;display:-ms-flexbox!important;display:flex!important}}.u-hidden{display:none!important}@media screen and (max-width:768px){.u-hidden--small{display:none!important}}@media (min-width:768px) and (max-width:1030px){.u-hidden--medium{display:none!important}}@media screen and (min-width:1030px){.u-hidden--large{display:none!important}}.u-visible{display:block!important}@media screen and (max-width:768px){.u-visible--small{display:block!important}}@media (min-width:768px) and (max-width:1030px){.u-visible--medium{display:block!important}}@media screen and (min-width:1030px){.u-visible--large{display:block!important}}.p-sidebar-nav__toggle--collapse,.p-sidebar-nav__toggle--expand{cursor:pointer;float:right;padding:.5em 0;width:.6em}.p-aside{-ms-flex-item-align:start;align-self:flex-start;border-top:1px solid #cdcdcd;-ms-flex:0 0 16em;flex:0 0 16em;font-size:.875rem;padding:0 1rem}@media (min-width:768px){.p-aside{background:#fff;border-left:1px solid #cdcdcd;border-top:0;height:100%;margin-top:2rem;overflow-y:auto;padding:0 1rem}}.p-aside__header{color:#666;font-size:1em;margin-bottom:.5rem;text-transform:uppercase}.p-aside__section{padding:1rem 0}.p-aside__section:not(:last-child){border-bottom:1px dotted #cdcdcd}.p-breadcrumbs{display:block;margin-left:1rem;margin-top:1rem}.p-breadcrumbs__link{color:#111;font-weight:300}.p-breadcrumbs__link:visited{color:#111}.p-breadcrumbs__link:hover{color:#007aa6}.p-breadcrumbs__link--active{font-weight:400}.p-breadcrumbs__link--active:hover{color:#111}@media (min-width:768px){.p-breadcrumbs{display:none}}.p-footer{border-top:1px solid #cdcdcd;color:#666;padding:1rem}@media (min-width:768px){.p-footer{padding:1.5rem}}.row{max-width:100%;padding:0;width:100%}.row .row{padding:20px}img.is-bordered{border:1px solid #cdcdcd;max-width:100%;padding:2px}@media (min-width:768px){.p-layout{-ms-flex-direction:column;flex-direction:column;min-height:100vh}}@media (min-width:768px){.p-layout,.p-layout__wrap{display:-ms-flexbox;display:flex}}.p-layout__main{display:-ms-flexbox;display:flex;-ms-flex:1;flex:1;padding:1.5rem 1rem 0}@media (min-width:768px){.p-layout__main{border-left:1px solid #cdcdcd;margin-left:0;padding:2rem}}.p-layout__img-links a{border-bottom:0}.p-layout__inner{max-width:1030px;width:100%}.p-layout__sidebar{-ms-flex:0 0 16em;flex:0 0 16em}.p-layout__versions{border-bottom:1px dotted #111;padding:0 1rem}.p-layout__outline{border:1px solid #666}.p-layout__outline--inner{border:1px dotted #666;margin:1rem;padding:1rem}.p-navigation{background:#fff;border-bottom:1px solid #cdcdcd;color:#111;line-height:32px;margin-bottom:0;padding:7.5px 0}.p-navigation__link{color:#111;margin:0}.p-navigation__link:visited{color:#111}.p-navigation__logo{color:#111;margin-bottom:0;margin-top:0}.p-navigation__image{display:block;float:left;height:32px;margin:0 1rem 0 0;vertical-align:middle}.p-sidebar-nav{margin:0 auto;width:100%}.p-sidebar-nav__list{list-style:none;margin:0;padding-left:0;width:100%}.p-sidebar-nav__list .p-sidebar-nav__list .p-sidebar-nav__link{display:inline-block}.p-sidebar-nav__list .p-sidebar-nav__list .p-sidebar-nav__list .p-sidebar-nav__link{padding-left:1rem}.p-sidebar-nav__link{border-bottom:0;color:#111;font-weight:300;margin-bottom:.5rem}.p-sidebar-nav__link:hover{color:#007aa6}.p-sidebar-nav__link:visited{color:#111}.p-sidebar-nav__link:hover{color:#335280}.p-sidebar-nav__link.is-active{font-weight:400}.p-sidebar-nav__toggle--collapse{filter:FlipV;transform:scaleY(-1)}.p-sidebar-nav__header{margin-bottom:0}@media (min-width:768px){.p-sidebar-nav__header{font-size:1.3125rem}}.p-sidebar-nav__header+.p-sidebar-nav__section{margin-top:1rem}.p-sidebar-nav__section--collapsed{display:none}.p-sidebar-nav__group{border-bottom:1px dotted #cdcdcd;margin:0;padding:1rem}@media (min-width:768px){.p-sidebar-nav__group:last-child{border-bottom:0}}.p-sidebar-nav__top{display:none;margin:0 1rem 1rem}@media (min-width:768px){.p-sidebar-nav__top{display:inline-block}}.p-social-list{float:right;list-style:none;margin:0}.p-social-list__item{display:inline-block;margin-left:.5rem}.p-social-list__link{border-bottom:0}.p-social-list__image{height:31px}.p-toc{list-style:none;margin:0;padding:0}.p-toc__item{margin-bottom:.5rem}.p-toc__item--separate{border-top:1px solid #cdcdcd;margin-bottom:0;margin-top:1rem;padding:1rem 0}.p-toc__item--separate+.p-toc__item--separate{margin-top:0}.p-toc__item:last-child{margin-bottom:0;padding-bottom:0}.p-toc__link{border-bottom:0;color:#111}.p-toc__link.is-active{font-weight:400}.p-toc__link:visited{color:#111}.p-toc__link:hover{color:#007aa6}.p-versions{list-style:none;margin:0;padding:0}.p-versions__link,.p-versions__link:visited{color:#111}.p-versions__link:hover{color:#007aa6}.p-versions__item,.p-versions__item--current,.p-versions__item--missing{display:inline-block;margin-right:1rem}.p-versions__item--current{font-weight:400}.p-versions__item--missing{color:#666;text-decoration:line-through}
+
+      /* pygmentize codehilite */
+      /* github.css style from: https://github.com/nottrobin/github-pygments-theme */
+      .codehilite .hll {color:#595e62;}
+
+      .codehilite .w {color: #333;}
+      .codehilite .esc {color:#63a35c;}
+      .codehilite .err {color:#333;}
+      .codehilite .x {color:#333;}
+
+      .codehilite .k {color:#a71d5d;}
+      .codehilite .kc {color:#0086b3;}
+      .codehilite .kd {color:#a71d5d;}
+      .codehilite .kn {color:#a71d5d;}
+      .codehilite .kp {color:#0086b3;}
+      .codehilite .kr {color:#0086b3;}
+      .codehilite .kt {color:#0086b3;}
+
+      .codehilite .n {color:#333;}
+      .codehilite .na {color:#795da3;}
+      .codehilite .nb {color:#0086b3;}
+      .codehilite .bp {color:#ed6a43;}
+      .codehilite .nc {color:#795da3;}
+      .codehilite .no {color:#0086b3;}
+      .codehilite .nd {color:#333;}
+      .codehilite .ni {color:#0086b3;}
+      .codehilite .ne {color:#ed6a43;}
+      .codehilite .nf {color:#333;}
+      .codehilite .py {color:#ed6a43;}
+      .codehilite .nl {color:#0086b3;}
+      .codehilite .nn {color:#333;}
+      .codehilite .nx {color:#795da3;}
+      .codehilite .nt {color:#63a35c;}
+      .codehilite .nv {color:#183691;}
+      .codehilite .vc {color:#ed6a43;}
+      .codehilite .vg {color:#ed6a43;}
+      .codehilite .vi {color:#ed6a43;}
+
+      .codehilite .l {color:#63a35c;}
+      .codehilite .ld {color:#795da3;}
+
+      .codehilite .s {color:#183691;}
+      .codehilite .sb {color:#595e62;}
+      .codehilite .sc {color:#183691;}
+      .codehilite .sd {color:#183691;}
+      .codehilite .s2 {color:#183691;}
+      .codehilite .se {color:#183691;}
+      .codehilite .sh {color:#183691;}
+      .codehilite .si {color:#183691;}
+      .codehilite .sx {color:#183691;}
+      .codehilite .sr {color:#183691;}
+      .codehilite .s1 {color:#183691;}
+      .codehilite .ss {color:#a71d5d;}
+
+      .codehilite .m {color:#0086b3;}
+      .codehilite .mb {color:#0086b3;}
+      .codehilite .mf {color:#0086b3;}
+      .codehilite .mh {color:#0086b3;}
+      .codehilite .mi {color:#0086b3;}
+      .codehilite .il {color:#0086b3;}
+      .codehilite .mo {color:#0086b3;}
+
+      .codehilite .o {color:#333;}
+      .codehilite .ow {color:#a71d5d;}
+      .codehilite .p {color:#183691;}
+
+      .codehilite .c {color:#969896;}
+      .codehilite .cm {color:#969896;}
+      .codehilite .cp {font-weight: bold; color:#1d3e81;}
+      .codehilite .c1 {color:#969896;}
+      .codehilite .cs {color:#969896;}
+
+      .codehilite .g {color:#0086b3;}
+      .codehilite .gd {color:#bd2c00; background-color:#ffecec;}
+      .codehilite .ge {color:#b52a1d;}
+      .codehilite .gr {color:#b52a1d;}
+      .codehilite .gh {font-weight: bold, #1d3e81;}
+      .codehilite .gi {color:#55a532;background-color:#eaffea;}
+      .codehilite .go {color:#333;}
+      .codehilite .gp {color:#333;}
+      .codehilite .gs {color:#333;}
+      .codehilite .gu {font-weight: bold, #1d3e81;}
+      .codehilite .gt {color:#333}
+
+      /* Header search styling - to be migrated into vanilla-docs-theme*/
+      .search__label {
+        display: none;
+      }
+      .search--header {
+        margin: 0;
+        float: right;
+        margin-left: auto;
+        margin-right: 7.5px;
+      }
+      .search__field,
+      .search__field[type='search'] {
+        max-width: 480px;
+        padding: 6px 38px 6px 10px;
+        float: left;
+        margin-right: -38px;
+        border-color: #cdcdcd;
+        display: block;
+        background-color: transparent;
+        line-height: 24px;
+        margin-bottom: 0;
+      }
+      .search--header .search__field {
+        width: 250px;
+      }
+      @media (max-width: 767px) {
+        .search__button {
+          width: auto;
+        }
+      }
+      .search__button,
+      .search__button:focus,
+      .search__button:active {
+        border: none;
+        display: block;
+        padding: 6px;
+        margin: 0;
+        vertical-align: middle;
+        background-color: transparent;
+        line-height: 0;
+      }
+      .search__button:hover {
+        background-color: transparent;
+        border: none;
+      }
+      .search__svg-frame {
+        stroke: #888
+      }
+      .search__button:hover .search__svg-frame {
+        stroke: #111;
+      }
+      .search__svg-handle {
+        fill: #888;
+      }
+      .search__button:hover .search__svg-handle {
+        fill: #111;
+      }
+
+      /**
+       * Make the aside section fixed to the top
+       */
+      .p-aside.fixed {
+        position: fixed;
+        top: 0;
+        right: 0;
+        margin-top: 0;
+       }
+
+      /**
+       * The border around images shouldn't be moved upstream just yet
+       * until it's been agreed:
+       * https://github.com/ubuntudesign/docs-vanilla-theme/issues/32
+       */
+      .theme__inner img {
+        max-width: 100%;
+        padding: 2px;
+        border: 1px solid #cdcdcd;
+      }
+
+      .theme > .theme__header {
+        padding-right: 36px;
+        display: block;
+      }
+
+
+      /**
+       * Don't migrate this upstream yet, because we need to have
+       * a discussion about the burger menu first. Which will delay things.
+       * Ideally I'd like to replace the burger with the word "MENU".
+       * Partly because it works better offline. Also, usability.
+       */
+      .theme__sidebar-toggle-button {
+        display: block;
+      }
+
+      .theme__sidebar-toggle {
+        display: none;
+      }
+
+      .p-sidebar-nav {
+        display: none;
+      }
+
+      .theme__sidebar-toggle:checked + .p-sidebar-nav {
+        display: block;
+      }
+
+      @media (min-width: 768px) {
+        .theme__sidebar-toggle-button {
+          display: none;
+          position: absolute;
+          top: 6px;
+          right: 6px;
+          cursor: pointer;
+          text-indent: -1000px;
+          background-image: url('https://assets.ubuntu.com/v1/39a96c62-navigation-menu-black.svg');
+          width: 38px;
+          height: 32px;
+          background-repeat: no-repeat;
+          background-position: center center;
+        }
+
+        .p-sidebar-nav {
+          display: block;
+        }
+      }
+    </style>
+  </head>
+  <body class="theme">
+    {% if tag_manager_code %}
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ tag_manager_code }}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    {% endif %}
+
+    <header class="p-navigation" role="banner">
+      <div class="p-navigation__logo">
+        {% if site_root %}<a class="p-navigation__link" href="{{ site_root }}">{% endif %}
+          {% if site_logo_url %}<img class="p-navigation__image" src="{{ site_logo_url }}" alt="{{ site_title }} logo" />{% endif %}
+          {{ site_title if site_title else 'Documentation' }}
+        {% if site_root %}</a>{% endif %}
+      </div>
+      <label for="nav-toggle-checkbox" class="theme__sidebar-toggle-button">Menu</label>
+
+      {% if search_url %}
+        <form id="search" action="{{ search_url }}" class="search--header">
+          <label for="edit-keys" class="search__label">Search</label>
+          <input class="search__field" type="search" name="q" id="search" placeholder="{{ search_placeholder }}" />
+          {% for domain in search_domains %}
+            <input type="hidden" name="domain" value="{{ domain }}" />
+          {% endfor %}
+          <button type="submit" class="search__button">
+            <svg xmlns="https://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 90 90">
+              <g color="#000">
+                <path fill="none" stroke-width="4" overflow="visible" enable-background="accumulate" d="M0 0h90v90H0z"></path>
+                <path class="search__svg-frame" d="M69 36.5a33 33.5 0 1 1-66 0 33 33.5 0 1 1 66 0z" transform="matrix(.636 0 0 .627 16.114 16.12)" fill="none" stroke="#fff" stroke-width="9.5" overflow="visible" enable-background="accumulate"></path>
+                <path class="search__svg-handle" style="text-indent:0;text-align:start;line-height:normal;text-transform:none;block-progression:tb;-inkscape-font-specification:Sans" d="M55.773 52.917L52.94 55.75l14 14 2.833-2.833-14-14z" font-size="xx-small" fill="#fff" stroke-width="6" overflow="visible" enable-background="accumulate" font-family="Sans"></path>
+                <path class="search__svg-handle" style="text-indent:0;text-align:start;line-height:normal;text-transform:none;block-progression:tb;-inkscape-font-specification:Sans" d="M60.972 57.03c-1.55.01-3.045 1.023-3.626 2.46-.58 1.436-.21 3.207.898 4.29l9.194 9.2c2.683 2.85 3.262 2.464 5.643.083 2.384-2.38 2.77-2.792-.08-5.646l-9.195-9.2c-.734-.753-1.78-1.192-2.83-1.188z" fill="#fff" stroke-width="11.804"></path>
+              </g>
+            </svg>
+          </button>
+        </form>
+      {% endif %}
+    </header>
+    <div class="row">
+      <div class="p-layout__wrap">
+        {% if navigation %}
+        <div class="col-3 p-layout__sidebar">
+          <input id="nav-toggle-checkbox" type="checkbox" class="theme__sidebar-toggle" />
+          <nav class="p-sidebar-nav">
+            <ul class="p-sidebar-nav__list">
+              {% for item in navigation %}
+              <li class="p-sidebar-nav__group">
+                {% if item.location %}
+                    {% if item.children %}
+                    <h4 class="p-sidebar-nav__header {% if item.active %}is-active{% endif %}"><a href="{{ item.location }}">{{ item.title }}</a></h4>
+                    {% else %}
+                    <a class="p-sidebar-nav__link {% if item.active %}is-active{% endif %}" href="{{ item.location }}">{{ item.title }}</a>
+                    {% endif %}
+                {% else %}
+                <h4 class="p-sidebar-nav__header">{{ item.title }}</h4>
+                {% endif %}
+
+                {% if item.children %}
+                <section id="settings" class="p-sidebar-nav__section">
+                  <ul class="p-sidebar-nav__list">
+                    {% for child in item.children %}
+                    <li>
+                      {% if child.location %}
+                      <a class="p-sidebar-nav__link {% if child.active %}is-active{% endif %}" href="{{ child.location }}">
+                        {{ child.title }}
+                      </a>
+                      {% else %}
+                      <span class="p-sidebar-nav__link">{{ child.title }}</span>
+                      {% endif %}
+
+                      {% if child.children %}
+                      <section id="settings" class="p-sidebar-nav__section">
+                        <ul class="p-sidebar-nav__list">
+                          {% for grandchild in child.children %}
+                          <li>
+                            {% if grandchild.location %}
+                            <a class="p-sidebar-nav__link {% if grandchild.active %}is-active{% endif %}" href="{{ grandchild.location }}">
+                              {{ grandchild.title }}
+                            </a>
+                            {% else %}
+                            <span class="p-sidebar-nav__link">{{ grandchild.title }}</span>
+                            {% endif %}
+                          </li>
+                          {% endfor %}
+                        </ul>
+                      </section>
+                      {% endif %}
+                    </li>
+                    {% endfor %}
+                  </ul>
+                </section>
+                {% endif %}
+              </li>
+              {% endfor %}
+            </ul>
+          </nav>
+          <script>
+          /* Polyfill functions
+           * =================== */
+
+          /**
+           * Array.prototype.forEach polyfill
+           * from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
+           */
+          if (!Array.prototype.forEach) {
+              Array.prototype.forEach = function(fun) {
+                  if (
+                      this === void 0
+                      || this === null
+                      || typeof fun !== "function"
+                  ) { throw new TypeError(); }
+
+                  var t = Object(this);
+                  var len = t.length >>> 0;
+
+                  var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+                  for (var i = 0; i < len; i++) {
+                      if (i in t) {
+                          fun.call(thisArg, t[i], i, t);
+                      }
+                  }
+              };
+          }
+
+          /**
+           * Add Array methods to NodeList
+           */
+          Object.getOwnPropertyNames(Array.prototype).forEach(
+            function (methodName) {
+              if(!(methodName in NodeList.prototype)) {
+                NodeList.prototype[methodName] = Array.prototype[methodName];
+              }
+            }
+          );
+
+          /* Element.prototype.classList polyfill, by Eli Grey, http://eligrey.com
+           * https://github.com/eligrey/classList.js */
+          if("document"in self){if(!("classList"in document.createElement("_"))||document.createElementNS&&!("classList"in document.createElementNS("http://www.w3.org/2000/svg","g"))){(function(t){"use strict";if(!("Element"in t))return;var e="classList",i="prototype",n=t.Element[i],s=Object,r=String[i].trim||function(){return this.replace(/^\s+|\s+$/g,"")},a=Array[i].indexOf||function(t){var e=0,i=this.length;for(;e<i;e++){if(e in this&&this[e]===t){return e}}return-1},o=function(t,e){this.name=t;this.code=DOMException[t];this.message=e},l=function(t,e){if(e===""){throw new o("SYNTAX_ERR","An invalid or illegal string was specified")}if(/\s/.test(e)){throw new o("INVALID_CHARACTER_ERR","String contains an invalid character")}return a.call(t,e)},c=function(t){var e=r.call(t.getAttribute("class")||""),i=e?e.split(/\s+/):[],n=0,s=i.length;for(;n<s;n++){this.push(i[n])}this._updateClassName=function(){t.setAttribute("class",this.toString())}},u=c[i]=[],f=function(){return new c(this)};o[i]=Error[i];u.item=function(t){return this[t]||null};u.contains=function(t){t+="";return l(this,t)!==-1};u.add=function(){var t=arguments,e=0,i=t.length,n,s=false;do{n=t[e]+"";if(l(this,n)===-1){this.push(n);s=true}}while(++e<i);if(s){this._updateClassName()}};u.remove=function(){var t=arguments,e=0,i=t.length,n,s=false,r;do{n=t[e]+"";r=l(this,n);while(r!==-1){this.splice(r,1);s=true;r=l(this,n)}}while(++e<i);if(s){this._updateClassName()}};u.toggle=function(t,e){t+="";var i=this.contains(t),n=i?e!==true&&"remove":e!==false&&"add";if(n){this[n](t)}if(e===true||e===false){return e}else{return!i}};u.toString=function(){return this.join(" ")};if(s.defineProperty){var h={get:f,enumerable:true,configurable:true};try{s.defineProperty(n,e,h)}catch(d){if(d.number===-2146823252){h.enumerable=false;s.defineProperty(n,e,h)}}}else if(s[i].__defineGetter__){n.__defineGetter__(e,f)}})(self)}else{(function(){"use strict";var t=document.createElement("_");t.classList.add("c1","c2");if(!t.classList.contains("c2")){var e=function(t){var e=DOMTokenList.prototype[t];DOMTokenList.prototype[t]=function(t){var i,n=arguments.length;for(i=0;i<n;i++){t=arguments[i];e.call(this,t)}}};e("add");e("remove")}t.classList.toggle("c3",false);if(t.classList.contains("c3")){var i=DOMTokenList.prototype.toggle;DOMTokenList.prototype.toggle=function(t,e){if(1 in arguments&&!this.contains(t)===!e){return e}else{return i.call(this,t)}}}t=null})()}}
+
+          /* Element.prototype.addEventListener (https://gist.github.com/jonathantneal/3748027) */
+          !window.addEventListener&&function(e,t,n,r,i,s,o){e[r]=t[r]=n[r]=function(e,t){var n=this;o.unshift([n,e,t,function(e){e.currentTarget=n,e.preventDefault=function(){e.returnValue=!1},e.stopPropagation=function(){e.cancelBubble=!0},e.target=e.srcElement||n,t.call(n,e)}]),this.attachEvent("on"+e,o[0][3])},e[i]=t[i]=n[i]=function(e,t){for(var n=0,r;r=o[n];++n)if(r[0]==this&&r[1]==e&&r[2]==t)return this.detachEvent("on"+e,o.splice(n,1)[0][3])},e[s]=t[s]=n[s]=function(e){return this.fireEvent("on"+e.type,e)}}(Window.prototype,HTMLDocument.prototype,Element.prototype,"addEventListener","removeEventListener","dispatchEvent",[])
+
+          /* String.prototype.startsWith polyfill, by Mathius Bynens, https://mathiasbynens.be/
+           * https://github.com/mathiasbynens/String.prototype.startsWith */
+          String.prototype.startsWith||!function(){"use strict";var t=function(){try{var t={},r=Object.defineProperty,e=r(t,t,t)&&r}catch(n){}return e}(),r={}.toString,e=function(t){if(null==this)throw TypeError();var e=String(this);if(t&&"[object RegExp]"==r.call(t))throw TypeError();var n=e.length,i=String(t),a=i.length,o=arguments.length>1?arguments[1]:void 0,h=o?Number(o):0;h!=h&&(h=0);var u=Math.min(Math.max(h,0),n);if(a+u>n)return!1;for(var g=-1;++g<a;)if(e.charCodeAt(u+g)!=i.charCodeAt(g))return!1;return!0};t?t(String.prototype,"startsWith",{value:e,configurable:!0,writable:!0}):String.prototype.startsWith=e}();
+
+          /* scopeQuerySelectorShim.js
+          * Copyright (C) 2015 Larry Davis - https://github.com/lazd/scopedQuerySelectorShim
+          */
+          !function(){function a(a,c){var e=a[c];a[c]=function(a){var c,f=!1,g=!1;return a.match(d)?(a=a.replace(d,""),this.parentNode||(b.appendChild(this),g=!0),parentNode=this.parentNode,this.id||(this.id="rootedQuerySelector_id_"+(new Date).getTime(),f=!0),c=e.call(parentNode,"#"+this.id+" "+a),f&&(this.id=""),g&&b.removeChild(this),c):e.call(this,a)}}if(!HTMLElement.prototype.querySelectorAll)throw new Error("rootedQuerySelectorAll: This polyfill can only be used with browsers that support querySelectorAll");var b=document.createElement("div");try{b.querySelectorAll(":scope *")}catch(c){var d=/^\s*:scope/gi;a(HTMLElement.prototype,"querySelector"),a(HTMLElement.prototype,"querySelectorAll")}}();
+
+          /**
+           * Add "collaped" classes to all provided list items
+           * unless they're "active".
+           */
+          function expandCollapseAll(items) {
+            for(var num = 0; num < items.length; num++) {
+              var item = items[num];
+              var header = item.querySelector(':scope > .p-sidebar-nav__header');
+              var subSection = item.querySelector(':scope > .p-sidebar-nav__section');
+              var activeChild = Boolean(item.querySelector('.is-active'));
+
+              // If no subsection, skip this list item
+              if (! subSection) {
+                continue;
+              }
+
+              // Create the trigger button image
+              var trigger = document.createElement('img');
+              trigger.classList.add('p-sidebar-nav__toggle--collapse');
+              trigger.setAttribute(
+                'src',
+                'https://assets.ubuntu.com/v1/04d2075a-chevron_down.svg'
+              );
+              trigger.addEventListener(
+                'click',
+                function(subSection) {
+                  return function(clickEvent) {
+                    this.classList.toggle('p-sidebar-nav__toggle--collapse');
+                    this.classList.toggle('p-sidebar-nav__toggle--expand');
+                    subSection.classList.toggle('p-sidebar-nav__section--collapsed');
+                  };
+                }(subSection)
+              );
+
+              // Add the trigger image at the top of the header or item
+              if (header) {
+                header.insertBefore(trigger, header.firstElementChild);
+              } else {
+                item.insertBefore(trigger, item.firstElementChild)
+              }
+
+              // Collapse unless it has an active child
+              if (! activeChild) {
+                trigger.classList.remove('p-sidebar-nav__toggle--collapse');
+                trigger.classList.add('p-sidebar-nav__toggle--expand');
+                subSection.classList.add('p-sidebar-nav__section--collapsed');
+              }
+            }
+          }
+
+          // Collapse doubly-nested nav lists
+          expandCollapseAll(document.querySelectorAll('.p-sidebar-nav li'));
+          </script>
+        </div>
+        {% endif %}
+        <div class="col-12 p-layout__main">
+          <main id="main-content" class="p-layout__inner">
+            {{ content }}
+          </main>
+        </div>
+        {% if toc_items or versions %}
+        <div class="col-2">
+          <aside id="side-content" class="p-aside">
+            {% if versions %}
+            <nav class="p-aside__section">
+              <h4 class="p-aside__header">Versions</h4>
+              <ul class="p-versions">
+                {% for version in versions %}
+                  {% if version.path is none %}
+                  <li class="p-versions__item--missing">{{ version.name }}</li>
+                  {% elif version.path == '' %}
+                  <li class="p-versions__item--current">{{ version.name }}</li>
+                  {% else %}
+                  <li class="p-versions__item">
+                    <a href="{{ version.path }}" class="p-versions__link">{{ version.name }}</a>
+                  </li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
+            </nav>
+            {% endif %}
+            {% if toc_items %}
+            <div class="p-aside__section">
+              <h4 class="p-aside__header">Contents</h4>
+              <nav>
+                <ul class="p-toc">
+                  {{ toc_items }}
+                  <li class="p-toc__item--separate" id="back-to-top" style="display: none">
+                    <a class="p-toc__link" href="#">Back to top</a>
+                  </li>
+                </ul>
+              </nav>
+            </div>
+            {% endif %}
+          </aside>
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <footer class="p-footer" role="contentinfo">
+      <div class="row">
+        <div class="col-12">
+          <p>&copy; Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+        </div>
+      </div>
+    </footer>
+    <script>
+      /* Add classes to links */
+      var links = document.querySelectorAll('a');
+      links.forEach(function(link) {
+        if (link.hostname && link.hostname != location.hostname) {
+          link.className += ' p-link--external';
+        }
+      });
+
+      /* Setup sticky table of contents */
+      var aside = document.querySelector('#side-content');
+      if (aside) {
+        var asideOffset = aside.getBoundingClientRect().top;
+        var asideWidth = aside.offsetWidth;
+        var backToTop = document.querySelector('#back-to-top');
+
+        window.addEventListener(
+          'scroll',
+          function(scrollEvent) {
+            var scrolled = window.innerWidth >= 768 && window.scrollY > asideOffset;
+
+            aside.classList.toggle('fixed', scrolled);
+
+            if (scrolled) {
+              aside.style.width = asideWidth + 'px';
+              backToTop.style.display = 'block';
+            } else {
+              aside.style.width = '';
+              backToTop.style.display = 'none';
+            }
+          }
+        );
+      }
+    </script>
+    <script src="https://assets.ubuntu.com/v1/7db7c898-example-1.0.5.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -41,10 +41,11 @@
   },
   "scripts": {
     "build": "gulp build",
+    "build-docs": "documentation-builder --base-directory docs --output-path docs/templates --template-path docs/template.html --tag-manager-code 'GTM-K92JCQ' --no-link-extensions --force",
     "serve": "gulp jekyll",
     "test": "gulp test",
     "watch": "gulp develop",
-    "clean": "rm -rf build _jekyll/_site node_modules/ yarn-error.log .bundle",
+    "clean": "rm -rf build _jekyll/_site docs/templates node_modules/ yarn-error.log .bundle",
     "build-examples": "gulp build-examples"
   },
   "version": "1.6.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask==0.12.2
+PyYAML==3.12
+pycountry==17.9.23
+yamlordereddictloader==0.4.0
+ubuntudesign.documentation-builder==1.5.1


### PR DESCRIPTION
## Done

Adding Flask app to serve docs.
An update to ./run will come later to allow it to be served through it as a secondary site.

## QA

- Pull code
(Can't use ./run just yet 😞)
- `yarn run build-docs`
- Install python from requirements.txt in your favourite Python env manager
- `FLASK_APP=docs/app.py flask run`
- Follow address in terminal

