### PR TITLE
Darken neutral bg hover color by 10%

### DIFF
--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -33,7 +33,7 @@
     @include vf-button-pattern (
       $button-disabled-border-color: $color-mid-light,
       $button-border-color: $color-mid-light,
-      $button-hover-background-color: $color-light,
+      $button-hover-background-color: darken($color-light, 10%),
       $button-hover-border-color: $color-mid-light
     );
   }


### PR DESCRIPTION
## Done

Darken neutral bg hover color by 10%

## Note

@kwm14 Despite http://scg.ar-ch.org/ saying that using `darken(#F7F7F7, 10%)` should produce `#dddddd`, Chrome Inspector reports it as `#dedede` 🤷🏻‍♂️

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/buttons/neutral/
- Verify hovering over neutral button produces a background color of `#dbdbdb`

## Details

Fixes #1802
