### PR TITLE
Simplify baseline utility + add example page

### DIFF
--- a/_jekyll/_layouts/default.html
+++ b/_jekyll/_layouts/default.html
@@ -26,7 +26,7 @@
 
         document.addEventListener('DOMContentLoaded', function() {
             var body = document.body;
-            var controls = fragmentFromString('<div class="u-baseline-grid__toggle"><label><input type="checkbox" class="p-switch js-baseline-toggle" /><div class="p-switch__slider"></div></label></div>');
+            var controls = fragmentFromString('<div class="u-baseline-grid__toggle"><label>Toggle baseline grid<input type="checkbox" class="p-switch js-baseline-toggle" /><div class="p-switch__slider"></div></label></div>');
             body.appendChild(controls);
 
             var toggle = document.querySelector('.js-baseline-toggle');

--- a/_jekyll/_layouts/default.html
+++ b/_jekyll/_layouts/default.html
@@ -16,72 +16,24 @@
 
 {{ content }}
     </body>
+    {% if site.env == 'development' %}
     <script>
-        var VF_ENV = "PRODUCTION";
-        if (VF_ENV === "DEV") {
-            fragmentFromString = function fragmentFromString(strHTML) {
-                var temp = document.createElement('template');
-                temp.innerHTML = strHTML;
-                return temp.content;
-            }
-            class baselineGrid {
-                constructor() {
-                    this.target = document.body;
-                    this.baselineHeight = 8;
-                    this.baselineContainerClassName = "u-baseline-container";
-                    this.baselineRowClassName = "u-baseline";
-                    this.toggleGridClass = "u-hide";
-                }
-                addBaselineGridToggle() {
-                    var controls = fragmentFromString('<div class="controls"><label><input type="checkbox" class="p-switch js-baseline-toggle" /><div class="p-switch__slider"></div></label></div>');
-                    this.target.appendChild(controls);
-                }
-                appendBaselineRow(parent) {
-                    var baseline = document.createElement('div');
-                    baseline.classList.add(this.baselineRowClassName);
-                    parent.appendChild(baseline);
-                }
-                baselineCount() {
-                    return Math.floor(document.documentElement.scrollHeight / this.baselineHeight);
-                }
-                create() {
-                    var baselineContainer = document.createElement('div'),
-                        fragment = document.createDocumentFragment(),
-                        documentHeight = document.documentElement.scrollHeight,
-                        baselineCount = this.baselineCount(documentHeight);
-
-                    baselineContainer.classList.add(this.baselineContainerClassName);
-
-                    if (!this.showGrid) {
-                        baselineContainer.classList.add(this.toggleGridClass);
-                    }
-                    for (var i = 0; i < baselineCount; i++) {
-                        this.appendBaselineRow(baselineContainer);
-                    }
-                    fragment.appendChild(baselineContainer);
-                    this.target.appendChild(fragment);
-                    this.baselineContainer = document.querySelector('.u-baseline-container');
-                }
-                initGridToggle(switchBtn) {
-                    var toggle = document.querySelector(switchBtn);
-
-                    toggle.addEventListener('click', function (event) {
-                        this.baselineContainer.classList.toggle(this.toggleGridClass);
-                    }.bind(this));
-                }
-                update() {
-                    this.baselineContainer.remove();
-                    this.create();
-                }
-            }
-
-            var bg = new baselineGrid();
-            document.addEventListener('DOMContentLoaded', () => {
-                bg.create();
-                bg.addBaselineGridToggle();
-                bg.initGridToggle('.p-switch.js-baseline-toggle');
-            });
-            window.addEventListener('resize', () => { bg.update(); });
+        function fragmentFromString(htmlString) {
+            var temp = document.createElement('template');
+            temp.innerHTML = htmlString;
+            return temp.content;
         }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            var body = document.body;
+            var controls = fragmentFromString('<div class="u-baseline-grid__toggle"><label><input type="checkbox" class="p-switch js-baseline-toggle" /><div class="p-switch__slider"></div></label></div>');
+            body.appendChild(controls);
+
+            var toggle = document.querySelector('.js-baseline-toggle');
+            toggle.addEventListener('click', function (event) {
+                body.classList.toggle('u-baseline-grid');
+            });
+        });
     </script>
+    {% endif %}
 </html>

--- a/examples/utilities/baseline-grid.html
+++ b/examples/utilities/baseline-grid.html
@@ -1,0 +1,29 @@
+---
+layout: default
+title: Baseline grid
+category: _utilities
+---
+
+<div class="u-baseline-grid">
+  <h1>Heading one</h1>
+  <h2>Heading two</h2>
+  <h3>Heading three</h3>
+  <h4>Heading four</h4>
+  <h5>Heading five</h5>
+  <h6>Heading six</h6>
+  <label>
+    <input type="checkbox" class="p-switch" checked />
+    <div class="p-switch__slider"></div>
+  </label>
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    var target = document.querySelector('.u-baseline-grid');
+    var toggle = document.querySelector('.p-switch');
+
+    toggle.addEventListener('click', function (event) {
+      target.classList.toggle('u-baseline-grid');
+    });
+  });
+</script>

--- a/scss/_utilities_baseline-grid.scss
+++ b/scss/_utilities_baseline-grid.scss
@@ -1,47 +1,32 @@
+@import 'settings';
+
 @mixin vf-u-baseline-grid {
-  body {
+  $baseline-color: #f00 !default;
+  $baseline-offset: 0 !default;
+  $baseline-size: $sp-unit !default;
+
+  .u-baseline-grid {
     position: relative;
-  }
 
-  .controls {
-    bottom: .5rem;
-    padding: .75rem;
-    position: fixed;
-    right: .5rem;
-    z-index: 101;
-  }
+    &::after {
+      background: linear-gradient(to top, transparentize($baseline-color, .7), transparentize($baseline-color, .7) 1px, transparent 1px, transparent);
+      background-size: 100% $baseline-size;
+      bottom: 0;
+      content: "";
+      display: block;
+      left: 0;
+      pointer-events: none;
+      position: absolute;
+      right: 0;
+      top: $baseline-offset;
+      z-index: 100;
+    }
 
-  .u-baseline-container {
-    bottom: 0;
-    height: 100%;
-    left: 0;
-    overflow: hidden;
-    pointer-events: none;
-    position: absolute;
-    right: 0;
-    top: 0;
-    width: 100%;
-    z-index: 100;
-  }
-
-  .u-baseline {
-    font-size: 0;
-    height: $sp-unit;
-    margin: 0;
-    pointer-events: none;
-    position: relative;
-    width: 100%;
-  }
-
-  $debug-baseline-colour: #f00;
-
-  .u-baseline::after {
-    border-bottom: 1px solid fade-out($debug-baseline-colour, .75);
-    bottom: 0;
-    content: '';
-    height: 1px;
-    left: 0;
-    position: absolute;
-    right: 0;
+    &__toggle {
+      bottom: $spv-inter--scaleable;
+      position: fixed;
+      right: $sph-inter--expanded;
+      z-index: 101;
+    }
   }
 }


### PR DESCRIPTION
## Done

- Simplified `.u-baseline-grid` utility used in the Vanilla examples pages
- Added an example page

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check that there is a switch in the bottom-right that can turn on/off the baseline grid
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/headings/default/
- Check that the baseline grid is lined up with the headings
- Open `.env` and change the second line to `JEKYLL_ENV=production`
- Terminate local server and re `./run`
- Check that the switch is no longer present

