### PR TITLE
Fix contextual menu example

### DIFF
--- a/examples/patterns/contextual-menu.html
+++ b/examples/patterns/contextual-menu.html
@@ -92,6 +92,24 @@ category: _patterns
         }
     }
 
+    function clickOutsideListener(selector) {
+        var toggles = document.querySelectorAll(selector);
+
+        document.addEventListener('click', function(event) {
+            toggles.forEach(function(toggle) {
+                var dropdown = document.querySelector(toggle.getAttribute('aria-controls'));
+                var clickOutside = !(toggle.contains(event.target) || dropdown.contains(event.target));
+
+                if (clickOutside) {
+                    toggle.setAttribute('aria-expanded', false);
+                    dropdown.setAttribute('aria-hidden', true);
+                }
+            })
+        });
+
+    }
+
     toggle('.p-contextual-menu__toggle');
+    clickOutsideListener('.p-contextual-menu__toggle');
 })()
 </script>


### PR DESCRIPTION
## Done

- Added a function to the contextual menu example that closes an open dropdown if you click outside of it

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/contextual-menu/
- Click the `Link`s on the page and check that they close if you click outside of them

## Details

Fixes #1593 
