### PR TITLE
Minor sidebar navigation fixes

### DIFF
--- a/examples/patterns/navigation/sidebar.html
+++ b/examples/patterns/navigation/sidebar.html
@@ -4,7 +4,7 @@ title: Navigation / Sidebar
 category: _patterns
 ---
 
-<div class="row" style="max-width: 100%">
+<div class="row">
   <div class="col-4">
     <div class="p-navigation--sidebar">
       <header id="navigation" role="banner">

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -54,9 +54,8 @@
 
     .sidebar__content {
       background: $color-x-light;
+      margin-top: $sp-small;
       padding-bottom: $sp-medium;
-      position: absolute;
-      top: $sp-x-large;
       width: 100%;
 
       @media (min-width: $breakpoint-navigation-threshold + 1) {


### PR DESCRIPTION
## Done

- Removed inline styles from sidebar navigation example
- Removed `position: absolute` from sidebar content as it should be dictated by the grid

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/sidebar/
- Check there are no inline styles in the markup
- Check that the pattern still works properly

## Details

Fixes #1533, fixes #1542 
