### PR TITLE
Add file size check to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
 script:
   - yarn run test
   - yarn run build-examples
+  - tests/file-size-lint.sh
   - percy snapshot --widths "375,1280" _jekyll/_site/ --baseurl "/vanilla-framework"
   - sass --no-cache --sourcemap=none scss/build.scss build/css/build.css
 notifications:

--- a/tests/file-size-lint.sh
+++ b/tests/file-size-lint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 FILE='build/css/build.min.css'
-if [ ! -f $FILE ]
-then
+if [ ! -f $FILE ]; then
   echo 'ERROR: Build file could not be found or is not readable. Please build first with `./run build`'
   exit 1
 fi
@@ -11,8 +10,7 @@ CURRENTSIZE=$(du -b $FILE | cut -f 1)
 REPONSESTART='Your generated CSS is '
 REPONSEJOIN=' with a threshold of '
 MESSAGE=$REPONSESTART$CURRENTSIZE$REPONSEJOIN$THRESHOLD
-if [ $CURRENTSIZE -lt $THRESHOLD ]
-then
+if [ $CURRENTSIZE -lt $THRESHOLD ]; then
   STATUS='SUCCESS: '
   EXIT=0
 else

--- a/tests/file-size-lint.sh
+++ b/tests/file-size-lint.sh
@@ -7,16 +7,14 @@ fi
 
 THRESHOLD=400000
 CURRENTSIZE=$(du -b $FILE | cut -f 1)
-REPONSESTART='Your generated CSS is '
-REPONSEJOIN=' with a threshold of '
-MESSAGE=$REPONSESTART$CURRENTSIZE$REPONSEJOIN$THRESHOLD
+MESSAGE="Your generated CSS is ${CURRENTSIZE} with a threshold of ${THRESHOLD}"
 if [ $CURRENTSIZE -lt $THRESHOLD ]; then
-  STATUS='SUCCESS: '
+  STATUS='SUCCESS'
   EXIT=0
 else
-  STATUS='ERROR: '
+  STATUS='ERROR'
   EXIT=1
 fi
 
-echo $STATUS$MESSAGE
+echo "${STATUS}: ${MESSAGE}"
 exit $EXIT

--- a/tests/file-size-lint.sh
+++ b/tests/file-size-lint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+FILE='build/css/build.min.css'
+if [ ! -f $FILE ]
+then
+  echo 'ERROR: Build file could not be found or is not readable. Please build first with `./run build`'
+  exit 1
+fi
+
+THRESHOLD=400000
+CURRENTSIZE=$(du -b $FILE | cut -f 1)
+REPONSESTART='Your generated CSS is '
+REPONSEJOIN=' with a threshold of '
+MESSAGE=$REPONSESTART$CURRENTSIZE$REPONSEJOIN$THRESHOLD
+if [ $CURRENTSIZE -lt $THRESHOLD ]
+then
+  STATUS='SUCCESS: '
+  EXIT=0
+else
+  STATUS='ERROR: '
+  EXIT=1
+fi
+
+echo $STATUS$MESSAGE
+exit $EXIT

--- a/tests/file-size-lint.sh
+++ b/tests/file-size-lint.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
+
+THRESHOLD=400000
 FILE='build/css/build.min.css'
+
 if [ ! -f $FILE ]; then
   echo 'ERROR: Build file could not be found or is not readable. Please build first with `./run build`'
   exit 1
 fi
 
-THRESHOLD=400000
 CURRENTSIZE=$(du -b $FILE | cut -f 1)
-MESSAGE="Your generated CSS is ${CURRENTSIZE} with a threshold of ${THRESHOLD}"
-if [ $CURRENTSIZE -lt $THRESHOLD ]; then
-  STATUS='SUCCESS'
-  EXIT=0
-else
-  STATUS='ERROR'
-  EXIT=1
+if [ ${CURRENTSIZE} -gt ${THRESHOLD} ]; then
+  echo "ERROR: Your CSS is over ${THRESHOLD} (it's ${CURRENTSIZE})"
+  exit 1
 fi
 
-echo "${STATUS}: ${MESSAGE}"
-exit $EXIT
+echo "Success: your generated CSS is ${CURRENTSIZE} (under ${THRESHOLD})"


### PR DESCRIPTION
## Done
Add filesize check to CI with a threshold

## QA
- Run `./run clean`
- Run `tests/file-size-lint.sh` and see that it errors because it cant find the build file
- Run `./run build`
- Run `tests/file-size-lint.sh` and see it passes and outputs the current file size of the build with the threshold

_The threshold is set to 400kb which is way to high. Lets half that and more as soon as possible_
