### PR TITLE
Reduce vertical spacing on examples directory + prettify markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,93 +10,81 @@ title: Home
 {% endcapture %}
 {% assign sortedpages = pages | split: '|' | sort %}
 
-<!-- Header -->
-<div class="p-strip is-deep">
-    <div class="row">
-      <div class="col-12">
-        <h1>{{ site.name }}</h1>
-      </div>
-    </div>
+<div class="p-strip is-shallow">
+  <div class="row">
+    <h1>{{ site.name }}</h1>
+    <hr />
+  </div>
 </div>
-
-<div>
-    <div class="row">
-        <div class="col-12">
-          <hr />
-        </div>
+<div class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-3">
+      <h3>Base</h3>
+      <nav>
+        <ul class="p-list">
+          {% for page in sortedpages %}
+          {% assign pageitems = page | split: '#' %}
+          {% if pageitems[1] contains '/base/' %}
+          <li class="p-list__item">
+            <a href="{{ pageitems[1] | prepend:site.baseurl }}" class="p-link--soft">
+              {{ pageitems[0] }}
+            </a>
+          </li>
+          {% endif %}
+          {% endfor %}
+        </ul>
+      </nav>
     </div>
-    <div class="row">
-        <div class="col-3">
-            <h3>Base</h3>
-            <nav>
-              <ul class="p-list">
-                {% for page in sortedpages %}
-                  {% assign pageitems = page | split: '#' %}
-                  {% if pageitems[1] contains '/base/' %}
-                    <li class="p-list__item">
-                      <a href="{{ pageitems[1] | prepend:site.baseurl }}"
-                        class="p-link--soft">
-                        {{ pageitems[0] }}
-                      </a>
-                    </li>
-                  {% endif %}
-                {% endfor %}
-              </ul>
-            </nav>
-        </div>
-        <div class="col-3">
-            <h3>Patterns</h3>
-            <nav>
-                <ul class="p-list">
-                  {% for page in sortedpages %}
-                    {% assign pageitems = page | split: '#' %}
-                    {% if pageitems[1] contains '/patterns/' %}
-                      <li class="p-list__item">
-                        <a href="{{ pageitems[1] | prepend:site.baseurl }}"
-                          class="p-link--soft">
-                          {{ pageitems[0] }}
-                        </a>
-                      </li>
-                    {% endif %}
-                  {% endfor %}
-                </ul>
-            </nav>
-        </div>
-        <div class="col-3">
-            <h3>Utilities</h3>
-            <nav>
-              <ul class="p-list">
-                {% for page in sortedpages %}
-                  {% assign pageitems = page | split: '#' %}
-                  {% if pageitems[1] contains '/utilities/' %}
-                  <li class="p-list__item">
-                    <a href="{{ pageitems[1] | prepend:site.baseurl }}"
-                      class="p-link--soft">
-                      {{ pageitems[0] }}
-                    </a>
-                  </li>
-                  {% endif %}
-                {% endfor %}
-              </ul>
-            </nav>
-        </div>
-        <div class="col-3">
-            <h3>Templates</h3>
-            <nav>
-              <ul class="p-list">
-                {% for page in sortedpages %}
-                  {% assign pageitems = page | split: '#' %}
-                  {% if pageitems[1] contains '/templates/' %}
-                  <li class="p-list__item">
-                    <a href="{{ pageitems[1] | prepend:site.baseurl }}"
-                      class="p-link--soft">
-                      {{ pageitems[0] }}
-                    </a>
-                  </li>
-                  {% endif %}
-                {% endfor %}
-              </ul>
-            </nav>
-        </div>
+    <div class="col-3">
+      <h3>Patterns</h3>
+      <nav>
+        <ul class="p-list">
+          {% for page in sortedpages %}
+          {% assign pageitems = page | split: '#' %}
+          {% if pageitems[1] contains '/patterns/' %}
+          <li class="p-list__item">
+            <a href="{{ pageitems[1] | prepend:site.baseurl }}" class="p-link--soft">
+              {{ pageitems[0] }}
+            </a>
+          </li>
+          {% endif %}
+          {% endfor %}
+        </ul>
+      </nav>
     </div>
+    <div class="col-3">
+      <h3>Utilities</h3>
+      <nav>
+        <ul class="p-list">
+          {% for page in sortedpages %}
+          {% assign pageitems = page | split: '#' %}
+          {% if pageitems[1] contains '/utilities/' %}
+          <li class="p-list__item">
+            <a href="{{ pageitems[1] | prepend:site.baseurl }}" class="p-link--soft">
+              {{ pageitems[0] }}
+            </a>
+          </li>
+          {% endif %}
+          {% endfor %}
+        </ul>
+      </nav>
+    </div>
+    <div class="col-3">
+      <h3>Templates</h3>
+      <nav>
+        <ul class="p-list">
+          {% for page in sortedpages %}
+          {% assign pageitems = page | split: '#' %}
+          {% if pageitems[1] contains '/templates/' %}
+          <li class="p-list__item">
+            <a href="{{ pageitems[1] | prepend:site.baseurl }}" class="p-link--soft">
+              {{ pageitems[0] }}
+            </a>
+          </li>
+          {% endif %}
+          {% endfor %}
+        </ul>
+      </nav>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
## Done

- Prettified index.html
- Made strip shallow instead of deep

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check out the reduced vertical space
