### PR TITLE
Remove redundant Form docs pages

### DIFF
--- a/docs/en/base/forms.md
+++ b/docs/en/base/forms.md
@@ -104,7 +104,7 @@ Adding the ```[disabled="disabled"]``` attribute to an input will prevent user i
 
 Applying the classes ```.is-error```, ```.is-caution``` or ```.is-success``` to an input will style that element differently to provide visual feedback in case there is an error, caution or success notification related to the element.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/forms/form-validation/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/forms/form-validation/"
     class="js-example">
     View example of form validation patterns
 </a>

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -153,12 +153,6 @@ navigation:
   - location: base/forms.md
     title: Forms
 
-  - location: patterns/forms.md
-    title: Form layout
-
-  - location: patterns/form-validation.md
-    title: Form validation
-
   - location: patterns/links.md
     title: Links
 


### PR DESCRIPTION
## Done

- Fixed an error where Form Validation did not render an example
- Removed redundant Forms pages in the docs from the `metadata.yaml`

## QA

- Pull code
- Run `cd docs && ./run serve --watch`
- Open http://0.0.0.0:8104
- Check that the navigation has "Forms" in the sidebar nav under "Interactive elements", and there is no mention of "Forms layout" or "Form validation"
- Check that Form validation example renders
