### PR TITLE
1479: Change u-show and u-visible to display: inherit

### DIFF
--- a/scss/_utilities_show.scss
+++ b/scss/_utilities_show.scss
@@ -4,23 +4,23 @@
 @mixin vf-u-show {
 
   .u-show {
-    display: block !important;
+    display: inherit !important;
 
     &--small {
       @media screen and (max-width: $breakpoint-medium) {
-        display: block !important;
+        display: inherit !important;
       }
     }
 
     &--medium {
       @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
-        display: block !important;
+        display: inherit !important;
       }
     }
 
     &--large {
       @media screen and (min-width: $breakpoint-large) {
-        display: block !important;
+        display: inherit !important;
       }
     }
   }

--- a/scss/_utilities_visibility.scss
+++ b/scss/_utilities_visibility.scss
@@ -30,23 +30,23 @@
 
   @include deprecate('2.0.0', 'Use .u-show instead') {
     .u-visible {
-      display: block !important;
+      display: inherit !important;
 
       &--small {
         @media screen and (max-width: $breakpoint-medium) {
-          display: block !important;
+          display: inherit !important;
         }
       }
 
       &--medium {
         @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
-          display: block !important;
+          display: inherit !important;
         }
       }
 
       &--large {
         @media screen and (min-width: $breakpoint-large) {
-          display: block !important;
+          display: inherit !important;
         }
       }
     }


### PR DESCRIPTION
## Done

- Changed `display: block` to `display: inherit` in u-show and u-visible to keep styling consistent

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/utilities/hide/
- Open http://0.0.0.0:8101/vanilla-framework/examples/utilities/show/
- Check that both still work as expected
- Change any of the `<div>` tags in the example pages to something that doesn't have a `display: block` property, such as a `<span>` or `<table>` and check that the `display` property is not overtwritten

## Details

Fixes #1479 
