### PR TITLE
Revert heading icon changes from #1745, and amend with new spacing

### DIFF
--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -3,17 +3,32 @@
 @mixin vf-p-heading-icon {
 
   .p-heading-icon {
+    margin-bottom: $spv-inter--regular;
+
+    @media (min-width: $breakpoint-medium) {
+      margin-bottom: 0;
+    }
+
     &__header {
       display: flex;
+      margin-bottom: $spv-intra--expanded;
+    }
+
+    &__title {
+      margin-bottom: 0;
+      padding-top: 0;
     }
 
     &__img {
-      align-self: flex-start;
       flex-shrink: 0;
-      margin: auto $sph-inter auto 0  ;
-      max-height: map-get($icon-sizes, thumb);
-      max-width: map-get($icon-sizes, thumb);
-      padding-bottom: $spv-inter--regular; // sets white space under to the min white space under the smalllest heading that can sit next to it (muted-heading)
+      height: map-get($icon-sizes, heading-icon--small);
+      margin-right: $sph-intra;
+      width: map-get($icon-sizes, heading-icon--small);
+
+      @media (min-width: $breakpoint-medium) {
+        height: map-get($icon-sizes, heading-icon);
+        width: map-get($icon-sizes, heading-icon);
+      }
     }
   }
 }

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -97,7 +97,9 @@ $icon-sizes: (
   default: 2 * $sp-unit,
   thumb--card: 4 * $sp-unit,
   social: 5 * $sp-unit,
+  heading-icon--small: $sp-unit * 5,
   thumb--small: $sp-unit * 6,
+  heading-icon: $sp-unit * 7.5,
   thumb: $sp-unit * 10,
   thumb--large: $sp-unit * 12
 );


### PR DESCRIPTION
## Done

- Reverted the work done on #1745 as it was causing issues on several instances of the heading icon pattern (see screenshot)
- Rewrote the pattern slightly to make it compatible with the new spacing variables
- Added heading icon sizes to `$icon-sizes` map

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/heading-icon/
- Check that the heading icon pattern looks as it does on https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon/ (there will be some minor spacing differences, but the icon itself should be identical)

## Screenshots
![screenshot](https://user-images.githubusercontent.com/25733845/39131686-fd2cfba6-4707-11e8-9b90-248c04032051.png)

