### PR TITLE
Separate u-align and u-align-text utilities

### DIFF
--- a/examples/utilities/align.html
+++ b/examples/utilities/align.html
@@ -3,15 +3,17 @@ layout: default
 title: Align
 category: _utilities
 ---
-
-<div class="p-card u-align--center">
-  <p>I am centered text.</p>
-</div>
-
-<div class="p-card u-align--left">
-  <p>I am left text.</p>
-</div>
-
-<div class="p-card u-align--right">
-  <p>I am right text.</p>
+<div>
+  <div class="u-align--center">
+    <img src="http://placehold.it/160x100?text=Center" alt="" />
+  </div>
+  <div class="u-align--left">
+    <img src="http://placehold.it/160x100?text=Left" alt="" />
+  </div>
+  <div class="u-align--right">
+    <img src="http://placehold.it/160x100?text=Right" alt="" />
+  </div>
+  <p class="u-align-text--center">Centered text</h3>
+  <p class="u-align-text--left">Left-aligned text</h3>
+  <p class="u-align-text--right">Right-aligned text</h3>
 </div>

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -145,7 +145,6 @@
 
   p {
     @extend %paragraph;
-    @extend %align-text;
     @include p-max-width;
 
     &:empty {
@@ -318,7 +317,6 @@
   // Heading placeholders
 
   %vf-heading-1 {
-    @extend %align-text;
     @include heading-max-width--short;
     font-size: pow($ms-ratio, 8) * 1rem;
     font-style: normal;
@@ -330,7 +328,6 @@
   }
 
   %vf-heading-2 {
-    @extend %align-text;
     @include heading-max-width--short;
     font-size: pow($ms-ratio, 6) * 1rem;
     font-style: normal;
@@ -342,7 +339,6 @@
   }
 
   %vf-heading-3 {
-    @extend %align-text;
     @include heading-max-width--long;
     font-size: pow($ms-ratio, 4) * 1rem;
     font-style: normal;
@@ -354,7 +350,6 @@
   }
 
   %vf-heading-4 {
-    @extend %align-text;
     @include heading-max-width--long;
     font-size: pow($ms-ratio, 2) * 1rem;
     font-style: normal;
@@ -367,7 +362,6 @@
 
   %vf-heading-5 {
     @extend %paragraph;
-    @extend %align-text;
     @include p-max-width;
     font-size: 1rem;
     font-style: normal;
@@ -376,7 +370,6 @@
 
   %vf-heading-6 {
     @extend %paragraph;
-    @extend %align-text;
     @include p-max-width;
     font-size: 1rem;
     font-style: italic;
@@ -421,21 +414,6 @@
 
   %bold {
     font-weight: 400;
-  }
-}
-
-%align-text {
-  .u-align--center & {
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  .u-align--left & {
-    margin-right: auto;
-  }
-
-  .u-align--right & {
-    margin-left: auto;
   }
 }
 

--- a/scss/_utilities_content-align.scss
+++ b/scss/_utilities_content-align.scss
@@ -5,33 +5,51 @@
   @include vf-u-align--center;
   @include vf-u-align--left;
   @include vf-u-align--right;
+  @include vf-u-align--text;
 }
 
-// Center all text within an element
+// Center all children within an element
 @mixin vf-u-align--center {
   .u-align--center {
     justify-content: center !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
     text-align: center !important;
   }
 }
 
-// Left align all text within an element
+// Left align all children within an element
 @mixin vf-u-align--left {
   .u-align--left {
     justify-content: flex-start !important;
-    margin-right: auto !important;
     text-align: left !important;
   }
 }
 
-// Right align all text within an element
+// Right align all children within an element
 @mixin vf-u-align--right {
   .u-align--right {
     justify-content: flex-end !important;
-    margin-left: auto !important;
     text-align: right !important;
+  }
+}
+
+// Separate utility for aligning text
+@mixin vf-u-align--text {
+  .u-align-text {
+    &--center {
+      margin-right: auto !important;
+      margin-left: auto !important;
+      text-align: center !important;
+    }
+
+    &--left {
+      margin-right: auto !important;
+      text-align: left !important;
+    }
+
+    &--right {
+      margin-left: auto !important;
+      text-align: right !important;
+    }
   }
 }
 


### PR DESCRIPTION
## Done

- Separated `.u-align-text` from `u-align`
- Removed `u-align` utilities from base typography file
- Updated "Align" example to reflect the separation
- **Note:** this will necessitate some markup updates in the uncommon instances where we use centered and right-aligned text

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/utilities/align/
- Check that it all looks good

## Details

Fixes #1677 
