### PR TITLE
Creates “Tables” category

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -144,6 +144,21 @@ navigation:
   - location: patterns/pull-quote.md
     title: Quotes
 
+- title: Tables
+  children:
+
+  - location: base/table.md
+    title: Table
+
+  - location: patterns/table-sortable.md
+    title: Table sortable
+
+  - location: patterns/table-expanding.md
+    title: Table expanding
+
+  - location: patterns/table-mobile-card.md
+    title: Table mobile card
+
 - title: Interactive elements
   children:
 
@@ -179,18 +194,6 @@ navigation:
 
   - location: patterns/switch.md
     title: Switch
-
-  - location: base/table.md
-    title: Table
-
-  - location: patterns/table-sortable.md
-    title: Table sortable
-
-  - location: patterns/table-expanding.md
-    title: Table expanding
-
-  - location: patterns/table-mobile-card.md
-    title: Table mobile card
 
   - location: patterns/tooltips.md
     title: Tooltips


### PR DESCRIPTION
Fixes #1590 by creating a “Tables” category for “Table”, “Table sortable”, “Table expanding”, and “Table mobile card”.