### PR TITLE
1429: Fix alignment bugs in inline form example

### DIFF
--- a/examples/patterns/forms/form-inline.html
+++ b/examples/patterns/forms/form-inline.html
@@ -7,12 +7,14 @@ category: _patterns
 <form class="p-form p-form--inline">
   <div class="p-form__group">
     <label for="full-name-inline" class="p-form__label">Full name</label>
-    <input type="text" id="full-name-inline" class="p-form__control" required>
+    <div class="p-form__control u-clearfix">
+      <input type="text" id="full-name-inline" required>
+    </div>
   </div>
   <div class="p-form__group p-form-validation is-error">
-    <label for="address-inline" class="p-form__label">Address line 1</label>
+    <label for="address-inline1" class="p-form__label">Address line 1</label>
     <div class="p-form__control u-clearfix">
-      <input type="text" id="address-inline" class="p-form-validation__input" required aria-invalid="true" aria-describedby="input-error-message-inline">
+      <input type="text" id="address-inline1" class="p-form-validation__input" required aria-invalid="true" aria-describedby="input-error-message-inline">
       <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
         <strong>Error:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
       </p>
@@ -25,16 +27,16 @@ category: _patterns
   <div class="p-form__group">
     <label for="username-inline" class="p-form__label">Username</label>
     <div class="p-form__control u-clearfix">
-      <input type="text" id="uername-inline" class="p-form__control" required>
+      <input type="text" id="username-inline" class="p-form__control" required>
       <p class="p-form-help-text">
         Lowercase alphanumeric characters and - only.
       </p>
     </div>
   </div>
   <div class="p-form__group p-form-validation is-error">
-    <label for="address-inline" class="p-form__label">Address line 1</label>
+    <label for="address-inline2" class="p-form__label">Address line 1</label>
     <div class="p-form__control u-clearfix">
-      <input type="text" id="address-inline" class="p-form-validation__input" required aria-invalid="true" aria-describedby="input-error-message-inline">
+      <input type="text" id="address-inline2" class="p-form-validation__input" required aria-invalid="true" aria-describedby="input-error-message-inline">
       <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
         <strong>Error:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
       </p>


### PR DESCRIPTION
## Done

- Fixed a bug in the `.p-form--inline` example where form inputs would not baseline align with a button
- Fixed minor labelling bugs in the same example

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/forms/form-inline/
- Check that the inputs align along the length of the form (it can help to change the `background-color` of the forms to something other than white)
- Test using browsers listed in the [Browser Support doc](https://github.com/canonical-webteam/practices/blob/master/coding/browser-support.md)

## Details

Fixes #1429 