### PR TITLE
1721: Remove margins on .p-code-snippet__action

### DIFF
--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -20,14 +20,6 @@
 
     & + & {
       margin-top: 0; // overrides p + p
-
-      button {
-        margin-top: 0; // overrides  p + p button {}
-      }
-    }
-
-    button {
-      margin-bottom: 0;
     }
 
     &__input {
@@ -59,6 +51,8 @@
       border-radius: 0;
       display: block;
       height: 100%;
+      margin-bottom: 0;
+      margin-top: 0;
       padding: 0;
       position: absolute;
       right: 0;


### PR DESCRIPTION
## Done

- Set `margin-bottom` and `margin-top` to 0 on `.p-code-snippet__action`

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/code-snippet/
- Edit the HTML so that there is a `<p>` before the code snippet and check the button is still aligned
- Add a second p-code-snippet and check the buttons are aligned
- Change the `<div>`s to `<p>`s and check the buttons are aligned

## Details

Fixes #1721 
