### PR TITLE
Update hover color of strong link

### DIFF
--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -28,7 +28,7 @@
       }
 
       &:hover {
-        color: currentColor;
+        color: $color-link;
         text-decoration: underline;
       }
     }


### PR DESCRIPTION
## Done

Update hover color of strong link

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Ensure strong link hover is blue link color

## Details

Fixes #1575 
