### PR TITLE
Remove duplicate instance of icons in docs

### DIFF
--- a/docs/en/patterns/icons.md
+++ b/docs/en/patterns/icons.md
@@ -15,13 +15,11 @@ Class name  |
 `p-icon--minus` |
 `p-icon--expand` |
 `p-icon--collapse` |
-`p-icon--collapse` |
 `p-icon--spinner` |
 `p-icon--chevron` |
 `p-icon--close` |
 `p-icon--help` |
 `p-icon--information` |
-`p-icon--help` |
 `p-icon--delete` |
 `p-icon--external` |
 `p-icon--contextual-menu` |


### PR DESCRIPTION
## Done

Remove duplicate instance of icons in docs

## QA

- Pull code
- Run docs
- View 'Icons' section
- Ensure there are no duplicates

## Details

Fixes #1568
