### PR TITLE
fix row in nav when no p-navigation__row class is present

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -302,10 +302,9 @@ $nav-border-bottom-thickness: $px;
     }
   }
 
-  &__row {
+  &__row,
+  & .row {
     display: flex;
-    // XXX: these zero out the default row padding to avoid doubling.
-    // I think a more robust soljution would be to wrap the nav in a row, rather than nest one ins it and override it.
     padding-left: 0;
     padding-right: 0;
     width: 100%;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -29,6 +29,10 @@ $nav-border-bottom-thickness: $px;
     flex-direction: column;
     height: auto;
 
+    .p-navigation__banner .row {
+      flex-direction: row;
+    }
+
     .sidebar__cta {
       margin-top: 0;
 
@@ -352,5 +356,4 @@ $nav-border-bottom-thickness: $px;
     position: relative;
     right: unset;
   }
-
 }


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- [Add additional steps]

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
