### PR TITLE
Add !default to all settings

### DIFF
--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -1,7 +1,7 @@
 // Global grid settings
 $grid-margin-width:         $sph-inter--expanded !default;
 $grid-columns:              12 !default;
-$grid-gutter-column-ratio:  1.61803398875; // golden ratio
+$grid-gutter-column-ratio:  1.61803398875 !default; // golden ratio
 $grid-gutter-width:         100% / ($grid-columns * $grid-gutter-column-ratio + ($grid-columns - 1)) !default; // gutter expressed as percentage of full width
-$grid-max-width:            990 / 16 * 1rem + 2 * $grid-margin-width;
+$grid-max-width:            990 / 16 * 1rem + 2 * $grid-margin-width !default;
 $grid-col-name:             'col' !default;

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -1,14 +1,14 @@
 // Options
-$sticky-footer: false; // include sticky footer styling. Sets body to display: flex;
-$pad-lists: true; // Adds padding to list items
+$sticky-footer: false !default; // include sticky footer styling. Sets body to display: flex;
+$pad-lists: true !default; // Adds padding to list items
 
 // Typographic scale settings
-$ms-ratio: 16 / 14;
-$sp-unit-ratio: .5;
+$ms-ratio: 16 / 14 !default;
+$sp-unit-ratio: .5 !default;
 
 // Baseline grid settings
-$sp-unit: 1rem * $sp-unit-ratio;
-$px: .0625rem; // 1px as rem; useful in calculations where sizes are defined in rems.
+$sp-unit: 1rem * $sp-unit-ratio !default;
+$px: .0625rem !default; // 1px as rem; useful in calculations where sizes are defined in rems.
 
 //
 $line-heights: (
@@ -18,7 +18,7 @@ $line-heights: (
   h4: 4 * $sp-unit,
   default-text: 3 * $sp-unit,
   small: $sp-unit * 2.5
-);
+) !default;
 
 // baseline nudges for type scale ratio of (16/14) squared
 $nudges: (
@@ -29,44 +29,44 @@ $nudges: (
   nudge--p: .4rem,
   nudge--small: .05rem,
   nudge--muted: 0
-);
+) !default;
 
 //scaling factor
-$multi: 2;
+$multi: 2 !default;
 
 ////////////////////////////////////////////////////////
 // Variables connecting spacings that should be identical
 
 // top: nudge; bottom: unit - nudge; result: height = exact multiple of base unit
-$spv-nudge: map-get($nudges, nudge--p);
-$spv-nudge-compensation: $sp-unit - $spv-nudge;
+$spv-nudge: map-get($nudges, nudge--p) !default;
+$spv-nudge-compensation: $sp-unit - $spv-nudge !default;
 
 // 1. VERTICAL SPACING
 // 1.1 Vertical spacing inside components
-$spv-intra--condensed: $sp-unit * .5; // buttons margins inside table,
-$spv-intra--condensed--scaleable: $spv-intra--condensed * $multi;
-$spv-intra: $sp-unit;
-$spv-intra--scaleable: $spv-intra * $multi;
-$spv-intra--expanded: $spv-intra * 1.5; //vertical padding in: navigation, tabs
+$spv-intra--condensed: $sp-unit * .5 !default; // buttons margins inside table,
+$spv-intra--condensed--scaleable: $spv-intra--condensed * $multi !default;
+$spv-intra: $sp-unit !default;
+$spv-intra--scaleable: $spv-intra * $multi !default;
+$spv-intra--expanded: $spv-intra * 1.5 !default; //vertical padding in: navigation, tabs
 
 // 1.2 Vertical spacing between components
-$spv-inter--condensed: $sp-unit * 1; //labels
-$spv-inter--condensed-scaleable: $sp-unit * $multi;
-$spv-inter--regular: $sp-unit * 2;
-$spv-inter--scaleable: $sp-unit * (1 + $multi);
+$spv-inter--condensed: $sp-unit * 1 !default; //labels
+$spv-inter--condensed-scaleable: $sp-unit * $multi !default;
+$spv-inter--regular: $sp-unit * 2 !default;
+$spv-inter--scaleable: $sp-unit * (1 + $multi) !default;
 
 // 1.3 Vertical spacing between a group of components and its wrapper - strips, views, entire page
-$spv-inter--shallow-scaleable: $sp-unit * 2 * $multi;
-$spv-inter--regular-scaleable: $sp-unit * 2 * (2 + $multi);
-$spv-inter--deep-scaleable: $sp-unit * 2 * (4 + $multi);
+$spv-inter--shallow-scaleable: $sp-unit * 2 * $multi !default;
+$spv-inter--regular-scaleable: $sp-unit * 2 * (2 + $multi) !default;
+$spv-inter--deep-scaleable: $sp-unit * 2 * (4 + $multi) !default;
 
 // 2. HORIZONTAL SPACING
 // 2.1 Horizontal spacing inside components
-$sph-intra--condensed: $sp-unit; // input-elements,
-$sph-intra: $sp-unit * 2; // buttons, accordions, tabs, menu, card padding, stepped-list bullet offset
+$sph-intra--condensed: $sp-unit !default; // input-elements,
+$sph-intra: $sp-unit * 2 !default; // buttons, accordions, tabs, menu, card padding, stepped-list bullet offset
 // 2.2 Horizontal spacing outside components
-$sph-inter: $sph-intra;
-$sph-inter--expanded: $sp-unit * 3; // checboxes, radios, list bullets
+$sph-inter: $sph-intra !default;
+$sph-inter--expanded: $sp-unit * 3 !default; // checboxes, radios, list bullets
 
 $sp-before: (
   h1: $sp-unit * 4,
@@ -77,7 +77,7 @@ $sp-before: (
   h6: $sp-unit * 2,
   p: $sp-unit * 2,
   muted: $sp-unit * 2
-);
+) !default;
 
 // space after element on desktop
 $sp-after: (
@@ -90,7 +90,7 @@ $sp-after: (
   small: $sp-unit * 1,
   small--dense: $sp-unit * 2,
   default-text: $sp-unit
-);
+) !default;
 
 $icon-sizes: (
   accordion: 1.5 * $sp-unit,
@@ -102,7 +102,7 @@ $icon-sizes: (
   heading-icon: $sp-unit * 7.5,
   thumb: $sp-unit * 10,
   thumb--large: $sp-unit * 12
-);
+) !default;
 
 // generic units
 $sp-xx-small: $sp-unit * .25 !default;


### PR DESCRIPTION
## Done

- Added `!default` to all settings so they can be defined in a separate settings file and loaded in before Vanilla

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Open `_vanilla.scss` and add a line at the top that overwrites one of values that now have `!default`, for example:
``` scss
$grid-max-width: 1500px;
```
or
``` scss
$sp-unit-ratio: 1;
```
- Check that the changes take effect on http://0.0.0.0:8101/vanilla-framework/
