### PR TITLE
Convert .p-switch from button to checkbox

### DIFF
--- a/_jekyll/_layouts/default.html
+++ b/_jekyll/_layouts/default.html
@@ -26,15 +26,14 @@
             }
             class baselineGrid {
                 constructor() {
-                    this.target = document.body,
+                    this.target = document.body;
                     this.baselineHeight = 8;
                     this.baselineContainerClassName = "u-baseline-container";
                     this.baselineRowClassName = "u-baseline";
                     this.toggleGridClass = "u-hide";
-                    this.showGrid = false;
                 }
                 addBaselineGridToggle() {
-                    var controls = fragmentFromString('<div class="controls"><button id="switch-on" class="p-switch js-baseline-toggle" type="button" role="switch" aria-checked="false" aria-labelledby="switch-on-label"><span>On</span><span>Off</span></button></div>');
+                    var controls = fragmentFromString('<div class="controls"><label><input type="checkbox" class="p-switch js-baseline-toggle" /><div class="p-switch__slider"></div></label></div>');
                     this.target.appendChild(controls);
                 }
                 appendBaselineRow(parent) {
@@ -64,19 +63,11 @@
                     this.baselineContainer = document.querySelector('.u-baseline-container');
                 }
                 initGridToggle(switchBtn) {
-                    var toggle = document.querySelector(switchBtn),
-                        that = this;
+                    var toggle = document.querySelector(switchBtn);
 
                     toggle.addEventListener('click', function (event) {
-                        if (!that.showGrid) {
-                            this.setAttribute('aria-checked', true);
-                            that.baselineContainer.classList.remove(that.toggleGridClass);
-                        } else {
-                            this.setAttribute('aria-checked', false);
-                            that.baselineContainer.classList.add(that.toggleGridClass);
-                        }
-                        that.showGrid = !that.showGrid;
-                    });
+                        this.baselineContainer.classList.toggle(this.toggleGridClass);
+                    }.bind(this));
                 }
                 update() {
                     this.baselineContainer.remove();

--- a/examples/patterns/switch.html
+++ b/examples/patterns/switch.html
@@ -4,70 +4,27 @@ title: Switch
 category: _patterns
 ---
 
-<label id="switch-on-label" for="switch-on">Switch - On</label>
-<button id="switch-on" class="p-switch" type="button" role="switch" aria-checked="true" aria-labelledby="switch-on-label">
-  <span>On</span>
-  <span>Off</span>
-</button>
+<label>
+    Switch - On
+    <input type="checkbox" class="p-switch" checked />
+    <div class="p-switch__slider"></div>
+</label>
 
-<label id="switch-off-label" for="switch-off">Switch - Off</label>
-<button id="switch-off" class="p-switch" type="button" role="switch" aria-checked="false" aria-labelledby="switch-off-label">
-  <span>On</span>
-  <span>Off</span>
-</button>
+<label>
+    Switch - Off
+    <input type="checkbox" class="p-switch" />
+    <div class="p-switch__slider"></div>
+</label>
 
-<label id="on-disabled-label" for="on-disabled">Switch - On disabled</label>
-<button id="on-disabled" class="p-switch" type="button" role="switch" aria-checked="true" aria-labelledby="on-disabled-label" disabled>
-  <span>On</span>
-  <span>Off</span>
-</button>
 
-<label id="off-disabled-label" for="off-disabled">Switch - Off disabled</label>
-<button id="off-disabled" class="p-switch" type="button" role="switch" aria-checked="false" aria-labelledby="off-disabled-label" disabled>
-  <span>On</span>
-  <span>Off</span>
-</button>
+<label>
+    Switch - On disabled
+    <input type="checkbox" class="p-switch" checked disabled />
+    <div class="p-switch__slider"></div>
+</label>
 
-<script>
-(function() {
-  /**
-   * Control switch elements via toggling aria-checked
-   *
-   * @param {String} switchBtn
-   *
-   * @example
-   * <label id="switch-label" for="switch">Switch</label>
-   * <button id="switch" class="p-switch" type="button" role="switch" aria-checked="false" aria-labelledby="switch-label">
-   *   <span>On</span>
-   *   <span>Off</span>
-   * </button>
-   *
-   */
-  function switchToggle(switchBtn) {
-
-    // Select all switch control elements
-    /**
-     * @param {Object[]} switches
-     * @param {String} switchBtn
-     */
-    var switches = Array.prototype.slice.call(
-      document.querySelectorAll(switchBtn)
-    );
-
-    // Set click event to each switch control element
-    /**
-     * @param {String} switchBtn
-     */
-    switches.forEach(function (switchBtn) {
-      switchBtn.addEventListener('click', function(event) {
-
-        // If aria-checked is already true, set to false
-        this.setAttribute('aria-checked',
-          this.getAttribute('aria-checked') === 'true' ? 'false' : 'true');
-      });
-    });
-  }
-
-  switchToggle('.p-switch');
-})()
-</script>
+<label>
+    Switch - Off disabled
+    <input type="checkbox" class="p-switch" disabled />
+    <div class="p-switch__slider"></div>
+</label>

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -243,6 +243,7 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
 
   label {
     @extend %default-text;
+    width: fit-content;
   }
 
   // Accessible checkbox technique from https://medium.com/claritydesignsystem/pure-css-accessible-checkboxes-and-radios-buttons-54063e759bb3

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -1,66 +1,116 @@
 @import 'settings';
+$knob-size: $sp-unit * 3;
 
 @mixin vf-p-switch {
   .p-switch {
-    $knob-size: $sp-unit * 3;
-    align-items: stretch;
-    border: 0;
-    display: inline-flex;
     height: $knob-size;
-    padding: initial;
+    margin: 0;
     position: relative;
     width: $knob-size * 2;
 
+    &:checked + .p-switch__slider::before {
+      left: 50%;
+    }
+
+    &:disabled + .p-switch__slider {
+      @extend %vf-disabled-element;
+    }
+
     &:focus {
-      outline: 1px solid $color-link;
-      outline-offset: 3px;
-    }
+      outline: 0;
 
-    :first-child,
-    :last-child {
-      box-shadow: inset 0 2px 5px 0 transparentize($color-dark, .8);
-      line-height: $knob-size;
-      margin: 0;
-      text-align: center;
-      width: 50%;
-    }
-
-    :first-child {
-      background-color: $color-information;
-      border-radius: 2px 0 0 2px;
-      color: $color-x-light;
-    }
-
-    :last-child {
-      background-color: $color-mid-light;
-      border-radius: 0 2px 2px 0;
-    }
-
-    &::before {
-      @include vf-animation($duration: slow);
-
-      background-color: $color-x-light;
-      border-radius: $border-radius;
-      box-shadow: 0 1px 5px 1px transparentize($color-dark, .8);
-      content: '';
-      display: block;
-      height: 100%;
-      left: 0;
-      max-height: $sp-x-large;
-      padding: 0;
-      position: absolute;
-      top: 0;
-      width: 50%;
-    }
-
-    &[aria-checked='true'] {
-      &::before {
-        left: 50%;
+      + .p-switch__slider {
+        outline: 1px solid $color-focus;
+        outline-offset: 2px;
       }
     }
 
-    & span {
-      @extend %vf-hide-text;
+    &__slider {
+      @extend %vf-has-round-corners;
+      background: linear-gradient(to right, $color-information 50%, $color-mid-light 50%);
+      box-shadow: inset 0 2px 5px 0 transparentize($color-dark, .8);
+      height: $knob-size;
+      margin: $spv-nudge-compensation 0 $spv-inter--condensed-scaleable 0;
+      position: relative;
+      width: $knob-size * 2;
+
+      &::before {
+        @extend %vf-has-round-corners;
+        @extend %vf-has-box-shadow;
+        @include vf-animation($duration: slow);
+        background: $color-x-light;
+        content: "";
+        height: $knob-size;
+        left: 0;
+        position: absolute;
+        width: $knob-size;
+      }
+
+      & span {
+        @extend %vf-hide-text;
+      }
+    }
+  }
+
+  @include deprecate('2.0.0', 'Use checkbox version of .p-switch') {
+    button.p-switch { // sass-lint:disable-line no-qualifying-elements
+      align-items: stretch;
+      border: 0;
+      display: inline-flex;
+      height: $knob-size;
+      padding: initial;
+      width: $knob-size * 2;
+
+      :first-child,
+      :last-child {
+        box-shadow: inset 0 2px 5px 0 transparentize($color-dark, .8);
+        line-height: $knob-size;
+        margin: 0;
+        text-align: center;
+        width: 50%;
+      }
+
+      :first-child {
+        background-color: $color-information;
+        border-radius: 2px 0 0 2px;
+        color: $color-x-light;
+      }
+
+      :last-child {
+        background-color: $color-mid-light;
+        border-radius: 0 2px 2px 0;
+      }
+
+      &::before {
+        @include vf-animation($duration: slow);
+        background: inherit;
+        background-color: $color-x-light;
+        border-radius: $border-radius;
+        box-shadow: 0 1px 5px 1px transparentize($color-dark, .8);
+        content: '';
+        display: block;
+        height: 100%;
+        left: 0;
+        max-height: $sp-x-large;
+        padding: 0;
+        position: absolute;
+        top: 0;
+        width: 50%;
+      }
+
+      &::after {
+        display: none;
+      }
+
+      &[aria-checked='true'] {
+        &::before {
+          left: 50%;
+        }
+      }
+
+      & span {
+        @extend %vf-hide-text;
+      }
     }
   }
 }


### PR DESCRIPTION
## Done

- Converted the `.p-switch` component to a checkbox so it can be used without JS
- Updated example page with new markup and removed JS
- Deprecated the old button version, to be removed in v2.0.0
- Changed the baseline grid switch to the new checkbox version
- Aligned the switch component to the baseline grid
- Fixed the focus colour
- Added `width: fit-content` to `<label>`s so you can't click way outside the label to get the input to trigger

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/switch/
- Check that it behaves exactly like https://vanilla-framework.github.io/vanilla-framework/examples/patterns/switch/ (there will be a small difference in vertical spacing)
- Test on Chrome, IE, Edge and Firefox < v58
- Turn on the baseline grid (`_jekyll/_layouts/default.html` change `VF_ENV` to `"DEV"`)
- Check that the switches and labels sit on the lines
- Check that the focus colour is the same as all the other form elements (`#19b6ee`)
- Edit the markup of the page so it uses the button version (see [here](https://github.com/vanilla-framework/vanilla-framework/blob/develop/examples/patterns/switch.html)) and check that it still looks and functions right

## Details

Fixes #1453, fixes #1759 
