### PR TITLE
Update docs copy with 1.7.0 content

### DIFF
--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -7,7 +7,7 @@ table_of_contents: true
 
 All text in Vanilla uses the Ubuntu typeface.
 
-Vanilla's typographic scale has a base font size of 16 pixels (1rem) and a font weight of 300.
+Vanilla's typographic scale has a base font-size of `1rem` (`16px`) and a font-weight of 300.
 The heading sizes h1-h4 follow a modular scale with a base value of 16/14 (~1.143). On large
 screens the ratio is 1:2 and on small to medium screens the ratio is 2:3. This means that the
 font size is calculated from

--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -7,42 +7,47 @@ table_of_contents: true
 
 All text in Vanilla uses the Ubuntu typeface.
 
-Vanilla's typographic scale has a base font size of 15 pixels (screens smaller than 768 pixels)
-and a font weight of 300.  At the medium breakpoint, the base font size increases to 16
-pixels.
+Vanilla's typographic scale has a base font size of 16 pixels (1rem) and a font weight of 300.
+The heading sizes h1-h4 follow a modular scale with a base value of 16/14 (~1.143). On large
+screens the ratio is 1:2 and on small to medium screens the ratio is 2:3. This means that the
+font size is calculated from
+
+<p>(16/14)<sup><em>n</em></sup></p>
+
+where _n_ is the point on the modular scale.
 
 ### Typographic scale
 
-|               | Small  | Medium | Large  |
-| ------------- | -----  | ------ | -----  |
-| **p**         |        |        |        |
-| font size     | `16px` | `16px` | `16px` |
-| line height   | `24px` | `24px` | `24px` |
-| margin top    | `16px` | `16px` | `24px` |
-| <h1>h1</h1>   |        |        |        |
-| font size     | `32px` | `32px` | `48px` |
-| line height   | `42px` | `42px` | `60px` |
-| margin top    | `32px` | `32px` | `60px` |
-| <h2>h2</h2>   |        |        |        |
-| font size     | `28px` | `28px` | `36px` |
-| line height   | `36px` | `36px` | `48px` |
-| margin top    | `24px` | `24px` | `32px` |
-| <h3>h3</h3>   |        |        |        |
-| font size     | `24px` | `24px` | `28px` |
-| line height   | `32px` | `32px` | `36px` |
-| margin top    | `24px` | `24px` | `32px` |
-| <h4>h4</h4>   |        |        |        |
-| font size     | `22px` | `22px` | `24px` |
-| line height   | `28px` | `28px` | `32px` |
-| margin top    | `24px` | `24px` | `32px` |
-| <h5>h5</h5>   |        |        |        |
-| font size     | `18px` | `18px` | `20px` |
-| line height   | `24px` | `24px` | `28px` |
-| margin top    | `24px` | `24px` | `32px` |
-| <h6>h6</h6>   |        |        |        |
-| font size     | `16px` | `16px` | `16px` |
-| line height   | `24px` | `24px` | `24px` |
-| margin top    | `24px` | `24px` | `32px` |
+|               | Small-Medium | Large |
+| ------------- | -----  | ------ |
+| <h1 class="u-no-margin--bottom">h1</h1> |        |        |
+| modular point | `8` | `6` |
+| font size     | `2.22819rem` | `2.91029rem` |
+| line height   | `3rem` | `3.5rem` |
+| <h2 class="u-no-margin--bottom">h2</h2> |        |        |
+| modular point | `6` | `4.5` |
+| font size     | `1.83274rem` | `2.22819rem` |
+| line height   | `2.5rem` | `3rem` |
+| <h3 class="u-no-margin--bottom">h3</h3> |        |        |
+| modular point | `4` | `3` |
+| font size     | `1.49271rem` | `1.70596rem` |
+| line height   | `2rem` | `2.5rem` |
+| <h4 class="u-no-margin--bottom">h4</h4> |        |        |
+| modular point | `2` | `1.5` |
+| font size     | `1.22176rem` | `1.30612rem` |
+| line height   | `1.5rem` | `2rem` |
+| <h5 class="u-no-margin--bottom">h5</h5> |        |        |
+| modular point | `0` | `0` |
+| font size     | `1rem` | `1rem` |
+| line height   | `1.5rem` | `1.5rem` |
+| <h6 class="u-no-margin--bottom">h6</h6> |        |        |
+| modular point | `0` | `0` |
+| font size     | `1rem` | `1rem` |
+| line height   | `1.5rem` | `1.5rem` |
+| <p class="u-no-margin--bottom">p</p> |        |        |
+| modular point | `0` | `0` |
+| font size     | `1rem` | `1rem` |
+| line height   | `1.5rem` | `1.5rem` |
 
 ### Heading classes
 

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -9,6 +9,9 @@ navigation:
   - location: settings/color-settings.md
     title: Color
 
+  - location: utilities/functions.md
+    title: Functions
+
   - location: settings/font-settings.md
     title: Font
 

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -12,6 +12,9 @@ navigation:
   - location: settings/font-settings.md
     title: Font
 
+  - location: settings/placeholder-settings.md
+    title: Placeholders
+
   - location: base/reset.md
     title: Reset
 

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -85,7 +85,7 @@ navigation:
     title: Footer
 
   - location: patterns/navigation.md
-    title: Global navigation
+    title: Navigation
 
   - location: patterns/pagination.md
     title: Pagination

--- a/docs/en/settings/breakpoint-settings.md
+++ b/docs/en/settings/breakpoint-settings.md
@@ -5,7 +5,7 @@ table_of_contents: true
 
 ## Breakpoints
 
-Vanilla uses three breakpoints: one for small screens (like phones), one for medium sized screens and a third for large screens.
+Vanilla uses four main breakpoints for screen sizes: `$breakpoint-x-small` and `$breakpoint-small` for mobile screen sizes, `$breakpoint-medium` for tablets, and `$breakpoint-large` for desktop/laptop screens.
 
 Setting  | Default value
  ------------- | -------------
@@ -14,11 +14,20 @@ Setting  | Default value
 `$breakpoint-medium`   | `768px`
 `$breakpoint-large`   | `1030px`
 `$breakpoint-navigation-threshold`   | `$breakpoint-medium`
+`$breakpoint-heading-threshold`   | `$breakpoint-medium`
+
+### Target extra small screens
+
+```css
+@media screen and (max-width: $breakpoint-small) {
+    // css
+}
+```
 
 ### Target small screens
 
 ```css
-@media screen and (max-width: $breakpoint-medium) {
+@media screen and (min-width: $breakpoint-small) and (max-width: $breakpoint-medium) {
     // css
 }
 ```
@@ -26,7 +35,7 @@ Setting  | Default value
 ### Target medium screens
 
 ```css
-@media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
+@media screen and (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
     // css
 }
 ```
@@ -39,11 +48,12 @@ Setting  | Default value
 }
 ```
 
-### Modifying the navigation threshold
-The `$breakpoint-navigation-threshold` is the breakpoint in which the
-navigation switches from horizontal (large screen) navigation to a burger style
-menu (small screen).
+### Modifying the navigation breakpoint threshold
 
-If you have a large number of menu items, you may consider overriding this
-value to a large breakpoint so the navigation snaps to a burger menu at a
-larger breakpoint.
+The `$breakpoint-navigation-threshold` is the breakpoint in which the navigation switches from horizontal (large screen) navigation to a burger style menu (small screen).
+
+If you have a large number of menu items, you may consider overriding this value to a large breakpoint so the navigation snaps to a burger menu at a larger breakpoint.
+
+### Modifying the heading breakpoint threshold
+
+`$breakpoint-heading-threshold` is the breakpoint in which the heading sizes switch from a 1:2 modular scale ratio (large screens) to a 2:3 ratio (small screens).

--- a/docs/en/settings/placeholder-settings.md
+++ b/docs/en/settings/placeholder-settings.md
@@ -1,0 +1,19 @@
+---
+title: Placeholder settings
+table_of_contents: false
+---
+
+## Placeholders
+
+Vanilla uses several global placeholders to share common stylings between components. These placeholders can be edited via the following placeholder variables, assuming a `$sp-unit` of 0.5rem.
+
+Placeholder variable | Default value | Use cases
+ ------------------- | ------------- |
+`$bar-thickness`     | `3px`         | Navigation, notification
+`$border-radius`     | `2px`         | Button, Card, Code, Form, Media object, Switch, Tooltip
+`$border`            | `1px solid $color-mid-light` | Card, Code, Form, Search box
+`$box-shadow`        | `0 1px 5px 1px transparentize($color-dark, .8)` | Card (highlighted), Modal, Notification, Switch
+
+### Related
+
+* [Spacing settings](/en/settings/spacing-settings)

--- a/docs/en/settings/placeholder-settings.md
+++ b/docs/en/settings/placeholder-settings.md
@@ -5,7 +5,7 @@ table_of_contents: false
 
 ## Placeholders
 
-Vanilla uses several global placeholders to share common stylings between components. These placeholders can be edited via the following placeholder variables, assuming a `$sp-unit` of 0.5rem.
+Vanilla uses several global placeholders to share common styles between components. These placeholders can be edited via the following placeholder variables, assuming a `$sp-unit` of `0.5rem`.
 
 Placeholder variable | Default value | Use cases
  ------------------- | ------------- |

--- a/docs/en/settings/spacing-settings.md
+++ b/docs/en/settings/spacing-settings.md
@@ -49,7 +49,7 @@ Spacing variable | Formula | Default value
 
 ### Generic units
 
-There are also generic spacing units for backwards compatibility with components created with Vanilla before v1.7.0.
+There are also generic spacing units for backwards compatibility with components created with Vanilla before `v1.7.0`.
 
 Spacing variable | Formula | Default value
  ------------------- | ------------- |

--- a/docs/en/settings/spacing-settings.md
+++ b/docs/en/settings/spacing-settings.md
@@ -5,15 +5,61 @@ table_of_contents: true
 
 ## Spacing
 
-Vanilla uses spacing variables across the codebase to help ensure consistency of spacing between elements in across patterns and utilities.
+Vanilla uses numerous spacing variables across the codebase in order to ensure consistency in spacing between components, and to ensure typographic elements sit on the baseline grid.
 
-Setting  | Default value
- ------------- | -------------
-`$sp-xx-small` | `0.25rem`
-`$sp-x-small` | `0.5rem`
-`$sp-small` | `0.75rem`
-`$sp-medium` | `1rem`
-`$sp-large` | `1.5rem`
-`$sp-x-large` | `2rem`
-`$sp-xx-large` | `2.5rem`
-`$sp-xxx-large` | `3rem`
+### Spacing unit
+
+Vanilla uses a default spacing unit of `.5rem` (`8px`) as a basis to calculate spacing inside and between components, as well as the line-heights of the different type sizes.
+
+![Baseline grid example](https://assets.ubuntu.com/v1/d2c31b2d-screenshot.png "Baseline grid example")
+
+The image shows the headings sitting on the baseline grid, where the space between each line is one `$sp-unit`.
+
+### Vertical spacing
+
+The `$spv-intra` variables are used to determine vertical spacing inside components, while `$spv-inter` variables are used for spacing between components.
+
+Spacing variable | Formula | Default value
+ ------------------- | ------------- |
+`$spv-intra` | `$sp-unit` | `.5rem`
+`$spv-intra--condensed` | `$spv-intra * .5` | `.25rem`
+`$spv-intra--expanded` | `$spv-intra * 1.5` | `.75rem`
+`$spv-inter--regular` | `$sp-unit * 2` | `1rem`
+`$spv-inter--condensed` | `$sp-unit` | `.5rem`
+`$spv-inter--expanded` | `$sp-unit * 3` | `1.5rem`
+
+The following vertical spacing variables are used between a group of components and its wrapper, for example in strips.
+
+Spacing variable | Formula | Default value
+ ------------------- | ------------- |
+`$spv-inter--shallow-scaleable` | `$sp-unit * 4` | `2rem`
+`$spv-inter--regular-scaleable` | `$sp-unit * 6` | `3rem`
+`$spv-inter--shallow-scaleable` | `$sp-unit * 8` | `4rem`
+
+### Horizontal spacing
+
+The `$sph-intra` variables are used to determine horizontal spacing inside components, while `$sph-inter` variables are used for spacing between components.
+
+Spacing variable | Formula | Default value
+ ------------------- | ------------- |
+`$sph-intra` | `$sp-unit * 2` | `1rem`
+`$sph-intra--condensed` | `$sp-unit` | `.5rem`
+`$sph-inter` | `$sp-unit` | `.5rem`
+`$sph-inter--expanded` | `$sp-unit * 3` | `1.5rem`
+
+### Generic units
+
+There are also generic spacing units for backwards compatibility with components created with Vanilla before v1.7.0.
+
+Spacing variable | Formula | Default value
+ ------------------- | ------------- |
+`$sp-xx-small` | `$sp-unit * .25` | `.125rem`
+`$sp-x-small` | `$sp-unit * .5` | `.25rem`
+`$sp-small` | `$sp-unit` | `.5rem`
+`$sp-medium` | `$sp-unit * 2` | `1rem`
+`$sp-large` | `$sp-unit * 3` | `1.5rem`
+`$sp-x-large` | `$sp-unit * 4` | `2rem`
+`$sp-xx-large` | `$sp-unit * 5` | `2.5rem`
+`$sp-xxx-large` | `$sp-unit * 6` | `3rem`
+`$sp-xxxx-large` | `$sp-unit * 8` | `4rem`
+`$sp-xxxxx-large` | `$sp-unit * 12` | `6rem`

--- a/docs/en/utilities/functions.md
+++ b/docs/en/utilities/functions.md
@@ -10,7 +10,7 @@ Vanilla has several global functions used across multiple components or utilitie
 
 ### URL-friendly color
 
-This function is used to inject Vanilla color variables into inline SVGs by converting all `#` with the HTML encoded `%23`.
+This function is used to inject Vanilla color variables into inline vector graphics by converting all `#` with the HTML encoded `%23`.
 
 ``` scss
 @function vf-url-friendly-color($color) {

--- a/docs/en/utilities/functions.md
+++ b/docs/en/utilities/functions.md
@@ -1,0 +1,66 @@
+---
+title: Functions
+table_of_contents: true
+---
+
+## Functions
+
+Vanilla has several global functions used across multiple components or utilities, which can be also be used when building custom components.
+
+
+### URL-friendly color
+
+This function is used to inject Vanilla color variables into inline SVGs by converting all `#` with the HTML encoded `%23`.
+
+``` scss
+@function vf-url-friendly-color($color) {
+  @if type-of($color) != 'color' {
+    @warn '#{$color} is not a color.';
+    @return false;
+  } @else {
+    @return '%23' + str-slice('#{$color}', 2, -1);
+  }
+}
+```
+
+### Determine text color
+
+This function tests the value of the background's colour and returns light or dark text accordingly.
+
+``` scss
+@function vf-determine-text-color($background-color) {
+  @if (lightness($background-color) > 50) {
+    @return $color-dark;
+  } @else {
+    @return $color-x-light;
+  }
+}
+```
+
+### Power function
+
+This function raises a given number to a given power.
+
+``` scss
+@function pow($number, $exponent) {
+  $value: 1;
+
+  @if $exponent > 0 {
+    @for $i from 1 through $exponent {
+      $value: $value * $number;
+    }
+  } @else if $exponent < 0 {
+    @for $i from 1 through -$exponent {
+      $value: $value / $number;
+    }
+  }
+
+  @return $value;
+}
+```
+
+### Related
+
+* [Icons](/en/patterns/icons)
+* [Strip](/en/patterns/strip)
+* [Typography](/en/base/typography)


### PR DESCRIPTION
## Done

- Updated Typography page with new type scale
- Updated Breakpoints page to include `$breakpoint-heading-threshold`
- Updated Spacing settings page with new spacing variables
- Created a Placeholders settings page
- Created a Functions page
- Renamed 'Global navigation' to 'Navigation' (which I think makes more sense)

## QA

- Pull code
- Run `cd docs && ./run`
- Navigate to the following pages and check that they load alright and the copy makes sense
  - http://0.0.0.0:8104/en/base/typography
  - http://0.0.0.0:8104/en/settings/breakpoint-settings
  - http://0.0.0.0:8104/en/settings/placeholder-settings
  - **http://0.0.0.0:8104/en/settings/spacing-settings** (variable names are likely to change in the next release, which will mostly involve renaming/refactoring and minimal if any design changes)
  - http://0.0.0.0:8104/en/utilities/functions
- Ignore the non-wrapping `<pre>` blocks for now - this will be fixed when 1.7.0 is released.

