### PR TITLE
1516: Add Slider to docs navigation

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -15,7 +15,7 @@ navigation:
   - location: settings/spacing-settings.md
     title: Spacing
 
-- title: Global layout 
+- title: Global layout
   children:
 
   - location: settings/breakpoint-settings.md
@@ -131,7 +131,7 @@ navigation:
 
   - location: patterns/code-snippet.md
     title: Code snippet
-    
+
   - location: base/typography.md
     title: Typography
 
@@ -161,6 +161,9 @@ navigation:
 
   - location: patterns/notification.md
     title: Notifications
+
+  - location: patterns/slider.md
+    title: Slider
 
   - location: patterns/switch.md
     title: Switch
@@ -197,7 +200,7 @@ navigation:
 
   - location: utilities/spin.md
     title: Spin
-   
+
 - location: https://vanillaframework.io/
   title: vanillaframework.io
   external: true


### PR DESCRIPTION
## Done

- Added slider details to `docs/en/metadata.yaml`

## QA

- Pull code
- Run `cd docs && ./run`
- Open http://0.0.0.0:8104/
- Check that the slider pattern can be found in the side nav under 'Interactive Elements'
- Check that clicking on it directs to /en/patterns/slider
- Check that the slider docs page is explained well

## Details

Fixes #1516 
