### PR TITLE
Update Docs to 1.7.1

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -37,7 +37,7 @@ Note: If you don't need the whole framework, you can just include specific parts
 
 Alternatively, you can add Vanilla directly to your markup:
 
-`<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.7.0.min.css" />`
+`<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.7.1.min.css" />`
 
 ### Download
 

--- a/docs/en/utilities/functions.md
+++ b/docs/en/utilities/functions.md
@@ -59,6 +59,27 @@ This function raises a given number to a given power.
 }
 ```
 
+### Highlight bar
+
+This function adds a `3px` thick, coloured bar to the top or bottom of a component (for example in Notification, Navigation and Tab components). The `$over-border` argument determines whether the bar sits on top of a component with borders.
+
+``` scss
+@mixin vf-highlight-bar($bg-color: $color-mid-dark, $position: top, $over-border: false) {
+  @extend %vf-pseudo-bar;
+
+  &::before {
+    background-color: $bg-color;
+    #{$position}: 0;
+
+    @if $over-border == true {
+      left: -1px;
+      right: -1px;
+      z-index: 1;
+    }
+  }
+}
+```
+
 ### Related
 
 * [Icons](/en/patterns/icons)

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "node-sass": "^4.5.3",
-    "vanilla-framework": "1.7.0",
+    "vanilla-framework": "1.7.1",
     "watch-cli": "^0.2.2"
   }
 }

--- a/docs/template.html
+++ b/docs/template.html
@@ -69,7 +69,7 @@
         </header>
         <div class="sidebar__content js-sidebar-toggle u-hide" aria-hidden="true">
           <select name="version-select" id="version-select">
-            <option value="latest">v1.7.0</option>
+            <option value="latest">v1.7.1</option>
           </select>
           <form class="p-search-box" onsubmit="return false">
             <input type="search" id="search-docs" class="p-search-box__input" name="search" placeholder="Search components" oninput="filterDocs()" title="Search the documentation" required />

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1223,9 +1223,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.7.0.tgz#ae198e46f0823ee2d316bcd2783e4846df676728"
+vanilla-framework@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.7.1.tgz#3649e693a57cdd9b457d9589e98aecd32218b9be"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- Updated the Vanilla docs to version 1.7.1 (I will automate this soon, I swear :sweat_smile:)
- Added `Highlight bar` function to Functions page

## QA

- Pull code, `cd docs && ./run`, http://0.0.0.0:8104/en/
- Check that the dropdown says 1.7.1 and the hotlink on the index page says 1.7.1
- Go to http://0.0.0.0:8104/en/utilities/functions and check that the Highlight bar function is there