### PR TITLE
1517: Build search box component

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -144,8 +144,11 @@ navigation:
   - location: patterns/buttons.md
     title: Buttons
 
-  - location: patterns/forms.md
+  - location: base/forms.md
     title: Forms
+
+  - location: patterns/forms.md
+    title: Form layout
 
   - location: patterns/form-validation.md
     title: Form validation
@@ -161,6 +164,9 @@ navigation:
 
   - location: patterns/notification.md
     title: Notifications
+
+  - location: patterns/search-box.md
+    title: Search box
 
   - location: patterns/slider.md
     title: Slider

--- a/docs/en/patterns/search-box.md
+++ b/docs/en/patterns/search-box.md
@@ -1,0 +1,22 @@
+---
+title: Search box
+table_of_contents: true
+---
+
+## Search box
+
+Search boxes enable search functionality on a page and are typically used in a navigation bar. The pattern expands to the full width of its container by default.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/search-box/default"
+    class="js-example">
+    View examples of search box patterns
+</a>
+
+### Navigation
+
+This pattern integrates with `.p-navigation__nav` for both large and small screens.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/search-box/navigation"
+    class="js-example">
+    View examples of search box navigation patterns
+</a>

--- a/examples/patterns/search-box/default.html
+++ b/examples/patterns/search-box/default.html
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Search box / Default
+category: _patterns
+---
+
+<form class="p-search-box">
+  <input type="search" class="p-search-box__input" name="search" placeholder="Search" required>
+  <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
+  <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
+</form>
+<form class="p-search-box">
+  <input type="search" class="p-search-box__input" name="search" placeholder="Search" required disabled>
+  <button type="reset" class="p-search-box__reset" alt="reset" disabled><i class="p-icon--close"></i></button>
+  <button type="submit" class="p-search-box__button" alt="search" disabled><i class="p-icon--search"></i></button>
+</form>

--- a/examples/patterns/search-box/navigation.html
+++ b/examples/patterns/search-box/navigation.html
@@ -1,0 +1,31 @@
+---
+layout: default
+title: Search box / Navigation
+category: _patterns
+---
+<header id="navigation" class="p-navigation">
+  <div class="p-navigation__banner">
+    <div class="p-navigation__logo">
+      <a class="p-navigation__link" href="#">
+        <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="" class="p-navigation__image" />
+      </a>
+    </div>
+    <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+    <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+  </div>
+  <nav class="p-navigation__nav" role="menubar">
+    <span class="u-off-screen">
+      <a href="#main-content">Jump to main content</a>
+    </span>
+    <ul class="p-navigation__links" role="menu">
+      <li class="p-navigation__link" role="menuitem"><a href="#">Link1</a></li>
+      <li class="p-navigation__link" role="menuitem"><a href="#">Link2</a></li>
+      <li class="p-navigation__link" role="menuitem"><a href="#">Link3</a></li>
+    </ul>
+    <form class="p-search-box">
+      <input type="search" class="p-search-box__input" name="search" placeholder="Search" required>
+      <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
+      <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
+    </form>
+  </nav>
+</header>

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -254,6 +254,7 @@
       @media (min-width: $breakpoint-navigation-threshold + 1) {
         background-color: transparent;
         clear: none;
+        flex-shrink: 0;
         float: left;
       }
 
@@ -311,7 +312,30 @@
       margin-top: 0;
 
       @media (min-width: $breakpoint-navigation-threshold + 1) {
-        display: block;
+        display: flex;
+      }
+
+      > .p-search-box {
+        align-self: center;
+        margin-left: auto;
+        margin-top: 0;
+        max-width: 20rem;
+        order: 1;
+        width: 100%;
+
+        @media (max-width: $breakpoint-navigation-threshold) {
+          max-width: inherit;
+          order: -1;
+          top: 0;
+        }
+
+        > .p-search-box__input,
+        .p-search-box__button,
+        .p-search-box__reset {
+          @media (max-width: $breakpoint-navigation-threshold) {
+            border-bottom: 0;
+          }
+        }
       }
     }
   }
@@ -328,7 +352,12 @@
     }
 
     .p-navigation__nav {
-      display: block;
+      display: flex;
+      flex-direction: row;
+
+      @media (max-width: $breakpoint-navigation-threshold) {
+        flex-direction: column;
+      }
     }
   }
 }

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -1,0 +1,55 @@
+@mixin vf-p-search-box {
+
+  %search-box-button {
+    background: $color-x-light;
+    border-bottom: 1px solid $color-mid-light;
+    border-top: 1px solid $color-mid-light;
+    display: block;
+    height: 100%;
+    margin: 0;
+    padding: 0 $sp-small;
+    position: absolute;
+    top: 0;
+    width: $sp-xx-large;
+
+    &:hover {
+      background: inherit;
+
+      &:disabled {
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  .p-search-box {
+    box-shadow: inset 0 1px 2px $color-input-shadow;
+    display: flex;
+    position: relative;
+
+    &__input {
+      border-radius: 2px;
+      box-shadow: none;
+      flex-grow: 2;
+
+      &::-webkit-search-cancel-button {
+        -webkit-appearance: none;  // sass-lint:disable-line no-vendor-prefixes
+      }
+
+      &:not(:valid) ~ .p-search-box__reset {
+        display: none;
+      }
+    }
+
+    &__button {
+      @extend %search-box-button;
+      right: 0;
+    }
+
+    &__reset {
+      @extend %search-box-button;
+      border-left: 0;
+      border-right: 0;
+      right: $sp-xx-large;
+    }
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -33,6 +33,7 @@
 'patterns_slider',
 'patterns_table-mobile-card',
 'patterns_tabs',
+'patterns_search-box',
 'patterns_strip',
 'patterns_switch',
 'patterns_table-sortable',
@@ -95,6 +96,7 @@
   @include vf-p-notification;
   @include vf-p-pull-quotes;
   @include vf-p-table-mobile-card;
+  @include vf-p-search-box;
   @include vf-p-slider;
   @include vf-p-strip;
   @include vf-p-switch;


### PR DESCRIPTION
## Done

- Built search box component as per [specs](https://github.com/ubuntudesign/vanilla-design/tree/master/Search)
- Includes Default and Navigation examples
- Added docs page for the search box component (and included it in the side nav this time)

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/search-box/default and http://0.0.0.0:8101/vanilla-framework/examples/patterns/search-box/navigation
- Check that the component matches the [specs](https://github.com/ubuntudesign/vanilla-design/tree/master/Search)
- Check that everything looks right in all browsers that we support ([link](https://github.com/canonical-webteam/practices/blob/master/coding/browser-support.md))
- `cd` into the docs folder and run `./run`
- Open http://0.0.0.0:8104/
- Check that you can find 'Search box' in the side nav under 'Interactive elements'
- Check that it navigates to the appropriate docs page

## Details

Fixes #1517