### PR TITLE
Removes sidebar link to vanillaframework.io

### DIFF
--- a/docs/template.html
+++ b/docs/template.html
@@ -331,10 +331,6 @@
               {% endfor %}
               {% endfor %}
             </ul>
-            <hr>
-            <ul class="p-list u-no-margin--top">
-              <li><a class="p-link--external sidebar__link" href="https://vanillaframework.io/">vanillaframework.io</a></li>
-            </ul>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Now that docs.vanillaframework.io has the same header navigation as the rest of vanillaframework.io ([vanillaframework.io#117](https://github.com/canonical-websites/vanillaframework.io/issues/117)), with the “Vanilla” wordmark linked to [vanillaframework.io/](https://vanillaframework.io/), it’s redundant to link to vanillaframework.io in the sidebar as well.