### PR TITLE
Update accordion example to be more agnostic

### DIFF
--- a/examples/patterns/accordion.html
+++ b/examples/patterns/accordion.html
@@ -7,20 +7,20 @@ category: _patterns
 <aside class="p-accordion" role="tablist" aria-multiselect="true">
   <ul class="p-accordion__list">
     <li class="p-accordion__group">
-      <button class="p-accordion__tab" id="owner-tab" role="tab" aria-controls="#owner" aria-expanded="true">Owner</button>
-      <section class="p-accordion__panel" id="owner" role="tabpanel" aria-hidden="false" aria-labelledby="owner-tab">
+      <button type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="#tab1-section" aria-expanded="true">Owner</button>
+      <section class="p-accordion__panel" id="tab1-section" role="tabpanel" aria-hidden="false" aria-labelledby="tab1-section">
         <p>Open panel</p>
       </section>
     </li>
     <li class="p-accordion__group">
-      <button class="p-accordion__tab" id="status-tab" role="tab" aria-controls="#status" aria-expanded="false">Status</button>
-      <section class="p-accordion__panel" id="status" role="tabpanel" aria-hidden="true" aria-labelledby="status-tab">
+      <button type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="#tab2-section" aria-expanded="false">Status</button>
+      <section class="p-accordion__panel" id="tab2-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab2-section">
         <p>Closed panel</p>
       </section>
     </li>
     <li class="p-accordion__group">
-      <button class="p-accordion__tab" id="tags-tab" role="tab" aria-controls="#tags" aria-expanded="false">Tags</button>
-      <section class="p-accordion__panel" id="tags" role="tabpanel" aria-hidden="true" aria-labelledby="tags-tab">
+      <button type="button" class="p-accordion__tab" id="tab3" role="tab" aria-controls="#tab3-section" aria-expanded="false">Tags</button>
+      <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
         <p>Closed panel</p>
       </section>
     </li>


### PR DESCRIPTION
## Done

- Added `type="button"` attribute to each button so that if an accordion is placed within a form, it does not trigger submit behaviour.

- Changed names of ids and labels to make them more generic, making cutting and pasting from example section easier.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/accordion/
- Check accordion example and ensure it still works as expected
