### PR TITLE
Bump version to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
     "clean": "rm -rf build _jekyll/_site docs/templates node_modules/ yarn-error.log .bundle",
     "build-examples": "gulp build-examples"
   },
-  "version": "1.7.0-beta-2.1"
+  "version": "1.7.0"
 }

--- a/scss/_settings_system.scss
+++ b/scss/_settings_system.scss
@@ -1,2 +1,2 @@
 // Global system settings
-$app-version: '1.7.0-beta-2.1' !default;
+$app-version: '1.7.0' !default;


### PR DESCRIPTION
## Done

- Bumped version number to 1.7.0
- This will be released early tomorrow morning (10/05), alongside the docs and vf.io
