### PR TITLE
Reduce headings sizes for smaller screens

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -223,6 +223,17 @@
     vertical-align: baseline;
   }
 
+  h3,
+  h4,
+  .p-heading--three,
+  .p-heading--four {
+    & + p {
+      @media (max-width: $breakpoint-heading-threshold) {
+        margin-top: - $sp-unit;
+      }
+    }
+  }
+
   h5,
   h6,
   .p-heading--five,
@@ -239,7 +250,7 @@
   .p-heading--five,
   .p-heading--six {
     .p-muted-heading + & {
-      margin-top: -$sp-unit * 2;
+      margin-top: - $sp-unit;
     }
   }
 
@@ -248,21 +259,33 @@
   h6 + p:not(.p-muted-heading),
   .p-heading--five + p:not(.p-muted-heading),
   .p-heading--six + p:not(.p-muted-heading) {
-    margin-top: -$sp-unit * 2;
+    margin-top: - $sp-unit * 2;
   }
 
   // Increase space above headings that follow a paragraph.
 
   %sp--ph1 {
     padding-top: map-get($nudges, nudge--h1) + map-get($sp-before, h1);
+
+    @media (max-width: $breakpoint-heading-threshold) {
+      padding-top: map-get($nudges, nudge--h1-mobile) + map-get($sp-before, h1-mobile);
+    }
   }
 
   %sp--ph2 {
     padding-top: map-get($nudges, nudge--h2) + map-get($sp-before, h2);
+
+    @media (max-width: $breakpoint-heading-threshold) {
+      padding-top: map-get($nudges, nudge--h2-mobile) + map-get($sp-before, h2-mobile);
+    }
   }
 
   %sp--ph3 {
     padding-top: map-get($nudges, nudge--h3) + map-get($sp-before, h3);
+
+    @media (max-width: $breakpoint-heading-threshold) {
+      padding-top: map-get($nudges, nudge--h3-mobile) + map-get($sp-before, h3-mobile);
+    }
   }
 
   %sp--ph4 {
@@ -329,6 +352,13 @@
     margin-bottom: map-get($sp-after, h1) - map-get($nudges, nudge--h1);
     margin-top: 0;
     padding-top: map-get($nudges, nudge--h1);
+
+    @media (max-width: $breakpoint-heading-threshold) {
+      font-size: pow($ms-ratio, 6) * 1rem;
+      line-height: map-get($line-heights, h1-mobile);
+      margin-bottom: map-get($sp-after, h1-mobile) - map-get($nudges, nudge--h1-mobile);
+      padding-top: map-get($nudges, nudge--h1-mobile);
+    }
   }
 
   %vf-heading-2 {
@@ -340,6 +370,13 @@
     margin-bottom: map-get($sp-after, h2) - map-get($nudges, nudge--h2);
     margin-top: 0;
     padding-top: map-get($nudges, nudge--h2);
+
+    @media (max-width: $breakpoint-heading-threshold) {
+      font-size: 1.83274rem; // pow($ms-ratio, 4.5) * 1rem
+      line-height: map-get($line-heights, h2-mobile);
+      margin-bottom: map-get($sp-after, h2-mobile) - map-get($nudges, nudge--h2-mobile);
+      padding-top: map-get($nudges, nudge--h2-mobile);
+    }
   }
 
   %vf-heading-3 {
@@ -351,6 +388,13 @@
     margin-bottom: map-get($sp-after, h3) - map-get($nudges, nudge--h3);
     margin-top: 0;
     padding-top: map-get($nudges, nudge--h3);
+
+    @media (max-width: $breakpoint-heading-threshold) {
+      font-size: pow($ms-ratio, 3) * 1rem;
+      line-height: map-get($line-heights, h3-mobile);
+      margin-bottom: map-get($sp-after, h3-mobile) - map-get($nudges, nudge--h3-mobile);
+      padding-top: map-get($nudges, nudge--h3-mobile);
+    }
   }
 
   %vf-heading-4 {
@@ -362,6 +406,13 @@
     margin-bottom: map-get($sp-after, h4) - map-get($nudges, nudge--h4);
     margin-top: 0;
     padding-top: map-get($nudges, nudge--h4);
+
+    @media (max-width: $breakpoint-heading-threshold) {
+      font-size: 1.22176rem; // pow($ms-ratio, 1.5) * 1rem
+      line-height: map-get($line-heights, h4-mobile);
+      margin-bottom: map-get($sp-after, h4-mobile) - map-get($nudges, nudge--h4-mobile);
+      padding-top: map-get($nudges, nudge--h4-mobile);
+    }
   }
 
   %vf-heading-5 {
@@ -393,7 +444,7 @@
   }
 
   %small-text {
-    font-size: 1rem / pow($ms-ratio, 1);
+    font-size: pow($ms-ratio, -1) * 1rem;
     line-height: map-get($line-heights, small);
     margin-bottom: map-get($sp-after, small) + map-get($line-heights, default-text) - map-get($line-heights, small) - map-get($nudges, nudge--small);
     padding-top: map-get($nudges, nudge--small);

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -1,6 +1,6 @@
 @import 'settings';
-$bullet-padding: map-get($nudges, nudge--h3) * 0;
-$numbered-bullet-width: map-get($line-heights, h3) + $bullet-padding * 2;
+$numbered-bullet-width: map-get($line-heights, h3);
+$numbered-bullet-width--mobile: map-get($line-heights, h3-mobile);
 $numbered-bullet-margin-right: $sph-inter--expanded;
 $numbered-bullet-offset: $numbered-bullet-width + $numbered-bullet-margin-right;
 $tick-height: .875rem; //14px value from svg as rem so it can be used in calculations
@@ -271,10 +271,15 @@ $spv-list-item--inner: .25 * $spv-inter--condensed-scaleable; // padding top and
       display: inline-block;
       margin-left: - $numbered-bullet-offset;
       margin-top: map-get($nudges, nudge--h3);
-      padding: $bullet-padding 0 $bullet-padding;
+      padding: 0;
       position: absolute;
       text-align: center;
       width: $numbered-bullet-width;
+
+      @media (max-width: $breakpoint-heading-threshold) {
+        margin-top: map-get($nudges, nudge--h3-mobile);
+        width: $numbered-bullet-width--mobile;
+      }
     }
   }
   @include vf-p-list;

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -118,6 +118,10 @@
       & + & {
         margin-top: 0; // Negate nudge compensation for multiple .p-matrix__desc
       }
+
+      @media (max-width: $breakpoint-heading-threshold) {
+        margin-top: - $sp-unit;
+      }
     }
   }
 }

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -36,6 +36,10 @@
     &__content {
       margin-bottom: $spv-nudge-compensation + $sp-unit;
       margin-top: - $sp-unit * 2;
+
+      @media (max-width: $breakpoint-heading-threshold) {
+        margin-top: - $sp-unit;
+      }
     }
 
     &__image.is-round {
@@ -82,11 +86,15 @@
 
       .p-media-object__title {
         @extend %vf-heading-1;
-        margin-top: - $sp-unit * 2;
+        margin-top: - $sp-unit;
       }
 
       .p-media-object__content {
         margin-top: - $sp-unit * 5;
+
+        @media (max-width: $breakpoint-heading-threshold) {
+          margin-top: - $sp-unit * 3;
+        }
       }
     }
   }

--- a/scss/_settings_breakpoints.scss
+++ b/scss/_settings_breakpoints.scss
@@ -4,3 +4,4 @@ $breakpoint-small: 620px !default;
 $breakpoint-medium: 768px !default;
 $breakpoint-large: 1030px !default;
 $breakpoint-navigation-threshold: $breakpoint-medium !default;
+$breakpoint-heading-threshold: $breakpoint-medium !default;

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -10,12 +10,15 @@ $sp-unit-ratio: .5 !default;
 $sp-unit: 1rem * $sp-unit-ratio !default;
 $px: .0625rem !default; // 1px as rem; useful in calculations where sizes are defined in rems.
 
-//
 $line-heights: (
   h1: 7 * $sp-unit,
-  h2: 5 * $sp-unit,
+  h2: 6 * $sp-unit,
   h3: 5 * $sp-unit,
   h4: 4 * $sp-unit,
+  h1-mobile: 6 * $sp-unit,
+  h2-mobile: 5 * $sp-unit,
+  h3-mobile: 4 * $sp-unit,
+  h4-mobile: 3 * $sp-unit,
   default-text: 3 * $sp-unit,
   small: $sp-unit * 2.5
 ) !default;
@@ -23,9 +26,13 @@ $line-heights: (
 // baseline nudges for type scale ratio of (16/14) squared
 $nudges: (
   nudge--h1: .2rem,
-  nudge--h2: .45rem,
+  nudge--h2: .2rem,
   nudge--h3: .1rem,
   nudge--h4: .05rem,
+  nudge--h1-mobile: .2rem,
+  nudge--h2-mobile: .1rem,
+  nudge--h3-mobile: 0,
+  nudge--h4-mobile: .3rem,
   nudge--p: .4rem,
   nudge--small: .05rem,
   nudge--muted: 0
@@ -75,6 +82,10 @@ $sp-before: (
   h4: $sp-unit * 3,
   h5: $sp-unit * 2,
   h6: $sp-unit * 2,
+  h1-mobile: $sp-unit * 3,
+  h2-mobile: $sp-unit * 3,
+  h3-mobile: $sp-unit * 3,
+  h4-mobile: $sp-unit * 3,
   p: $sp-unit * 2,
   muted: $sp-unit * 2
 ) !default;
@@ -82,9 +93,13 @@ $sp-before: (
 // space after element on desktop
 $sp-after: (
   h1: $sp-unit * 5,
-  h2: $sp-unit * 5,
+  h2: $sp-unit * 4,
   h3: $sp-unit * 3,
   h4: $sp-unit * 2,
+  h1-mobile: $sp-unit * 4,
+  h2-mobile: $sp-unit * 3,
+  h3-mobile: $sp-unit * 2,
+  h4-mobile: $sp-unit * 2,
   p: $sp-unit * 3,
   muted: $sp-unit * 2,
   small: $sp-unit * 1,


### PR DESCRIPTION
## Done

- Made it so headings decrease in size once a certain screen size threshold is reached, which is `$breakpoint-medium` by default (i.e. `$breakpoint-heading-threshold: $breakpoint-medium !default`)
- Added nudges, sp-after and sp-before values for mobile headings to their respective maps, e.g. `$nudge--h1-mobile: .2rem`. This is to ensure the new heading sizes sit on the baseline grid, as well as anything that follows one.
- Added media queries to patterns that were affected by the change in heading sizes, to ensure the spacing looked right (media object, matrix, stepped list)
- The new mobile headings follow a different power scale to the originals. The large headings increase by 2 for each step up in size, while the mobile headings increase by 1.5.
**Note:** The pow() function doesn't work with non-integers, so the font-sizes have been hard-coded for now.

| Heading | Original Power | Original Font-size| Mobile Power | Mobile Font-size |
|---------|----------|--------|--------|--------|
| h1      | 8        | 2.91rem   | 6      | 2.22rem   |
| h2      | 6        | 2.22rem   | 4.5    | 1.82rem   |
| h3      | 4        | 1.71rem   | 3      | 1.49rem   |
| h4      | 2        | 1.31rem   | 1.5    | 1.22rem   |
| h5      | 0        | 1rem   | 0      | 1rem   |
| h6      | 0        | 1rem    | 0      | 1rem   |

- Changed the line-height of `<h2>`s to 3rem (`$sp-unit * 6`) and edited associated nudges/spacings to fit baseline

## QA

- Open `_jekyll/_layouts/default.html`
- Edit `VF_ENV` to be "DEV" 
- `./run`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/headings/default/
- Click the switch in the bottom-right to turn on the baseline grid
- Resize to under 768px width and check that the headings decrease in size, and that they sit on the baseline grid
- Add and move around text elements (e.g. paragraphs, headings) and make sure the text always sits on the baseline grid

## Issues

Fixes #1708 

## Screenshots
### Before

![screenshot_2](https://user-images.githubusercontent.com/25733845/39757887-19ce25f4-52c6-11e8-87a8-8f43f3755400.png)

### After

![screenshot_3](https://user-images.githubusercontent.com/25733845/39757894-1f2187d0-52c6-11e8-9b8c-b1af447c1968.png)
