### PR TITLE
1658: Fix issue with navigation logo sizing

### DIFF
--- a/examples/patterns/navigation/default.html
+++ b/examples/patterns/navigation/default.html
@@ -7,7 +7,7 @@ category: _patterns
   <div class="p-navigation__banner">
     <div class="p-navigation__logo">
       <a class="p-navigation__link" href="#">
-        <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="" class="p-navigation__image" />
+        <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="" width="95" />
       </a>
     </div>
     <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/examples/patterns/search-box/navigation.html
+++ b/examples/patterns/search-box/navigation.html
@@ -7,7 +7,7 @@ category: _patterns
   <div class="p-navigation__banner">
     <div class="p-navigation__logo">
       <a class="p-navigation__link" href="#">
-        <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="" class="p-navigation__image" />
+        <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="" width="95" />
       </a>
     </div>
     <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -196,7 +196,9 @@ $nav-border-bottom-thickness: $px;
   }
 
   &__image {
-    vertical-align: top;
+    align-self: center;
+    max-height: 2rem;
+    min-height: 1.5rem;
   }
 
   &__link {
@@ -259,12 +261,12 @@ $nav-border-bottom-thickness: $px;
 
   &__logo {
     display: flex;
+    height: 3rem;
     flex: 0 0 auto;
-    margin: $spv-intra--expanded $sph-intra auto $grid-margin-width;
+    margin: 0 $sph-intra 0 $grid-margin-width;
 
-    .p-navigation__image {
-      height: 24px;
-      width: auto;
+    .p-navigation__link {
+      display: flex;
     }
   }
 


### PR DESCRIPTION
## Done

- Set a height of 3rem on navigation logos
- Made it so logo can be between 1.5rem (24px) and 2rem (32px) in height
- Updated nav examples to depict 24px high Vanilla logo

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/default/
- Check that the nav looks the same
- Delete `<div class="p-navigation__banner">` from the DOM and check that the nav height is still 3rem
- Undo, now delete `<nav class="p-navigation__nav" role="menubar">` and check that the nav height is still 3rem
- Undo, now remove `width="95"` from the nav logo, and check that the logo reaches the max-height (32px) and is still vertically centered

## Details

Fixes #1658 
