### PR TITLE
Remove space from heading hashes

### DIFF
--- a/docs/en/patterns/icons.md
+++ b/docs/en/patterns/icons.md
@@ -75,6 +75,6 @@ If you wish to add share icons for Twitter, Facebook, Google+ or LinkedIn, we re
 
   <hr />
 
-  ### Design
+ ### Design
 
   * [Icons design](https://github.com/ubuntudesign/vanilla-design/tree/master/Icons)


### PR DESCRIPTION
This space was preventing the 'Design' h3 from parsing correctly.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Run docs
- Check icons page
- Scroll to bottom, verify heading parses correctly