### PR TITLE
Minor codebase cleanup

### DIFF
--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -3,15 +3,15 @@
 'base_blockquotes',
 'base_box-sizing',
 'base_button',
-'base_forms',
 'base_code',
+'base_forms',
+'base_hr',
 'base_links',
 'base_lists',
-'base_hr',
 'base_media',
 'base_placeholders',
-'base_tables',
 'base_reset',
+'base_tables',
 'base_typography';
 
 @mixin vf-base {
@@ -21,12 +21,13 @@
   @include vf-b-blockquotes;
   @include vf-b-box-sizing;
   @include vf-b-button;
-  @include vf-b-forms;
   @include vf-b-code;
+  @include vf-b-forms;
+  @include vf-b-hr;
   @include vf-b-links;
   @include vf-b-lists;
-  @include vf-b-hr;
   @include vf-b-media;
+  @include vf-b-placeholders;
   @include vf-b-tables;
   @include vf-b-typography;
 }

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -2,31 +2,31 @@
   // Placeholders containing used rules in multiple base components and patterns
   // Default settings can be found in _settings_placeholders
 
-  //Styling
-  %has-round-corners {
+  // Styling
+  %vf-has-round-corners {
     border-radius: $border-radius;
   }
 
-  %has-highlight {
+  %vf-has-box-shadow {
     box-shadow: $box-shadow;
   }
 
-  %is-bordered {
+  %vf-is-bordered {
     border: $border;
   }
 
-  %bg--light {
+  %vf-bg--light {
     background-color: $color-light;
     color: $color-dark;
   }
 
-  %bg--x-light {
+  %vf-bg--x-light {
     background-color: $color-x-light;
     color: $color-dark;
   }
 
   // Bars and borders
-  %pseudo-border {
+  %vf-pseudo-border {
     background-color: $color-mid-light;
     content: '';
     height: $px;
@@ -35,21 +35,21 @@
     right: 0;
   }
 
-  %pseudo-border--bottom {
+  %vf-pseudo-border--bottom {
     &::after {
-      @extend %pseudo-border;
+      @extend %vf-pseudo-border;
       bottom: 0;
     }
   }
 
-  %pseudo-border--top {
+  %vf-pseudo-border--top {
     &::after {
-      @extend %pseudo-border;
+      @extend %vf-pseudo-border;
       top: 0;
     }
   }
 
-  %pseudo-bar {
+  %vf-pseudo-bar {
     position: relative;
 
     &::before {

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -1,5 +1,6 @@
 @mixin vf-b-placeholders {
   // Placeholders containing used rules in multiple base components and patterns
+  // Default settings can be found in _settings_placeholders
 
   //Styling
   %has-round-corners {
@@ -7,11 +8,11 @@
   }
 
   %has-highlight {
-    box-shadow: 0 1px 5px 1px transparentize($color-dark, .8);
+    box-shadow: $box-shadow;
   }
 
   %is-bordered {
-    border: 1px solid $color-mid-light;
+    border: $border;
   }
 
   %bg--light {
@@ -28,7 +29,7 @@
   %pseudo-border {
     background-color: $color-mid-light;
     content: '';
-    height: 1px;
+    height: $px;
     left: 0;
     position: absolute;
     right: 0;
@@ -59,13 +60,5 @@
       right: 0;
       top: 0;
     }
-  }
-}
-
-@mixin vf-m-category-bar ($bg-color: #f00) {
-  @extend %pseudo-bar;
-
-  &::before {
-    background-color: $bg-color;
   }
 }

--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -66,7 +66,7 @@
 }
 
 @mixin vf-m-category-bar ($bg-color: #f00) {
-  @extend %pseudo-bar;
+  @extend %vf-pseudo-bar;
 
   &::before {
     background-color: $bg-color;

--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -64,3 +64,11 @@
 
   @return $value;
 }
+
+@mixin vf-m-category-bar ($bg-color: #f00) {
+  @extend %pseudo-bar;
+
+  &::before {
+    background-color: $bg-color;
+  }
+}

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -2,7 +2,7 @@
 
 @mixin vf-p-card {
   %p-card {
-    @extend %bg--x-light;
+    @extend %vf-bg--x-light;
     margin-bottom: $spv-inter--scaleable;
     overflow: auto; // prevent overflow of child margins
     padding: $spv-intra--scaleable;
@@ -17,8 +17,8 @@
 
 @mixin vf-p-card-default {
   .p-card {
-    @extend %is-bordered;
-    @extend %has-round-corners;
+    @extend %vf-is-bordered;
+    @extend %vf-has-round-corners;
     @extend %p-card;
     padding: $spv-intra--scaleable - $px;
   }
@@ -26,8 +26,8 @@
 
 @mixin vf-p-card-highlighted {
   %p-card--highlighted {
-    @extend %has-highlight;
-    @extend %has-round-corners;
+    @extend %vf-has-box-shadow;
+    @extend %vf-has-round-corners;
     @extend %p-card;
   }
 
@@ -48,9 +48,9 @@
 
 @mixin vf-p-card-muted {
   .p-card--muted {
-    @extend %bg--light;
-    @extend %has-highlight;
-    @extend %has-round-corners;
+    @extend %vf-bg--light;
+    @extend %vf-has-box-shadow;
+    @extend %vf-has-round-corners;
     margin-bottom: $spv-inter--scaleable;
     overflow: auto;
     padding: $spv-intra--scaleable;

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -29,7 +29,7 @@
     }
 
     &__list {
-      @extend %pseudo-border--bottom;
+      @extend %vf-pseudo-border--bottom;
       margin: 0 auto $spv-intra--scaleable;
       overflow-x: scroll;
       padding: 0;

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -13,13 +13,8 @@
 'settings_assets',
 'settings_breakpoints',
 'settings_colors',
+'settings_font',
 'settings_grid',
-'settings_system',
-'settings_font';
-
-
-// temporarily placing variables here
-$bar-thickness: $px * 3;
-$border-radius: $sp-unit * .25;
-
-
+'settings_placeholders',
+'settings_system'
+;

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -1,0 +1,6 @@
+// Global placeholder settings
+
+$bar-thickness: $px * 3;
+$border-radius: $sp-unit * .25;
+$border: $px solid $color-mid-light;
+$box-shadow: 0 1px 5px 1px transparentize($color-dark, .8);

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -6,66 +6,64 @@
 @import
 'patterns_accordion',
 'patterns_aside',
-'patterns_card',
-'patterns_contextual-menu',
 'patterns_breadcrumbs',
 'patterns_buttons',
+'patterns_card',
 'patterns_code-numbered',
 'patterns_code-snippet',
+'patterns_contextual-menu',
 'patterns_divider',
 'patterns_footer',
+'patterns_form-help-text',
+'patterns_form-validation',
+'patterns_forms',
 'patterns_grid',
-'patterns_headings',
 'patterns_heading-icon',
-'patterns_image',
-'patterns_matrix',
-'patterns_media-object',
-'patterns_modal',
-'patterns_muted-heading',
+'patterns_headings',
 'patterns_icons',
+'patterns_image',
 'patterns_inline-images',
 'patterns_links',
 'patterns_list-tree',
 'patterns_lists',
+'patterns_matrix',
+'patterns_media-object',
+'patterns_modal',
+'patterns_muted-heading',
 'patterns_navigation',
 'patterns_notifications',
 'patterns_pagination',
 'patterns_pull-quotes',
-'patterns_slider',
-'patterns_table-mobile-card',
-'patterns_tabs',
 'patterns_search-box',
+'patterns_slider',
 'patterns_strip',
 'patterns_switch',
-'patterns_table-sortable',
-'patterns_form-validation',
-'patterns_form-help-text',
-'patterns_forms',
-'patterns_tooltips',
 'patterns_table-expanding',
-'patterns_tooltips',
-'patterns_form-validation'
+'patterns_table-mobile-card',
+'patterns_table-sortable',
+'patterns_tabs',
+'patterns_tooltips'
 ;
 
 // Utilities
 @import
 'utilities_animations',
+'utilities_baseline-grid',
 'utilities_clearfix',
-'utilities_floats',
-'utilities_equal-height',
-'utilities_off-screen',
 'utilities_content-align',
-'utilities_margin-collapse',
-'utilities_padding-collapse',
 'utilities_embedded-media',
-'utilities_vertically-center',
-'utilities_show',
+'utilities_equal-height',
+'utilities_floats',
 'utilities_hide',
 'utilities_image-position',
-'utilities_visibility',
-'utilities_baseline-grid',
+'utilities_margin-collapse',
+'utilities_off-screen',
+'utilities_padding-collapse',
+'utilities_show',
 'utilities_sticky-footer',
-'utilities_vertical-spacing'
+'utilities_vertical-spacing',
+'utilities_vertically-center',
+'utilities_visibility'
 ;
 
 // Include all the CSS
@@ -82,55 +80,53 @@
   @include vf-p-contextual-menu;
   @include vf-p-divider;
   @include vf-p-footer;
-  @include vf-p-grid;
+  @include vf-p-form-help-text;
+  @include vf-p-form-validation;
+  @include vf-p-forms;
   @include vf-p-grid-modifications;
-  @include vf-p-headings;
+  @include vf-p-grid;
   @include vf-p-heading-icon;
+  @include vf-p-headings;
+  @include vf-p-icons;
   @include vf-p-image;
-  @include vf-p-media-object;
-  @include vf-p-modal;
-  @include vf-p-matrix;
-  @include vf-p-muted-heading;
-  @include vf-p-navigation;
+  @include vf-p-inline-images;
   @include vf-p-links;
   @include vf-p-list-tree;
   @include vf-p-lists;
-  @include vf-p-icons;
-  @include vf-p-tooltips;
-  @include vf-p-inline-images;
+  @include vf-p-matrix;
+  @include vf-p-media-object;
+  @include vf-p-modal;
+  @include vf-p-muted-heading;
+  @include vf-p-navigation;
   @include vf-p-notification;
+  @include vf-p-pagination;
   @include vf-p-pull-quotes;
-  @include vf-p-table-mobile-card;
   @include vf-p-search-box;
   @include vf-p-slider;
   @include vf-p-strip;
   @include vf-p-switch;
+  @include vf-p-table-expanding;
+  @include vf-p-table-mobile-card;
   @include vf-p-table-sortable;
   @include vf-p-tabs;
-  @include vf-p-table-expanding;
-  @include vf-p-form-validation;
-  @include vf-p-form-help-text;
-  @include vf-p-forms;
-  @include vf-p-pagination;
+  @include vf-p-tooltips;
   // Utilities
+  @include vf-u-align;
   @include vf-u-animations;
+  @include vf-u-baseline-grid;
   @include vf-u-clearfix;
-  @include vf-u-floats;
   @include vf-u-embedded-media;
   @include vf-u-equal-height;
-  @include vf-u-align;
-  @include vf-u-margin-collapse;
-  @include vf-u-padding-collapse;
+  @include vf-u-floats;
   @include vf-u-hide;
   @include vf-u-image-position;
-  @include vf-u-show;
+  @include vf-u-margin-collapse;
   @include vf-u-off-screen;
+  @include vf-u-padding-collapse;
+  @include vf-u-show;
+  @include vf-u-vertical-spacing;
   @include vf-u-vertically-center;
   @include vf-u-visibility;
-  @include vf-u-baseline-grid;
-  @include vf-u-vertical-spacing;
-
-  @include vf-b-placeholders;
 
   @if($sticky-footer) {
     @include vf-u-sticky-footer;

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -70,6 +70,7 @@
 @mixin vanilla {
   @include vf-base;
   // Patterns
+  @include vf-p-navigation;
   @include vf-p-accordion;
   @include vf-p-aside;
   @include vf-p-breadcrumbs;
@@ -97,7 +98,6 @@
   @include vf-p-media-object;
   @include vf-p-modal;
   @include vf-p-muted-heading;
-  @include vf-p-navigation;
   @include vf-p-notification;
   @include vf-p-pagination;
   @include vf-p-pull-quotes;


### PR DESCRIPTION
## Done

- Moved the `vf-b-placeholders` include from `vanilla.scss` to `base.scss`
- Alphabetised the imports and includes in `base.scss` and `vanilla.scss` (except for `vf-p-navigation`, which is placed first due to how `@at-root` is used in the sidebar navigation pattern)
- Created a settings file for the base placeholders, where you can change things like box-shadow, border-radius, and highlight bar thickness (like the one in https://vanilla-framework.github.io/vanilla-framework/examples/patterns/notifications/positive/) that are used across multiple components
- Namespaced the base placeholders to prevent conflicts with other scss frameworks (if anyone ever decides to use Vanilla with something else)

## QA

- Pull code
- Run `./run test` and check there are no errors
- Check Percy that nothing has changed design-wise
