### PR TITLE
Fix inline image aspect ratio and crop bug

### DIFF
--- a/examples/patterns/inline-images.html
+++ b/examples/patterns/inline-images.html
@@ -7,21 +7,21 @@ category: _patterns
 
 <ul class="p-inline-images">
   <li class="p-inline-images__item">
-    <img src="https://via.placeholder.com/150x200" alt="Placeholder image" />
+    <img class="p-inline-images__logo" src="https://via.placeholder.com/150x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="https://via.placeholder.com/175x200" alt="Placeholder image" />
+    <img class="p-inline-images__logo" src="https://via.placeholder.com/175x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="https://via.placeholder.com/150x200" alt="Placeholder image" />
+    <img class="p-inline-images__logo" src="https://via.placeholder.com/150x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="https://via.placeholder.com/175x200" alt="Placeholder image" />
+    <img class="p-inline-images__logo" src="https://via.placeholder.com/175x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="https://via.placeholder.com/150x200" alt="Placeholder image" />
+    <img class="p-inline-images__logo" src="https://via.placeholder.com/150x200" alt="Placeholder image" />
   </li>
   <li class="p-inline-images__item">
-    <img src="https://via.placeholder.com/175x200" alt="Placeholder image" />
+    <img class="p-inline-images__logo" src="https://via.placeholder.com/175x200" alt="Placeholder image" />
   </li>
 </ul>

--- a/scss/_patterns_inline-images.scss
+++ b/scss/_patterns_inline-images.scss
@@ -12,24 +12,21 @@
 
     &__item {
       display: inline-block;
-      margin: 1.875rem;
-      max-height: 5.625rem;
-      max-width: 5.625rem;
+      margin: 1rem;
       overflow: hidden;
       text-align: center;
       vertical-align: middle;
 
-      @media (min-width: $breakpoint-medium) {
+      @media only screen and (min-width: $breakpoint-medium) {
         margin: 1.875rem;
-        max-height: 11.25rem;
-        max-width: 11.25rem;
       }
 
-      * {
+      img {
         max-height: map-get($icon-sizes, thumb--small);
         max-width: 7rem;
+        width: auto;
 
-        @media only screen and (min-width: $breakpoint-medium) {
+        @media screen and (min-width: $breakpoint-medium) {
           max-height: 5.5rem;
           max-width: 9rem;
         }

--- a/scss/_patterns_inline-images.scss
+++ b/scss/_patterns_inline-images.scss
@@ -20,16 +20,16 @@
       @media only screen and (min-width: $breakpoint-medium) {
         margin: 1.875rem;
       }
+    }
 
-      img {
-        max-height: map-get($icon-sizes, thumb--small);
-        max-width: 7rem;
-        width: auto;
+    &__logo {
+      max-height: map-get($icon-sizes, thumb--small);
+      max-width: 7rem;
+      width: auto;
 
-        @media screen and (min-width: $breakpoint-medium) {
-          max-height: 5.5rem;
-          max-width: 9rem;
-        }
+      @media screen and (min-width: $breakpoint-medium) {
+        max-height: 5.5rem;
+        max-width: 9rem;
       }
     }
 
@@ -46,6 +46,12 @@
           margin: $sp-xxx-large;
           max-width: 11.25rem;
         }
+      }
+    }
+
+    @include deprecate('2.0.0', 'Use .p-inline-images__logo instead') {
+      &__item img {
+        @extend .p-inline-images__logo; //sass-lint:disable-line placeholder-in-extend
       }
     }
   }


### PR DESCRIPTION
## Done

This change ensures that images that are wider than the space allocated to them on small screens do not overflow.

Before this change: https://cl.ly/3r2B3z1E1i36

After this change: https://cl.ly/1d2x2g1Y1l0n

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Ensure Inline Images pattern works as expected across breakpoints