### PR TITLE
1452: Change footer to move to bottom of page if not enough content

### DIFF
--- a/_jekyll/_layouts/default.html
+++ b/_jekyll/_layouts/default.html
@@ -13,6 +13,6 @@
     </head>
 
     <body style="margin: 1rem;">
-{{ content }}
+      {{ content }}
     </body>
 </html>

--- a/scss/_patterns_footer.scss
+++ b/scss/_patterns_footer.scss
@@ -6,8 +6,21 @@
     border-top: 1px solid $color-mid-light;
     font-size: .875rem;
     line-height: 1.5;
+    margin-top: auto;
     padding-bottom: $sp-medium;
     padding-top: $sp-medium;
+
+    @at-root {
+      body,
+      html {
+        height: 100%;
+      }
+
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+    }
 
     @media (min-width: $breakpoint-medium) {
       padding-bottom: $sp-large;


### PR DESCRIPTION
## Done

- Changed default footer patter to be 'sticky' (i.e. it moves to the bottom of page if there's not enough content to fill a browser window)

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/footer/
- Check that the footer is at the bottom of the browser window
- Check it's compatible with the [browsers we support](https://github.com/canonical-webteam/practices/blob/master/coding/browser-support.md)
- **Note: All body tags in the examples have an inline style of `margin: 1rem` so the window height is actually 100%+2rem, meaning a scrollbar appears where it wouldn't normally**

## Details

Fixes #1452 
