### PR TITLE
Update docs with new sidebar design

### DIFF
--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -1,35 +1,11 @@
-// Sidebar menu overlay toggle
-var toggleElements = document.querySelectorAll('.js-sidebar-toggle');
-toggleElements.forEach(function(el) {
-  if (el.tagName === 'I') {
-    el.addEventListener(
-      "click",
-      function(e) {
-        e.stopPropagation();
-        toggleElements.forEach(function(el) {
-          el.classList.toggle("u-hide");
-          el.setAttribute('aria-hidden', el.getAttribute('aria-hidden') === 'true' ? 'false' : 'true');
-        });
-      },
-      false
-    );
-  }
-});
+// Toggle mobile sidebar nav
+var toggle = document.querySelector('.p-sidebar__toggle');
+var sidebarContent = document.querySelector('.p-sidebar__content');
 
-// Sidebar accordion sections
-var navSidebarLinks = document.querySelectorAll('.js-sidebar-toggle a');
-navSidebarLinks.forEach(function(el) {
-  el.addEventListener(
-    "click",
-    function(e) {
-      e.stopPropagation();
-      var item = this;
-      if (item.nextSibling) {
-        item.classList.toggle("is-selected");
-      }
-    },
-    false
-  );
+toggle.addEventListener('click', function(e) {
+  toggle.classList.toggle('p-icon--menu');
+  toggle.classList.toggle('p-icon--close');
+  sidebarContent.classList.toggle('u-hide--small');
 });
 
 // Add classes to links
@@ -44,8 +20,8 @@ links.forEach(function(link) {
 
 // Docs search functions
 function resetFilter() {
-  document.getElementById('docs-list-sorted').style.display = 'none';
-  document.getElementById('docs-list-unsorted').style.display = 'block';
+  document.getElementById('docs-list-sorted').classList.add('u-hide');
+  document.getElementById('docs-list-unsorted').classList.remove('u-hide');
 }
 
 function filterDocs() {
@@ -53,13 +29,17 @@ function filterDocs() {
   var filter = input.value.toLowerCase();
 
   if (filter) {
-    document.getElementById('docs-list-unsorted').style.display = 'none';
-    document.getElementById('docs-list-sorted').style.display = 'block';
+    document.getElementById('docs-list-unsorted').classList.add('u-hide');
+    document.getElementById('docs-list-sorted').classList.remove('u-hide');
 
-    var docsListItems = document.querySelectorAll('.js-list-items');
+    var docsListItems = document.querySelectorAll('#docs-list-sorted .p-sidebar-nav__item');
     docsListItems.forEach(function(item) {
       var text = item.firstElementChild.innerText.toLowerCase();
-      item.style.display = text.indexOf(filter) === 0 ? 'block' : 'none';
+      if (text.indexOf(filter) === 0) {
+        item.classList.remove('u-hide');
+      } else {
+        item.classList.add('u-hide');
+      }
     });
   } else {
     resetFilter();

--- a/docs/static/sass/styles.scss
+++ b/docs/static/sass/styles.scss
@@ -27,31 +27,43 @@ hr {
 /* --- */
 
 /* Sidebar navigation */
-.p-navigation--sidebar {
-  border-right: 1px solid $color-mid-light;
-  min-width: 18rem;
-  order: 0;
-  padding: 0 $sp-medium;
+.p-sidebar-nav {
 
-  &::after {
-    display: none;
+  &__list {
+    @extend .p-list;
+    margin-bottom: $spv-intra;
+    margin-top: -$spv-intra--condensed;
   }
 
-  .p-search-box {
-    margin: $sp-small 0;
-  }
+  &__item {
+    padding-bottom: $spv-intra--condensed / 2;
+    padding-top: $spv-intra--condensed / 2;
   
-  .row {
-    padding: $sp-medium 0 0 0;
+    &:first-of-type {
+      padding-top: $spv-intra;
+    }
+  
+    &:last-of-type {
+      padding-bottom: $spv-intra + $spv-intra--condensed;
+    }
+  
+    .is-active {
+      position: relative;
+
+      &::before {
+        background-color: $color-mid-light;
+        bottom: -$spv-intra--condensed;
+        content: '';
+        left: -$sph-intra;
+        position: absolute;
+        top: -$spv-intra--condensed;
+        width: $bar-thickness;
+      }
+    }
   }
 
-  .p-icon--minus,
-  .p-icon--plus {
-    right: $sp-small;
-  }
-
-  @media only screen and (max-width: $breakpoint-medium) {
-    border: 0;
+  &__item > &__list {
+    padding-left: $sph-intra;
   }
 }
 /* --- */
@@ -64,6 +76,33 @@ hr {
 
 .p-navigation {
   flex-basis: 100%;
+}
+
+.p-sidebar {
+  border-right: $border;
+  flex: 0 0 $sidebar-width;
+
+  @supports (position: sticky) {
+    height: 100vh;
+    overflow-y: scroll;
+    position: sticky;
+    top: 0;
+  }
+
+  &__banner {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  &__content {
+    padding: $sp-large;
+  }
+
+  &__toggle {
+    background-size: $sp-medium;
+    cursor: pointer;
+    padding: $sp-x-large;
+  }
 }
 
 .p-content {
@@ -81,6 +120,12 @@ hr {
   flex: 1;
   width: $toc-width;
 
+  @supports (position: sticky) {
+    height: 100vh;
+    position: sticky;
+    top: 0;
+  }
+
   .p-toc__item {
     @extend .p-list__item;
   }
@@ -93,6 +138,19 @@ hr {
 @media only screen and (max-width: $breakpoint-medium) {
   .docs-container {
     display: block;
+  }
+
+  .p-sidebar {
+    border-bottom: $border;
+    border-right: 0;
+    flex: auto;
+    height: inherit;
+    position: static;
+    overflow: hidden;
+
+    &__content {
+      padding: 0 $sp-large $sp-large $sp-large;
+    }
   }
 
   .p-content {

--- a/docs/template.html
+++ b/docs/template.html
@@ -51,22 +51,11 @@
         </nav>
       </header>
       {% if navigation %}
-      <div class="col-2 p-navigation--sidebar u-no-margin--left">
-        <header id="navigation" role="banner">
-          <div class="p-navigation__banner">
-            <div class="row">
-              <div class="sidebar__cta u-align-text--right">
-                <ul class="p-inline-list">
-                  <li class="p-inline-list__item">
-                    <i class="p-icon--menu js-sidebar-toggle" aria-hidden="false"></i>
-                    <i class="p-icon--close js-sidebar-toggle u-hide" aria-hidden="true"></i>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </header>
-        <div class="sidebar__content js-sidebar-toggle u-hide" aria-hidden="true">
+      <aside class="p-sidebar" id="navigation">
+        <div class="p-sidebar__banner u-hide--medium u-hide--large">
+          <i class="p-sidebar__toggle p-icon--menu"></i>
+        </div>
+        <div class="p-sidebar__content u-hide--small">
           <select name="version-select" id="version-select">
             <option value="latest">v1.7.1</option>
           </select>
@@ -75,31 +64,45 @@
             <button type="reset" class="p-search-box__reset u-no-margin--right" alt="reset" onclick="resetFilter()"><i class="p-icon--close"></i></button>
             <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
           </form>
-          <ul id="docs-list-unsorted" class="p-list sidebar__first-level" data-js="sidebar-first-level">
-            {% for item in navigation %}
-            <li>
-              {% if item.location %}
-              <a class="sidebar__link" href="{{ item.location }}">{{ item.title }}</a>
-              {% elif item.children %}
-              <a class="sidebar__link {% for child in item.children %}{% if child.active %}is-selected{% endif %}{% endfor %}" href="#{{ item.title }}">{{ item.title }}<i class="p-icon--plus"></i><i class="p-icon--minus"></i></a>
-              <ul class="sidebar__second-level">
-                {% for child in item.children %}
-                <li><a class="sidebar__link {% if child.active %}is-selected{% endif %}" href="{{ child.location }}">{{ child.title }}</a></li>
-                {% endfor %}
-              </ul>
-              {% endif %}
-            </li>
-            {% endfor %}
-          </ul>
-          <ul id="docs-list-sorted" class="p-list sidebar__first-level" data-js="sidebar-first-level" style="display: none;">
-            {% for item in navigation %}
-            {% for child in item.children %}
-            <li class="js-list-items"><a class="sidebar__link" href="{{ child.location }}">{{ child.title }}</a></li>
-            {% endfor %}
-            {% endfor %}
-          </ul>
+          <nav class="p-sidebar-nav">
+            <ul class="p-sidebar-nav__list" id="docs-list-unsorted">
+              {% for item in navigation %}
+              <li class="p-sidebar-nav__item">
+                {% if item.location %}
+                  <a class="p-link--strong{% if item.active %} is-active{% endif %}" href="{{ item.location }}">{{ item.title }}</a>
+                {% else %}
+                  <strong>{{ item.title }}</strong>
+                {% endif %}
+                {% if item.children %}
+                <ul class="p-sidebar-nav__list">
+                  {% for child in item.children %}
+                    <li class="p-sidebar-nav__item">
+                      {% if child.location %}
+                        <a class="p-link--soft{% if child.active %} is-active{% endif %}" href="{{ child.location }}">{{ child.title }}</a>
+                      {% else %}
+                        {{ child.title }}
+                      {% endif %}
+                    </li>
+                  {% endfor %}
+                </ul>
+                {% endif %}
+              </li>
+              {% endfor %}
+            </ul>
+            <ul class="p-sidebar-nav__list u-hide" id="docs-list-sorted">
+              {% for item in navigation %}{% for child in item.children %}
+                <li class="p-sidebar-nav__item">
+                  {% if child.location %}
+                    <a class="p-link--soft" href="{{ child.location }}">{{ child.title }}</a>
+                  {% else %}
+                    {{ child.title }}
+                  {% endif %}
+                </li>
+              {% endfor %}{% endfor %}
+            </ul>
+          </nav>
         </div>
-      </div>
+      </aside>
       {% endif %}
       <main class="p-content" id="main-content">
         {% if homepage %}
@@ -116,6 +119,29 @@
             {{ content }}
           </div>
         </div>
+        <footer class="p-footer" role="contentinfo">
+          <div class="p-content__row u-no-margin--left">
+            <div class="col-12">
+              <p>&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+              <nav>
+                <ul class="p-inline-list--middot">
+                  <li class="p-inline-list__item">
+                    <a href="https://www.ubuntu.com/legal">Legal info</a>
+                  </li>
+                  <li class="p-inline-list__item">
+                    <a href="https://github.com/canonical-websites/vanillaframework.io/issues/new">Report a bug with this site</a>
+                  </li>
+                  <li class="p-inline-list__item">
+                    <a href="https://github.com/vanilla-framework/vanilla-framework/issues/new">Report a bug with Vanilla framework</a>
+                  </li>
+                </ul>
+                <span class="u-off-screen">
+                  <a href="#">Go to the top of the page</a>
+                </span>
+              </nav>
+            </div>
+          </div>
+        </footer>
       </main>
       {% if toc_items %}
       <aside id="side-content" class="p-aside">
@@ -131,29 +157,6 @@
         {% endif %}
       </aside>
       {% endif %}
-      <footer class="p-footer" role="contentinfo">
-        <div class="p-content__row u-no-margin--left">
-          <div class="col-12">
-            <p>&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
-            <nav>
-              <ul class="p-inline-list--middot">
-                <li class="p-inline-list__item">
-                  <a href="https://www.ubuntu.com/legal">Legal info</a>
-                </li>
-                <li class="p-inline-list__item">
-                  <a href="https://github.com/canonical-websites/vanillaframework.io/issues/new">Report a bug with this site</a>
-                </li>
-                <li class="p-inline-list__item">
-                  <a href="https://github.com/vanilla-framework/vanilla-framework/issues/new">Report a bug with Vanilla framework</a>
-                </li>
-              </ul>
-              <span class="u-off-screen">
-                <a href="#">Go to the top of the page</a>
-              </span>
-            </nav>
-          </div>
-        </div>
-      </footer>
     </div>
     <script src="/static/js/scripts.js"></script>
     <script src="https://assets.ubuntu.com/v1/7db7c898-example-1.0.5.js"></script>


### PR DESCRIPTION
## Done

- Updated Vanilla docs sidebar with new [design](https://github.com/vanilla-framework/vanilla-framework/issues/1814)
- Simplified JavaScript
- Made table of contents sticky

## QA

- Pull code, `cd docs && ./run`
- Open http://0.0.0.0:8104/
- Check that the sidebar matches the new [design](https://github.com/vanilla-framework/vanilla-framework/issues/1814) - remember to check active state
- Check that it sticks to the top of the screen on desktop, and works as it did before on mobile (sits just below the main nav)
- Check that the search still works on desktop and mobile
- Go to a page with a Table of contents (e.g. Functions) and check that it sticks to the top of the page

## Details

Fixes #1814 

## Screenshots

![0 0 0 0_8104_en_ 9](https://user-images.githubusercontent.com/25733845/40733670-1ff3f034-642e-11e8-9798-94d250d910a8.png)
