### PR TITLE
Fixes for various Vanilla docs bugs

### DIFF
--- a/docs/en/base/forms.md
+++ b/docs/en/base/forms.md
@@ -114,8 +114,3 @@ Applying the classes ```.is-error```, ```.is-caution``` or ```.is-success``` to 
 ### Design
 
 * [Forms design](https://github.com/ubuntudesign/vanilla-design/tree/master/Forms)
-
-### Related
-
-* [Forms layout pattern](/en/patterns/forms)
-* [Form validation pattern](/en/patterns/form-validation)

--- a/examples/patterns/card/header.html
+++ b/examples/patterns/card/header.html
@@ -5,7 +5,7 @@ category: _patterns
 ---
 
 <div class="p-card">
-  <img class="p-card__thumbnail" src="http://placehold.it/200x32?text=header image" alt="header image" />
+  <img class="p-card__thumbnail" src="https://via.placeholder.com/200x32?text=header image" alt="header image" />
   <hr class="u-sv1">
   <h3 class="p-card__title">Title</h3>
   <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipisicing.</p>

--- a/examples/patterns/image/bordered.html
+++ b/examples/patterns/image/bordered.html
@@ -4,5 +4,5 @@ title: Image / with border
 category: _patterns
 ---
 
-<img class="p-image--bordered" src="http://via.placeholder.com/350x350?text=*" alt="">
+<img class="p-image--bordered" src="https://via.placeholder.com/350x350?text=*" alt="">
 

--- a/examples/patterns/image/shadowed.html
+++ b/examples/patterns/image/shadowed.html
@@ -4,5 +4,5 @@ title: Image / with shadow
 category: _patterns
 ---
 
-<img class="p-image--shadowed" src="http://via.placeholder.com/350x350?text=*" alt="">
+<img class="p-image--shadowed" src="https://via.placeholder.com/350x350?text=*" alt="">
 

--- a/examples/patterns/inline-images.html
+++ b/examples/patterns/inline-images.html
@@ -7,21 +7,21 @@ category: _patterns
 
 <ul class="p-inline-images">
   <li class="p-inline-images__item">
-    <img src="http://placehold.it/150x200" alt="Placeholder image" />
+    <img src="https://via.placeholder.com/150x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="http://placehold.it/175x200" alt="Placeholder image" />
+    <img src="https://via.placeholder.com/175x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="http://placehold.it/150x200" alt="Placeholder image" />
+    <img src="https://via.placeholder.com/150x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="http://placehold.it/175x200" alt="Placeholder image" />
+    <img src="https://via.placeholder.com/175x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="http://placehold.it/150x200" alt="Placeholder image" />
+    <img src="https://via.placeholder.com/150x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="http://placehold.it/175x200" alt="Placeholder image" />
+    <img src="https://via.placeholder.com/175x200" alt="Placeholder image" />
   </li>
 </ul>

--- a/examples/patterns/matrix.html
+++ b/examples/patterns/matrix.html
@@ -6,63 +6,63 @@ category: _patterns
 
 <ul class="p-matrix u-clearfix">
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+    <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
       <p class="p-matrix__desc">Short description</p>
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+    <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
       <p class="p-matrix__desc">Short description</p>
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+    <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
       <p class="p-matrix__desc">Short description</p>
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+    <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
       <p class="p-matrix__desc">Short description</p>
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+    <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
       <p class="p-matrix__desc">Short description</p>
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+    <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
       <p class="p-matrix__desc">Short description</p>
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+    <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
       <p class="p-matrix__desc">Short description</p>
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+    <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
       <p class="p-matrix__desc">Short description</p>
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+    <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
       <p class="p-matrix__desc">Short description</p>

--- a/examples/patterns/media-object/media-object-circ-img.html
+++ b/examples/patterns/media-object/media-object-circ-img.html
@@ -5,7 +5,7 @@ category: _patterns
 ---
 
 <div class="p-media-object">
-  <img src="http://placehold.it/72x72" class="p-media-object__image is-round">
+  <img src="https://via.placeholder.com/72x72" class="p-media-object__image is-round">
   <div class="p-media-object__details">
     <h3 class="p-media-object__title">
       <a href="#">Person name</a>

--- a/examples/patterns/media-object/media-object-large.html
+++ b/examples/patterns/media-object/media-object-large.html
@@ -5,7 +5,7 @@ category: _patterns
 ---
 
 <div class="p-media-object--large">
-  <img src="http://placehold.it/96x96" class="p-media-object__image">
+  <img src="https://via.placeholder.com/96x96" class="p-media-object__image">
   <div class="p-media-object__details">
     <h1 class="p-media-object__title">Title</h1>
     <p class="p-media-object__content">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>

--- a/examples/patterns/media-object/media-object.html
+++ b/examples/patterns/media-object/media-object.html
@@ -5,7 +5,7 @@ category: _patterns
 ---
 
 <div class="p-media-object">
-  <img src="http://placehold.it/72x72" class="p-media-object__image">
+  <img src="https://via.placeholder.com/72x72" class="p-media-object__image">
   <div class="p-media-object__details">
     <h3 class="p-media-object__title">
       <a href="#">Event title</a>

--- a/examples/patterns/strips/accent.html
+++ b/examples/patterns/strips/accent.html
@@ -14,7 +14,7 @@ category: _patterns
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" />
     </div>
   </div>
 </section>

--- a/examples/patterns/strips/deep.html
+++ b/examples/patterns/strips/deep.html
@@ -14,7 +14,7 @@ category: _patterns
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" />
     </div>
   </div>
 </section>

--- a/examples/patterns/strips/image.html
+++ b/examples/patterns/strips/image.html
@@ -15,7 +15,7 @@ category: _patterns
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" />
     </div>
   </div>
 </section>
@@ -31,7 +31,7 @@ category: _patterns
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" />
     </div>
   </div>
 </section>

--- a/examples/patterns/strips/is-bordered.html
+++ b/examples/patterns/strips/is-bordered.html
@@ -14,7 +14,7 @@ category: _patterns
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" />
     </div>
   </div>
 </section>

--- a/examples/patterns/strips/shallow.html
+++ b/examples/patterns/strips/shallow.html
@@ -14,7 +14,7 @@ category: _patterns
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" />
     </div>
   </div>
 </section>

--- a/examples/patterns/tables/table-expanding.html
+++ b/examples/patterns/tables/table-expanding.html
@@ -29,7 +29,7 @@ category: _patterns
                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates architecto ipsa dolorum eaque rem expedita inventore voluptas odit aspernatur alias molestias facere, eum accusamus dolor, assumenda. Eaque, id! Dolorem perferendis reprehenderit eum, odio minima ad commodi earum non, iste suscipit.</p>
                     </div>
                     <div class="col-6">
-                        <img src="http://placehold.it/1024x325" alt="">
+                        <img src="https://via.placeholder.com/1024x325" alt="">
                     </div>
                 </div>
             </td>
@@ -48,7 +48,7 @@ category: _patterns
                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates architecto ipsa dolorum eaque rem expedita inventore voluptas odit aspernatur alias molestias facere, eum accusamus dolor, assumenda. Eaque, id! Dolorem perferendis reprehenderit eum, odio minima ad commodi earum non, iste suscipit.</p>
                     </div>
                     <div class="col-6">
-                        <img src="http://placehold.it/1024x325" alt="">
+                        <img src="https://via.placeholder.com/1024x325" alt="">
                     </div>
                 </div>
             </td>
@@ -67,7 +67,7 @@ category: _patterns
                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates architecto ipsa dolorum eaque rem expedita inventore voluptas odit aspernatur alias molestias facere, eum accusamus dolor, assumenda. Eaque, id! Dolorem perferendis reprehenderit eum, odio minima ad commodi earum non, iste suscipit.</p>
                     </div>
                     <div class="col-6">
-                        <img src="http://placehold.it/1024x325" alt="">
+                        <img src="https://via.placeholder.com/1024x325" alt="">
                     </div>
                 </div>
             </td>

--- a/examples/utilities/align.html
+++ b/examples/utilities/align.html
@@ -3,17 +3,15 @@ layout: default
 title: Align
 category: _utilities
 ---
-<div>
-  <div class="u-align--center">
-    <img src="http://placehold.it/160x100?text=Center" alt="" />
-  </div>
-  <div class="u-align--left">
-    <img src="http://placehold.it/160x100?text=Left" alt="" />
-  </div>
-  <div class="u-align--right">
-    <img src="http://placehold.it/160x100?text=Right" alt="" />
-  </div>
-  <p class="u-align-text--center">Centered text</h3>
-  <p class="u-align-text--left">Left-aligned text</h3>
-  <p class="u-align-text--right">Right-aligned text</h3>
+
+<div class="p-card u-align--center">
+  <p>I am centered text.</p>
+</div>
+
+<div class="p-card u-align--left">
+  <p>I am left text.</p>
+</div>
+
+<div class="p-card u-align--right">
+  <p>I am right text.</p>
 </div>

--- a/examples/utilities/image-position/bottom-left.html
+++ b/examples/utilities/image-position/bottom-left.html
@@ -7,7 +7,7 @@ category: _patterns
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom u-image-position--left" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" class="u-image-position--bottom u-image-position--left" />
     </div>
     <div class="col-6">
       <h2>Image position - bottom left</h2>

--- a/examples/utilities/image-position/bottom-right.html
+++ b/examples/utilities/image-position/bottom-right.html
@@ -11,7 +11,7 @@ category: _patterns
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom u-image-position--right" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" class="u-image-position--bottom u-image-position--right" />
     </div>
   </div>
 </section>

--- a/examples/utilities/image-position/bottom.html
+++ b/examples/utilities/image-position/bottom.html
@@ -11,7 +11,7 @@ category: _patterns
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" class="u-image-position--bottom" />
     </div>
   </div>
 </section>

--- a/examples/utilities/image-position/left.html
+++ b/examples/utilities/image-position/left.html
@@ -7,7 +7,7 @@ category: _patterns
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--left" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" class="u-image-position--left" />
     </div>
     <div class="col-6">
       <h2>Image position - left</h2>

--- a/examples/utilities/image-position/right.html
+++ b/examples/utilities/image-position/right.html
@@ -11,7 +11,7 @@ category: _patterns
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--right" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" class="u-image-position--right" />
     </div>
   </div>
 </section>

--- a/examples/utilities/image-position/top-left.html
+++ b/examples/utilities/image-position/top-left.html
@@ -7,7 +7,7 @@ category: _patterns
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top u-image-position--left" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" class="u-image-position--top u-image-position--left" />
     </div>
     <div class="col-6">
       <h2>Image position - top left</h2>

--- a/examples/utilities/image-position/top-right.html
+++ b/examples/utilities/image-position/top-right.html
@@ -11,7 +11,7 @@ category: _patterns
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top u-image-position--right" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" class="u-image-position--top u-image-position--right" />
     </div>
   </div>
 </section>

--- a/examples/utilities/image-position/top.html
+++ b/examples/utilities/image-position/top.html
@@ -11,7 +11,7 @@ category: _patterns
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top" />
+      <img src="https://via.placeholder.com/150x150" alt="Placeholder image" class="u-image-position--top" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Removed "Related" links from Forms page (there used to be separate pages, but they're now consolidated so are unnecessary not to mention 404ing)
- Reverted Align utility example page to reflect Vanilla 1.6.7, and will re-update when 1.7.0 is released
- Updated all instances of placeholder images with the new url over https

## QA

- Pull code
- Run `cd docs && ./run`
- Check that the Forms page has no related links
- Check that the Align page has the old markup (i.e. 3 full width cards, "This text is centre-aligned" etc)
- Check that images still load okay, for example in the inline images component, or the card etc

## Details

Fixes #1756, fixes #1758 
