### PR TITLE
Fix notifications.scss linting error

### DIFF
--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -53,7 +53,7 @@
     .p-icon--close {
       background-size: $sp-medium;
       border: 0;
-      margin: 0 -#{$sp-xx-small} auto auto;
+      margin: 0 -#{$sp-xx-small} auto auto; // sass-lint:disable-line space-around-operator
       padding: $sp-small;
     }
   }


### PR DESCRIPTION
## Done

- Disabled a single line of sass linting because the Jenkins sass lint throws a fit with negative value variables
