### PR TITLE
Re-add max-height of card header image

### DIFF
--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -41,7 +41,11 @@
     margin-bottom: $spv-intra--scaleable;
     padding-bottom: $spv-intra--scaleable - $px; // border compensation
 
-    >.p-link--soft {
+    > img {
+      max-height: 2rem;
+    }
+
+    > .p-link--soft {
       display: inline-block;
       overflow: auto;
     }


### PR DESCRIPTION
## Done

- Added a max-height of 2rem to img elements in a .p-card__header div

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/card/header/
- Check that the header image has a max-height of 2rem

## Details

Fixes #1659 
