### PR TITLE
Remove negative margin from consecutive .p-matrix__desc

### DIFF
--- a/examples/patterns/matrix.html
+++ b/examples/patterns/matrix.html
@@ -9,63 +9,77 @@ category: _patterns
     <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
-      <p class="p-matrix__desc">Short description</p>
+      <div class="p-matrix__desc">
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+        <p>Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
+      </div>
     </div>
   </li>
   <li class="p-matrix__item">
     <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
-      <p class="p-matrix__desc">Short description</p>
+      <div class="p-matrix__desc">
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+      </div>
     </div>
   </li>
   <li class="p-matrix__item">
     <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
-      <p class="p-matrix__desc">Short description</p>
+      <p class="p-matrix__desc">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+      <p class="p-matrix__desc">Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
     </div>
   </li>
   <li class="p-matrix__item">
     <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
-      <p class="p-matrix__desc">Short description</p>
+      <div class="p-matrix__desc">
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
+      </div>
     </div>
   </li>
   <li class="p-matrix__item">
     <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
-      <p class="p-matrix__desc">Short description</p>
+      <p class="p-matrix__desc">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
     </div>
   </li>
   <li class="p-matrix__item">
     <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
-      <p class="p-matrix__desc">Short description</p>
+      <p class="p-matrix__desc">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
     </div>
   </li>
   <li class="p-matrix__item">
     <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
-      <p class="p-matrix__desc">Short description</p>
+      <p class="p-matrix__desc">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+      <p class="p-matrix__desc">Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
     </div>
   </li>
   <li class="p-matrix__item">
     <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
-      <p class="p-matrix__desc">Short description</p>
+      <div class="p-matrix__desc">
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+        <p>Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
+      </div>
     </div>
   </li>
   <li class="p-matrix__item">
     <img class="p-matrix__img" src="https://via.placeholder.com/60x60" alt="icon">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
-      <p class="p-matrix__desc">Short description</p>
+      <div class="p-matrix__desc">
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+      </div>
     </div>
   </li>
 </ul>

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -13,7 +13,6 @@
     margin-left: 0;
     padding-left: 0;
 
-
     &__item {
       border-top: 1px solid $color-mid-light;
       display: flex;
@@ -82,32 +81,13 @@
       }
     }
 
-    &__img,
-    &__content {
-      align-self: flex-start;
-    }
-
-    &__img + &__content > * {
-      display: flex;
-
-      &::before {
-        content: '';
-        display: block;
-        flex: 0 0 auto;
-        margin-bottom: $spv-intra--scaleable;
-        margin-right: $matrix-img-gutter;
-        min-height: 1px;
-        position: relative;
-        width: $matrix-img-width;
-      }
-    }
-
     &__img {
       // maintain image aspect ratio, but ensure it doesn't overflow in either direction
       height: auto;
+      margin-bottom: $spv-intra--scaleable;
+      margin-right: $matrix-img-gutter;
       max-height: $matrix-img-width;
       max-width: $matrix-img-width;
-      position: absolute;
       width: auto;
     }
 
@@ -130,6 +110,14 @@
     &__desc {
       margin-bottom: $spv-nudge-compensation;
       margin-top: - $sp-unit * 2;
+
+      > p:last-child {
+        margin-bottom: 0;
+      }
+
+      & + & {
+        margin-top: 0; // Negate nudge compensation for multiple .p-matrix__desc
+      }
     }
   }
 }


### PR DESCRIPTION
## Done

- Removed negative margin on consecutive `.p-matrix__desc` so vertical spacing is like two normal paragraphs

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/matrix/
- Add a second `<p class="p-matrix__desc">Short description</p>` to any of the matrix cells
- Check that the space between the two paragraphs is the same as any two consecutive `<p>`

## Details

Fixes #1772 

## Screenshots

### Before

![screenshot_3](https://user-images.githubusercontent.com/25733845/39236354-8f14b6e4-4870-11e8-9e6e-c2f2de8b63d3.png)

### After

![screenshot_2](https://user-images.githubusercontent.com/25733845/39236323-7231bcde-4870-11e8-8900-137d2f8c8a53.png)

