### PR TITLE
Make u-vertically-center work with img elements

### DIFF
--- a/scss/_utilities_vertically-center.scss
+++ b/scss/_utilities_vertically-center.scss
@@ -6,6 +6,10 @@
     .u-vertically-center {
       align-items: center !important;
       display: flex !important;
+
+      > img {
+        align-self: center !important;
+      }
     }
   }
 }


### PR DESCRIPTION
## Done

- Added an `img` child selector to `u-vertically-center` to override the default `align-self: flex-start` behaviour

## QA

- Go to http://www.ubuntu.com-pr-2859.run.demo.haus/cloud/public-cloud
- Open Chrome Dev Tools and change `align-self: flex-start` to `align-self: center` from the card img elements
- Check they are now vertically centered
- Check Percy that I haven't inadvertently broken anything

## Details

Fixes #1669 

## Screenshots
Fix applied on [vanilla test on ubuntu](http://www.ubuntu.com-pr-2859.run.demo.haus/cloud/public-cloud)
![screenshot](https://user-images.githubusercontent.com/25733845/38564340-d9d10246-3cd6-11e8-8fc9-dc84add210f2.png)
