### PR TITLE
1556: Change code-snippet border to mid-light

### DIFF
--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -5,7 +5,7 @@
   // Default code snippet
   .p-code-snippet {
     background-color: $color-x-light;
-    border: 1px solid $color-mid-dark;
+    border: 1px solid $color-mid-light;
     border-radius: 2px;
     color: $color-dark;
     display: flex;
@@ -37,7 +37,7 @@
       background-repeat: no-repeat;
       background-size: $sp-medium;
       border-color: transparent;
-      border-left: 1px solid $color-mid-dark;
+      border-left: 1px solid $color-mid-light;
       border-radius: 0;
       display: block;
       flex: 1;
@@ -51,7 +51,7 @@
 
       &:hover {
         border-color: transparent;
-        border-left: 1px solid $color-mid-dark;
+        border-left: 1px solid $color-mid-light;
       }
     }
   }


### PR DESCRIPTION
## Done

- Changed border color of `.p-code-snippet` to `$color-mid-light` to match [design spec](https://github.com/ubuntudesign/vanilla-design/blob/master/Code/code.md)

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/code-snippet/
- Check that the border color of the pattern (including the inner one) is now `#cdcdcd` instead of `#666666`

## Details

Fixes #1556 
