### PR TITLE
Update highlight bar function to allow left/right placement

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -63,10 +63,7 @@
 
     &::before {
       content: '';
-      height: $bar-thickness;
-      left: 0;
       position: absolute;
-      right: 0;
     }
   }
 

--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -68,14 +68,37 @@
 @mixin vf-highlight-bar($bg-color: $color-mid-dark, $position: top, $over-border: false) {
   @extend %vf-pseudo-bar;
 
-  &::before {
-    background-color: $bg-color;
-    #{$position}: 0;
+  @if $position == top or $position == bottom {
+    &::before {
+      #{$position}: 0;
+      background-color: $bg-color;
+      height: $bar-thickness;
+      width: auto;
 
-    @if $over-border == true {
-      left: -1px;
-      right: -1px;
-      z-index: 1;
+      @if $over-border == true {
+        left: -1px;
+        right: -1px;
+        z-index: 1;
+      } @else {
+        left: 0;
+        right: 0;
+      }
+    }
+  } @else if $position == left or $position == right {
+    &::before {
+      background-color: $bg-color;
+      height: auto;
+      width: $bar-thickness;
+      #{$position}: 0;
+
+      @if $over-border == true {
+        bottom: -1px;
+        top: -1px;
+        z-index: 1;
+      } @else {
+        bottom: 0;
+        top: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
## Done

- Updated `vf-highlight-bar` to allow left/right placement

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/notifications/notifications/
- Check that the highlight bar is on the top
- Open `scss/_patterns_notifications.scss`
- Change line 26 to `@include vf-highlight-bar($color-mid-dark, left);`
- Reload page and check that the highlight bar is on the left
- Change line 26 to `@include vf-highlight-bar($color-mid-dark, right);`
- Reload page and check that the highlight bar is on the right
