### PR TITLE
Vanilla docs styling fixes

### DIFF
--- a/docs/static/sass/styles.scss
+++ b/docs/static/sass/styles.scss
@@ -6,10 +6,6 @@
 @import 'codehilite';
 @include codehilite;
 
-td, th {
-  padding: 1rem 0.75rem;
-}
-
 h2:nth-child(2) {
   display: inline-block;
   margin-bottom: $sp-medium;
@@ -17,6 +13,16 @@ h2:nth-child(2) {
 
 p {
   max-width: 52em;
+}
+
+p > iframe {
+  margin-top: $spv-inter--regular;
+}
+
+th:not(:first-child),
+td:not(:first-child) {
+  padding-left: $sph-intra--condensed;
+  padding-right: $sph-intra--condensed;
 }
 
 .main-col {


### PR DESCRIPTION
## Done

- Removed custom table styling from Docs sass
- Added padding-left to colour column on Color page

## QA

- Pull code
- Run `cd docs && ./run`
- Open http://0.0.0.0:8104/en/settings/color-settings
- Check that the cells in the colour column have .5rem padding on the left
- Open any page with iframes and check that they have `margin-top: 1rem`
