### PR TITLE
Align bordered strip to baseline grid using a negative margin

### DIFF
--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -94,6 +94,7 @@
 @mixin vf-p-strip-bordered {
   [class^='p-strip'].is-bordered {
     border-bottom: 1px solid $color-mid-light;
+    margin-bottom: - $px;
   }
 }
 


### PR DESCRIPTION
Apply negative margin of 1px to compensate for height of border.

## Done

[List of work items including drive-bys]

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- [Add additional steps]

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
