### PR TITLE
1481: Add -webkit prefix to mask check in external link pattern

### DIFF
--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -47,11 +47,11 @@
     }
   }
 
-  @supports (mask-size: 1em) {
+  @supports (mask-size: 1em) or (-webkit-mask-size: 1em) { //sass-lint:disable-line no-vendor-prefixes
     @include vf-mask-supported;
   }
 
-  @supports not (mask-size: 1em) {
+  @supports not ((mask-size: 1em) or (-webkit-mask-size: 1em)) { //sass-lint:disable-line no-vendor-prefixes
     @include vf-mask-unsupported;
   }
 
@@ -79,6 +79,7 @@
     // Used for links point at a different domain
     &--external {
       &::after {
+        -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' %3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E") no-repeat 0 0 / cover; //sass-lint:disable-line no-vendor-prefixes
         background-color: currentColor;
         content: '';
         margin: 0 0 0 .25em;


### PR DESCRIPTION
## Done

- Added `-webkit-mask` to `@support` checks
- Added `-webkit-mask` to external link pattern

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/templates/external-links/
- Check that external link patterns still look good in Chrome, Firefox and Edge (IE doesn't support the `@supports` tag)

## Details

Fixes #1481 
