### PR TITLE
1679: Fix navigation hover state colour

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -235,7 +235,7 @@ $nav-border-bottom-thickness: $px;
       }
 
       &:hover {
-        background-color: $color-light;
+        background-color: darken($color-navigation-background, 3%);
       }
     }
 


### PR DESCRIPTION
## Done

- Fixed a bug where nav hover state was hard-coded to `$color-light`, now is just 3% darker than whatever is set to be `$color-navigation-background`

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/default/
- Check that the hover state of the nav links changes the background colour to a darker gray
- Edit `$color-navigation-background` in `_settings_colors.scss` to any other colour
- Go back to http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/default/ and check that the hover state is a slightly darker version of this colour

## Details

Fixes #1679 
