### PR TITLE
Remove margin and padding from <code> + add vertical padding to <pre>

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -21,9 +21,7 @@
   }
 
   code {
-    @extend %default-text;
-    display: inline-block;
-    margin-bottom: $spv-intra + $spv-nudge-compensation - 2 * $px; // compensates for the borders around <pre>
+    display: inline;
     white-space: pre-wrap;
   }
 
@@ -36,8 +34,7 @@
     margin-bottom: $spv-inter--scaleable;
     margin-top: 0;
     overflow: auto;
-    padding-left: $sph-intra;
-    padding-right: $sph-intra;
+    padding: $spv-intra $sph-intra;
     text-align: left;
     text-shadow: none;
     white-space: nowrap;


### PR DESCRIPTION
## Done

- Removed default text behaviour from `<code>` as it's meant to be purely inline.
- Added vertical padding (`$spv-intra`) to `<pre>` blocks

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/code/
- Check that there is 0.5rem vertical padding on the `<pre>`
- Check that there is no margin or padding on the `<code>`

## Details

Fixes #1765 
