### PR TITLE
Hide overflow in u-image-position container

### DIFF
--- a/scss/_utilities_image-position.scss
+++ b/scss/_utilities_image-position.scss
@@ -3,6 +3,7 @@
   .u-image-position {
 
     @media (min-width: $breakpoint-medium) {
+      overflow: hidden;
       position: relative;
 
       %u-image-position {


### PR DESCRIPTION
## Done

- Added `overflow: hidden` to `u-image-position`

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/utilities/image-position/top-right/
- Change the image dimensions to 500x500
- Check that it doesn't overflow the strip

## Details

Fixes #1379 
