### PR TITLE
Give pre blocks white-space: pre-wrap

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -16,13 +16,13 @@
     direction: ltr;
     hyphens: none;
     tab-size: 4;
+    white-space: pre-wrap;
     word-spacing: normal;
     word-wrap: break-word;
   }
 
   code {
     display: inline;
-    white-space: pre-wrap;
   }
 
   pre {
@@ -37,6 +37,5 @@
     padding: $spv-intra $sph-intra;
     text-align: left;
     text-shadow: none;
-    white-space: nowrap;
   }
 }


### PR DESCRIPTION
## Done

- Changed the `white-space` property of `<pre>` blocks `pre-wrap` instead of `nowrap`
- This fixes a bug where a `<pre>` block without `<code>` lines show up as a single long line of code

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/code/
- Open dev tools and create a pre block with multiple lines of code without `<code>`, e.g.
``` html
<pre>
  Code line 1
  Code line 2
</pre>
```
- Check that the code block renders over multiple lines correctly

## Screenshots

### Before

![screenshot](https://user-images.githubusercontent.com/25733845/39747374-0f1465f4-52a5-11e8-8204-be86dc9eefdd.png)

### After

![screenshot_1](https://user-images.githubusercontent.com/25733845/39747378-11ea9f1e-52a5-11e8-97ca-044249abbfd3.png)

