### PR TITLE
Fix Vanilla component interdependencies

### DIFF
--- a/examples/base/forms/form.html
+++ b/examples/base/forms/form.html
@@ -12,5 +12,5 @@ category: _base
   <input type="file" id="exampleInputFile">
   <input type="checkbox" id="CheckMe">
   <label for="CheckMe">Check me out</label>
-  <button type="submit" class="p-button">Submit</button>
+  <button type="submit">Submit</button>
 </form>

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -181,7 +181,17 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
   }
 
   [type='submit'] {
-    @extend %p-button--positive;
+    @extend %vf-button-base;
+
+    @include vf-button-pattern (
+      $button-background-color: $color-positive,
+      $button-border-color: $color-positive,
+      $button-text-color: $color-x-light,
+      $button-hover-background-color: darken($color-positive, 10%),
+      $button-hover-border-color: darken($color-positive, 10%),
+      $button-disabled-background-color: $color-positive,
+      $button-disabled-border-color: $color-positive
+    );
   }
 
   // Select styles

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -67,7 +67,6 @@
       left: 0;
       position: absolute;
       right: 0;
-      top: 0;
     }
   }
 

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -73,4 +73,10 @@
     text-indent: calc(100% + 10rem);
     white-space: nowrap;
   }
+
+  %vf-clearfix::after {
+    clear: both;
+    content: '';
+    display: block;
+  }
 }

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -27,6 +27,13 @@
     color: $color-dark;
   }
 
+  %vf-card {
+    @extend %vf-bg--x-light;
+    margin-bottom: $spv-inter--scaleable;
+    overflow: auto; // prevent overflow of child margins
+    padding: $spv-intra--scaleable;
+  }
+
   // Bars and borders
   %vf-pseudo-border {
     background-color: $color-mid-light;

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -63,4 +63,14 @@
       top: 0;
     }
   }
+
+  // Utilities
+  %vf-hide-text {
+    overflow: hidden;
+    // rem value necessary because text indent in % does not work with padding;
+    // 10rem is bigger than any padding value on an element you'd hide text in (buttons, icons)
+    // but still smaller than 9999px so should have better performance
+    text-indent: calc(100% + 10rem);
+    white-space: nowrap;
+  }
 }

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -1,3 +1,5 @@
+@import 'settings';
+
 @mixin vf-b-placeholders {
   // Placeholders containing used rules in multiple base components and patterns
   // Default settings can be found in _settings_placeholders

--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -65,10 +65,17 @@
   @return $value;
 }
 
-@mixin vf-m-category-bar ($bg-color: #f00) {
+@mixin vf-highlight-bar($bg-color: $color-mid-dark, $position: top, $over-border: false) {
   @extend %vf-pseudo-bar;
 
   &::before {
     background-color: $bg-color;
+    #{$position}: 0;
+
+    @if $over-border == true {
+      left: -1px;
+      right: -1px;
+      z-index: 1;
+    }
   }
 }

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -1,13 +1,6 @@
 @import 'settings';
 
 @mixin vf-p-card {
-  %p-card {
-    @extend %vf-bg--x-light;
-    margin-bottom: $spv-inter--scaleable;
-    overflow: auto; // prevent overflow of child margins
-    padding: $spv-intra--scaleable;
-  }
-
   @include vf-p-card-default;
   @include vf-p-card-highlighted;
   @include vf-p-card-overlay;
@@ -17,18 +10,18 @@
 
 @mixin vf-p-card-default {
   .p-card {
+    @extend %vf-card;
     @extend %vf-is-bordered;
     @extend %vf-has-round-corners;
-    @extend %p-card;
     padding: $spv-intra--scaleable - $px;
   }
 }
 
 @mixin vf-p-card-highlighted {
   %p-card--highlighted {
+    @extend %vf-card;
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
-    @extend %p-card;
   }
 
   .p-card--highlighted {

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -8,7 +8,9 @@
 
     // Dropdown element for contextual menu
     &__dropdown {
-      @extend .p-card--highlighted; // sass-lint:disable-line placeholder-in-extend
+      @extend %vf-card;
+      @extend %vf-has-box-shadow;
+      @extend %vf-has-round-corners;
       display: none;
       margin: 0;
       max-width: 21rem;

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -127,7 +127,7 @@
 @mixin vf-p-icons {
 
   %icon {
-    @extend %u-hide-text;
+    @extend %vf-hide-text;
     @include vf-icon-size($sp-medium);
     background: {
       position: center;
@@ -143,7 +143,7 @@
   }
 
   %social-icon {
-    @extend %u-hide-text;
+    @extend %vf-hide-text;
     display: inline-block;
     height: map-get($icon-sizes, social);
     width: map-get($icon-sizes, social);

--- a/scss/_patterns_inline-images.scss
+++ b/scss/_patterns_inline-images.scss
@@ -3,7 +3,7 @@
 // Image grid to showcase group of images
 @mixin vf-p-inline-images {
   .p-inline-images {
-    @extend %clearfix;
+    @extend %vf-clearfix;
     display: block;
     list-style: none; // if list is used as wrapper
     margin-left: 0;

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -77,7 +77,7 @@ $spv-list-item--inner: .25 * $spv-inter--condensed-scaleable; // padding top and
 // List styling using list class
 @mixin vf-p-list {
   .p-list {
-    @extend %clearfix;
+    @extend %vf-clearfix;
     @include vf-list;
 
     &__item {
@@ -164,7 +164,7 @@ $spv-list-item--inner: .25 * $spv-inter--condensed-scaleable; // padding top and
 // Displays a step by step list of instructions
 @mixin vf-p-stepped-list {
   .p-list-step {
-    @extend %clearfix;
+    @extend %vf-clearfix;
     @extend %ol-numbered;
 
     > li {
@@ -190,7 +190,7 @@ $spv-list-item--inner: .25 * $spv-inter--condensed-scaleable; // padding top and
 
 @mixin vf-p-stepped-list-detailed {
   .p-stepped-list--detailed {
-    @extend %clearfix;
+    @extend %vf-clearfix;
     @extend %ol-numbered;
 
     > li {

--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -17,7 +17,9 @@
     width: 100%;
 
     &__dialog {
-      @extend .p-card--highlighted; // sass-lint:disable-line placeholder-in-extend
+      @extend %vf-card;
+      @extend %vf-has-box-shadow;
+      @extend %vf-has-round-corners;
       bottom: $sp-large;
       left: $sp-large;
       max-width: $grid-max-width;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -246,7 +246,7 @@ $nav-border-bottom-thickness: $px;
     }
 
     &.is-selected > a {
-      @extend %current-indicator;
+      @include vf-highlight-bar($color-mid-dark, bottom, true);
     }
   }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -246,7 +246,7 @@ $nav-border-bottom-thickness: $px;
     }
 
     &.is-selected > a {
-      @include vf-highlight-bar($color-mid-dark, bottom, true);
+      @include vf-highlight-bar($color-navigation-active-bar, bottom, true);
     }
   }
 

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -1,20 +1,15 @@
 @import 'settings';
-$notificaiton-response-padding-top: $spv-intra--condensed--scaleable + $spv-nudge - $bar-thickness;
 
 // Notification style patterns
 @mixin vf-p-notification {
 
   // The mixin for basic notification styling
   %vf-notification {
-    background-color: $color-x-light;
-    border: 0;
-    border-radius: $border-radius;
-    border-top: $bar-thickness solid $color-mid-dark;
-    box-shadow: 0 1px 5px 1px transparentize($color-x-dark, .8);
-    color: $color-dark;
+    @extend %vf-has-round-corners;
+    @extend %vf-has-box-shadow;
+    @extend %vf-card;
     display: flex;
-    margin-bottom: $spv-inter--scaleable;
-    overflow: hidden;
+    padding: 0;
   }
 
   @include vf-notifications-default;
@@ -28,6 +23,7 @@ $notificaiton-response-padding-top: $spv-intra--condensed--scaleable + $spv-nudg
 @mixin vf-notifications-default {
   .p-notification {
     @extend %vf-notification;
+    @include vf-highlight-bar($color-mid-dark);
 
     & + & {
       margin-top: $spv-inter--scaleable; // negate bottom margin
@@ -35,11 +31,10 @@ $notificaiton-response-padding-top: $spv-intra--condensed--scaleable + $spv-nudg
 
     &__response {
       @extend %default-text;
-
-      background-position: $sph-intra $notificaiton-response-padding-top + .5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default));
+      background-position: $sph-intra $spv-intra--condensed--scaleable + $spv-nudge + .5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default));
       background-repeat: no-repeat;
       background-size: map-get($icon-sizes, default);
-      padding: $notificaiton-response-padding-top $sph-intra ($spv-intra--scaleable - $spv-nudge) $sph-intra;
+      padding: $spv-intra--condensed--scaleable + $spv-nudge $sph-intra $spv-intra--condensed--scaleable;
     }
 
     &__status {
@@ -55,7 +50,7 @@ $notificaiton-response-padding-top: $spv-intra--condensed--scaleable + $spv-nudg
       background-color: transparent;
       background-size: map-get($icon-sizes, default);
       border: 0;
-      margin: $sp-unit * 2 $sph-intra auto auto;
+      margin: $sp-unit * 2 + $bar-thickness $sph-intra auto auto;
       padding: $spv-intra;
     }
   }
@@ -70,7 +65,7 @@ $notificaiton-response-padding-top: $spv-intra--condensed--scaleable + $spv-nudg
 @mixin vf-notifications-positive {
   .p-notification--positive {
     @extend %vf-notification;
-    border-top-color: $color-positive;
+    @include vf-highlight-bar($color-positive);
 
     .p-notification__response {
       background-image: url("data:image/svg+xml,%3Csvg width='17px' height='17px' viewBox='0 0 17 17' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='notification-success' transform='translate(1.000000, 1.000000)'%3E%3Cg id='Page-3---colours'%3E%3Cg id='Notifications---single'%3E%3Cg id='Group'%3E%3Cg id='ICON'%3E%3Ccircle id='circle6710' stroke='" + vf-url-friendly-color($color-positive) + "' stroke-width='1.5' fill='" + vf-url-friendly-color($color-positive) + "' cx='7.2500086' cy='7.2500086' r='7.2500086'%3E%3C/circle%3E%3Cpolygon id='path6712' fill='" + vf-url-friendly-color($color-x-light) + "' points='11.0502986 4.1734486 10.9843986 4.2311486 6.2496486 8.3783686 3.4740786 5.9974286 2.6350186 6.9463086 6.2503386 10.7500186 11.7500086 4.9627786 11.0502986 4.1734886'%3E%3C/polygon%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
@@ -83,7 +78,7 @@ $notificaiton-response-padding-top: $spv-intra--condensed--scaleable + $spv-nudg
 @mixin vf-notifications-caution {
   .p-notification--caution {
     @extend %vf-notification;
-    border-top-color: $color-caution;
+    @include vf-highlight-bar($color-caution);
 
     .p-notification__response {
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16'%3E%3Cg color='%23000'%3E%3Cpath fill='none' d='M0 0h16v16H0z'/%3E%3Cpath stroke-linejoin='round' fill='#{vf-url-friendly-color($color-caution)}' transform='matrix%282.28 0 0 2.437 -2180.8 -490.52%29' stroke='#{vf-url-friendly-color($color-caution)}' stroke-width='.848' d='M963.07 207.03h-6.15l3.08-5.33z'/%3E%3Cpath d='M7 5v5h2V5H7zm0 6v2h2v-2H7z' fill='%23111'/%3E%3C/g%3E%3C/svg%3E");
@@ -97,7 +92,7 @@ $notificaiton-response-padding-top: $spv-intra--condensed--scaleable + $spv-nudg
   @include deprecate('2.0.0', 'Use .p-notifications--caution instead') {
     .p-notification--warning {
       @extend %vf-notification;
-      border-top-color: $color-warning;
+      @include vf-highlight-bar($color-warning);
 
       .p-notification__response {
         background-image: url("data:image/svg+xml,%3Csvg width='17px' height='17px' viewBox='0 0 17 17' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='notification-warning' transform='translate(1.000000, 1.000000)'%3E%3Cg id='Page-3---colours'%3E%3Cg id='Notifications---single'%3E%3Cg id='Group'%3E%3Cg id='ICON'%3E%3Ccircle id='circle5432' stroke='" + vf-url-friendly-color($color-caution) + "' stroke-width='1.5' fill='" + vf-url-friendly-color($color-caution) + "' cx='7.2500086' cy='7.2500086' r='7.2500086'%3E%3C/circle%3E%3Cpath d='M6.2500086,3.2500086 L6.2500086,8.2500086 L8.2500086,8.2500086 L8.2500086,3.2500086 L6.2500086,3.2500086 L6.2500086,3.2500086 L6.2500086,3.2500086 Z M6.2500086,9.2500086 L6.2500086,11.2500086 L8.2500086,11.2500086 L8.2500086,9.2500086 L6.2500086,9.2500086 L6.2500086,9.2500086 L6.2500086,9.2500086 Z' id='rect5434' fill='" + vf-url-friendly-color($color-x-light) + "'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
@@ -111,7 +106,7 @@ $notificaiton-response-padding-top: $spv-intra--condensed--scaleable + $spv-nudg
 @mixin vf-notifications-negative {
   .p-notification--negative {
     @extend %vf-notification;
-    border-top-color: $color-negative;
+    @include vf-highlight-bar($color-negative);
 
     .p-notification__response {
       background-image: url("data:image/svg+xml,%3Csvg width='16px' height='17px' viewBox='0 0 16 17' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cg id='Page-3---colours' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='Notifications---single' transform='translate(-215.000000, -271.000000)'%3E%3Cg id='Group' transform='translate(205.000000, 254.000000)'%3E%3Cg id='ICON' transform='translate(10.000000, 17.000000)'%3E%3Crect id='rect6415' x='0' y='0.36218' width='16' height='16'%3E%3C/rect%3E%3Ccircle id='circle6417' stroke='" + vf-url-friendly-color($color-negative) + "' stroke-width='1.5' fill='" + vf-url-friendly-color($color-negative) + "' cx='8' cy='8.36218' r='7.2500086'%3E%3C/circle%3E%3Cpath d='M5.00001,5.36218 L11.00001,11.36218' id='path6479-8' stroke='" + vf-url-friendly-color($color-x-light) + "' stroke-width='1.5'%3E%3C/path%3E%3Cpath d='M11.00001,5.36218 L5.00001,11.36218' id='path6481-8' stroke='" + vf-url-friendly-color($color-x-light) + "' stroke-width='1.5'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
@@ -124,6 +119,6 @@ $notificaiton-response-padding-top: $spv-intra--condensed--scaleable + $spv-nudg
 @mixin vf-notifications-information {
   .p-notification--information {
     @extend %vf-notification;
-    border-top-color: $color-information;
+    @include vf-highlight-bar($color-information);
   }
 }

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -60,7 +60,7 @@
     }
 
     & span {
-      @extend %u-hide-text;
+      @extend %vf-hide-text;
     }
   }
 }

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -77,7 +77,7 @@
 
       &:hover,
       &[aria-selected="true"] {
-        @include vf-highlight-bar($color-mid-dark, bottom, true);
+        @include vf-highlight-bar($color-tabs-active-bar, bottom, true);
       }
     }
   }

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -77,23 +77,8 @@
 
       &:hover,
       &[aria-selected="true"] {
-        @extend %current-indicator;
+        @include vf-highlight-bar($color-mid-dark, bottom, true);
       }
-    }
-  }
-
-  %current-indicator {
-    position: relative;
-
-    &::after {
-      background: $color-mid-dark;
-      bottom: 0;
-      content: '';
-      height: $bar-thickness;
-      left: -1px;
-      position: absolute;
-      right: -1px;
-      z-index: 1;
     }
   }
 }

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -30,6 +30,10 @@ $grid-border-style:      1px dotted $color-mid-light !default;
 
 // for _patterns_navigation.scss
 $color-navigation-background:    $color-x-light !default;
+$color-navigation-active-bar:    $color-mid-dark !default;
+
+// for _patterns_tabs.scss
+$color-tabs-active-bar:          $color-mid-dark !default;
 
 $states: (
   error: $color-negative,

--- a/scss/_utilities_clearfix.scss
+++ b/scss/_utilities_clearfix.scss
@@ -2,14 +2,8 @@
 
 // Force a parent to clear floated children
 @mixin vf-u-clearfix {
-  %clearfix::after {
-    clear: both;
-    content: '';
-    display: block;
-  }
-
   .u-clearfix::after {
-    @extend %clearfix;
+    @extend %vf-clearfix;
   }
 }
 

--- a/scss/_utilities_hide.scss
+++ b/scss/_utilities_hide.scss
@@ -2,17 +2,8 @@
 
 // Hide elements with explicit breakpoints
 @mixin vf-u-hide {
-  %u-hide-text {
-    overflow: hidden;
-    // rem value necessary because text indent in % does not work with padding;
-    // 10rem is bigger than any padding value on an element you'd hide text in (buttons, icons)
-    // but still smaller than 9999px so should have  better performance
-    text-indent: calc(100% + 10rem);
-    white-space: nowrap;
-  }
-
   .u-hide-text {
-    @extend %u-hide-text;
+    @extend %vf-hide-text;
   }
 
   .u-hide {


### PR DESCRIPTION
## Done

- Added settings import to `_base-placeholders.scss` in case you wanted to be super selective about what you include from base
- Removed reference to `%p-button--positive` from base form and replaced with in situ version
- Moved `%u-hide-text` to `_base-placeholders` (encapsulation for switch + icon components)
- Moved `%clearfix` to `_base-placeholders` (encapsulation for list and inline image components)
- Moved `%p-card` to `_base-placeholders`, and extended p-card--highlighted, modal and contextual menu from this placeholder
- Updated highlight bar function so that you can choose position (top or bottom) and whether you want it to sit on top of borders, so it can be used for notification, tab and navigation (and in future p-card--featured)
- Rewrote Notification component to use highlight bar function, and fixed baseline alignment

## QA

- Pull code
- Open `scss/_vanilla.scss` and comment out all the includes except for vf-base
- Run `./run build` and ensure there are no errors
- Uncomment `vf-p-switch` and run `./run build` and ensure there are no errors
- Recomment `vf-p-switch`, uncomment `vf-p-icons` and run `./run build`
- Do the same for the following components and ensure no errors:
  - `vf-p-lists`
  - `vf-p-inline-images`
  - `vf-p-card`
  - `vf-p-modal`
  - `vf-p-contextual-menu`
  - `vf-p-navigation`
  - `vf-p-tabs`
  - `vf-p-notification`
- Percy should only show differences for the notification pattern, because baseline alignment has been fixed. If there are any other visual diffs, I've messed up somewhere :(

## Details

Fixes #1639 
