### PR TITLE
1526: Fix content alignment utilities

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -170,6 +170,7 @@
 
   p {
     @include p-max-width;
+    @include align-text;
     margin-bottom: 0;
   }
 
@@ -289,8 +290,24 @@
   max-width: 60em;
 }
 
+@mixin align-text {
+  .u-align--center & {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .u-align--left & {
+    margin-right: auto;
+  }
+
+  .u-align--right & {
+    margin-left: auto;
+  }
+}
+
 @mixin vf-heading-1 {
   @include heading-max-width--short;
+  @include align-text;
   font-size: 2rem;
   font-weight: 300;
   line-height: 1.3125;
@@ -303,6 +320,7 @@
 
 @mixin vf-heading-2 {
   @include heading-max-width--short;
+  @include align-text;
   font-size: 1.75rem;
   font-weight: 300;
   line-height: 1.2857;
@@ -315,6 +333,7 @@
 
 @mixin vf-heading-3 {
   @include heading-max-width--long;
+  @include align-text;
   font-size: 1.5rem;
   font-weight: 300;
   line-height: 1.333;
@@ -327,6 +346,7 @@
 
 @mixin vf-heading-4 {
   @include heading-max-width--long;
+  @include align-text;
   font-size: 1.375rem;
   font-weight: 300;
   line-height: 1.2727;
@@ -339,6 +359,7 @@
 
 @mixin vf-heading-5 {
   @include p-max-width;
+  @include align-text;
   font-size: 1.125rem;
   font-weight: 300;
   line-height: 1.333;
@@ -351,6 +372,7 @@
 
 @mixin vf-heading-6 {
   @include p-max-width;
+  @include align-text;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5;

--- a/scss/_utilities_content-align.scss
+++ b/scss/_utilities_content-align.scss
@@ -11,6 +11,8 @@
 @mixin vf-u-align--center {
   .u-align--center {
     justify-content: center !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
     text-align: center !important;
   }
 }
@@ -19,6 +21,7 @@
 @mixin vf-u-align--left {
   .u-align--left {
     justify-content: flex-start !important;
+    margin-right: auto !important;
     text-align: left !important;
   }
 }
@@ -27,6 +30,7 @@
 @mixin vf-u-align--right {
   .u-align--right {
     justify-content: flex-end !important;
+    margin-left: auto !important;
     text-align: right !important;
   }
 }


### PR DESCRIPTION
## Done

- Added margin overrides to `.u-align` utilities to account for `max-width` inclusion
- Added a small mixin for base typography so that if a parent `<div>` has a `.u-align` utility it properly defines the margins

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/utilities/align/
- Check that the three paragraphs in the cards are aligned as expected
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/headings/default/
- Add the class `u-align--center` to the `<body>` tag
- Check that all the headings align to the centre, and that they keep their max-widths (so there should be margins left and right of the heading)

## Details

Fixes #1478, fixes #1526 
