### PR TITLE
Fix sidebar nav having a constant height

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -14,6 +14,7 @@
       $border-color: if(lightness($color-navigation-background) > 50, $color-mid-light, transparent),
       $text-color: if(lightness($color-navigation-background) > 70, $color-dark, $color-light)
     );
+    height: $sp-xxx-large;
   }
 }
 
@@ -25,6 +26,7 @@
       $text-color: $color-dark
     );
     border-bottom: 0;
+    height: auto;
 
     .p-navigation__logo {
       margin: 0 $sp-medium 0 0;
@@ -149,7 +151,6 @@
   background-color: $background-color;
   border-bottom: 1px solid $border-color;
   color: $text-color;
-  height: $sp-xxx-large;
   margin-top: 0;
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Done

- Added height: auto to sidebar nav so it isn't always 3rem

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/sidebar/
- Check that the height of the sidebar nav is the entire component, not 3rem
