### PR TITLE
Add padding-right to select so chevron does not overlap text

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -194,6 +194,7 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     background-size: map-get($icon-sizes, accordion);
     color: $color-dark;
     min-height: 24px;
+    padding-right: $sph-intra--expanded;
     text-indent: .01px;
     text-overflow: '';
 

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -71,6 +71,7 @@ $spv-inter--deep-scaleable: $sp-unit * 2 * (4 + $multi) !default;
 // 2.1 Horizontal spacing inside components
 $sph-intra--condensed: $sp-unit !default; // input-elements,
 $sph-intra: $sp-unit * 2 !default; // buttons, accordions, tabs, menu, card padding, stepped-list bullet offset
+$sph-intra--expanded: $sp-unit * 3 !default;
 // 2.2 Horizontal spacing outside components
 $sph-inter: $sph-intra !default;
 $sph-inter--expanded: $sp-unit * 3 !default; // checboxes, radios, list bullets


### PR DESCRIPTION
## Done

- Added extra `padding-right` to `select`s so that the chevron does not overlap text
- Created a new spacing variable `$sph-intra--expanded` which is used here, and will probably be reused wherever there are 1rem icons used as backgrounds

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/forms/selects/
- Add a bunch of text to the first `select` option, e.g:
``` html
<option value="" disabled="disabled" selected="">Select an option Select an option Select an option Select an option</option>
```
- Check that the text and chevron don't overlap

## Details

Fixes #1563 
