### PR TITLE
Increase space under ul to address issue on insights page 

### DIFF
--- a/scss/_base_lists.scss
+++ b/scss/_base_lists.scss
@@ -14,7 +14,7 @@
 
   ol,
   ul {
-    margin-bottom: 0;
+    margin-bottom: $spv-inter--scaleable;
     margin-left: $sph-inter;
     margin-top: 0;
     padding-left: $sph-inter;

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -274,7 +274,7 @@
     padding-top: map-get($nudges, nudge--muted) + map-get($sp-before, muted);
   }
 
-
+  ul,
   p,
   h5,
   h6,


### PR DESCRIPTION
## Done
Aims to address https://github.com/vanilla-framework/vanilla-framework/issues/1673

Since the uls on insights have no classes and I understand they are coming from a cms, so classes cannot be added, I've added the default vertical spacing to them. This will need to be overriden in cases where it is not necessary with the no margin bottom utility.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- [Add additional steps]

## Details

Fixes #1673 

## Screenshots

[if relevant, include a screenshot]
