### PR TITLE
Add a title to the search input in the docs template

### DIFF
--- a/docs/template.html
+++ b/docs/template.html
@@ -304,7 +304,7 @@
               <option value="latest">v1.6.6</option>
             </select>
             <form class="p-search-box" style="margin-top: 1rem" onsubmit="return false">
-              <input type="search" id="search-docs" class="p-search-box__input" name="search" placeholder="Search components" oninput="filterDocs()" required>
+              <input type="search" id="search-docs" class="p-search-box__input" name="search" placeholder="Search components" oninput="filterDocs()" title="Search the documentation" required />
               <button type="reset" class="p-search-box__reset" alt="reset" onclick="resetFilter()"><i class="p-icon--close"></i></button>
               <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
             </form>


### PR DESCRIPTION
## Done
Added a `title` to the input to change the hover tooltip. I could not remove the required without making the reset button always visible. This seems to resolve the issue though.

## QA

- Pull code
- Run `cd docs`
- Run `./run`
- Open http://0.0.0.0:8104/en/
- Hover over the search box and see it says "Search the documentation" instead of "Please fill in this field."
- Enter some characters and see the reset (cross) icon appears

## Details
Fixes https://github.com/canonical-websites/vanillaframework.io/issues/124
