### PR TITLE
1477: Add close button to notification pattern

### DIFF
--- a/docs/en/patterns/notification.md
+++ b/docs/en/patterns/notification.md
@@ -7,7 +7,7 @@ table_of_contents: false
 
 ### .p-notification
 
-Notifications are used to display global information. A notification will display at the top and fill the full width of the page. A notification can be a default, caution, negative or position.
+Notifications are used to display global information. A notification will display at the top and fill the full width of the page. A notification can be a default, caution, negative or position. You can also include a close button using the `p-icon--close` pattern, although you will need to implement the click function yourself.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/notifications/notifications/"
     class="js-example">

--- a/examples/patterns/notifications/notifications.html
+++ b/examples/patterns/notifications/notifications.html
@@ -4,8 +4,16 @@ title: Notifications / Default
 category: _patterns
 ---
 
-<div class="p-notification">
+<div class="p-notification" id="notification">
   <p class="p-notification__response">
     Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt ipsum nemo autem reiciendis nulla tempore natus repudiandae dolorem. Corporis maxime, iure maiores repellat, odit facilis!
   </p>
+  <button class="p-icon--close" aria-label="Close notification" onclick="closeNotification('notification')">Close</button>
 </div>
+
+<script>
+function closeNotification(target) {
+  var notification = document.getElementById(target);
+  notification.style.display = 'none';
+}
+</script>

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -10,6 +10,7 @@
   border-top-width: 3px;
   box-shadow: 0 1px 5px 1px transparentize($color-x-dark, .8);
   color: $color-dark;
+  display: flex;
   font-size: $sp-medium;
   overflow: hidden;
   padding: .625rem;
@@ -35,6 +36,7 @@
       background-repeat: no-repeat;
       background-size: 16px 16px;
       margin: 0;
+      padding-right: $sp-small;
       text-align: left;
     }
 
@@ -46,6 +48,13 @@
     &__action {
       border-bottom: 0;
       margin-left: .3125rem;
+    }
+
+    .p-icon--close {
+      background-size: $sp-medium;
+      border: 0;
+      margin: 0 -#{$sp-xx-small} auto auto;
+      padding: $sp-small;
     }
   }
 


### PR DESCRIPTION
## Done

- Added `.p-notification__close` element to the notification pattern (optional) as per the [new design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Notifications)
- Edited default notification example to show it in action

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/notifications/notifications/
- Check that the close button follows the [new design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Notifications)
- Check that the example works (closes the notification on click)

## Details

Fixes #1477 
