### PR TITLE
Tab pattern fixes

### DIFF
--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -9,18 +9,20 @@
     position: relative;
 
     &::before {
-      background: linear-gradient(90deg, hsla(0, 0%, 100%, 0) 0, $color-x-light);// sass-lint:disable-line no-color-literals
+      background: linear-gradient(to right, hsla(0, 0%, 100%, 0), $color-x-light 50%);// sass-lint:disable-line no-color-literals
       bottom: 0;
       color: $color-mid-dark;
       content: '\203A';
       display: block;
       font-size: 2rem;
+      height: $sp-xxx-large;
       padding-right: $sp-large;
+      pointer-events: none;
       position: absolute;
       right: 0;
       text-align: right;
       top: 0;
-      width: 100px;
+      width: 5rem;
       z-index: 10;
 
       @media screen and (min-width: $breakpoint-medium) {
@@ -30,8 +32,8 @@
 
     &__list {
       margin: 0 auto;
-      overflow: scroll;
-      padding: 0 $sp-xxx-large 0 $sp-large;
+      overflow-x: auto;
+      padding: 0 0 0 $sp-large;
       position: relative;
       white-space: nowrap;
       width: 100%;
@@ -52,6 +54,14 @@
 
       @media screen and (min-width: $breakpoint-medium) {
         float: left;
+      }
+
+      &:last-child {
+        margin-right: $sp-xxx-large;
+
+        @media screen and (min-width: $breakpoint-medium) {
+          margin-right: 0;
+        }
       }
     }
 

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -56,6 +56,7 @@
     }
 
     &__link {
+      border-bottom: 3px solid transparent;
       color: $color-x-dark;
       display: inline-block;
       padding: $sp-small;


### PR DESCRIPTION
## Done

- Added a transparent border-bottom to `.p-tabs__link` by default, which should address styling issues if no tabs are selected and if the tab list extends over two lines
- Made it possible to click through the arrow on small screen tab pattern
- Changed overflow on small screen tabs to `auto`, so the horizontal scrollbar only appears when necessary

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/tabs/
- Remove `aria-selected="true"` from the markup of the selected tab
- Check that the height of the tab list does not change on hover
- Refresh
- Add extra `<li class="p-tabs__item" role="presentation">` until the tab list wraps around
- Check that the second row of tabs do not jump around on hover
- Refresh
- Resize window to small screen size, until the arrow on the right covers the last item
- Check that you can still click the last item, and that it comes out from behind the arrow

## Details

Fixes #1411, fixes #1458, fixes #1506  
  