### PR TITLE
1509: Remove tooltips max-width

### DIFF
--- a/examples/patterns/tooltips.html
+++ b/examples/patterns/tooltips.html
@@ -10,7 +10,7 @@ category: _patterns
 </button>
 <button class="p-tooltip p-tooltip--btm-center" aria-describedby="btm-cntr">
   Bottom center tooltip
-  <span class="p-tooltip__message" role="tooltip" id="btm-cntr">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Corrupti earum nesciunt&#xa;temporibus, aut iste voluptates obcaecati&#xa;quibusdam aliquam possimus unde eos, rem!&#xa;Doloribus, praesentium amet.</span>
+  <span class="p-tooltip__message" role="tooltip" id="btm-cntr">Lorem ipsum dolor sit amet, consectetur adipisicing elit.&#xa;Corrupti earum nesciunt temporibus, aut iste voluptates&#xa;obcaecati quibusdam aliquam possimus unde eos, rem!&#xa;Doloribus, praesentium amet.</span>
 </button>
 <button class="p-tooltip p-tooltip--btm-right" aria-describedby="btm-rgt">
   Bottom right tooltip
@@ -28,7 +28,7 @@ category: _patterns
 </button>
 <button class="p-tooltip p-tooltip--top-left" aria-describedby="tp-lft">
   Top left tooltip
-  <span class="p-tooltip__message" role="tooltip" id="tp-lft">Lorem ipsum dolor sit amet.</span>
+  <span class="p-tooltip__message" role="tooltip" id="tp-lft">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corrupti&#xa;earum nesciunt temporibus, aut iste voluptates obcaecati quibusdam&#xa;aliquam possimus unde eos, rem! Doloribus, praesentium amet.</span>
 </button>
 <button class="p-tooltip p-tooltip--top-center" aria-describedby="tp-cntr">
   Top center tooltip

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -13,7 +13,6 @@
       font-size: .875rem;
       left: 0;
       line-height: 1.5;
-      max-width: 330px;
       min-width: 155px;
       padding: $sp-x-small $sp-small;
       position: absolute;


### PR DESCRIPTION
## Done

- Removed `max-width` from tooltips so the content can set its own line-breaks
- Edited the example to show different widths of tooltips

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/tooltips/
- Check that there are tooltip messages that are wider than 330px and they word-wrap correctly

## Details

Fixes #1509 
