### PR TITLE
Add Advanced usage page to Vanilla docs

### DIFF
--- a/docs/en/building-vanilla.md
+++ b/docs/en/building-vanilla.md
@@ -1,0 +1,306 @@
+---
+title: Building with Vanilla
+table_of_contents: true
+---
+
+## Building with Vanilla
+
+Here you will find information on how you can use different tools to build Vanilla into production CSS.
+
+---
+
+### node-sass
+
+To quickly get set up with [`node-sass`](https://github.com/sass/node-sass), add the `node-sass` and `vanilla-framework` packages to your project dependencies:
+
+```
+yarn add node-sass vanilla-framework
+```
+
+In the script that builds the CSS in your `package.json`, you should include the path to `node_modules` when looking for `@import`s. In this example, we have called the build script `"build-css"`:
+
+```
+"build-css": "node-sass --include-path node_modules src --output dist"
+```
+
+Make a folder `src/`, create a file inside called `style.scss` and import Vanilla:
+
+```
+@import vanilla-framework/scss/vanilla;
+@include vanilla;
+```
+
+Now run `yarn build-css`, which will convert any Sass files in the `src/` folder to CSS in the `dist/` folder. In this case, `src/style.scss` will compile to `dist/style.css`, which can then be safely included in an HTML file. Your project's folder structure should now look something like this:
+
+<ul class="p-list-tree" aria-multiselectable="true" role="tablist">
+  <li class="p-list-tree__item p-list-tree__item--group">
+    <button class="p-list-tree__toggle" id="sub-1-btn" role="tab" aria-controls="sub-1" aria-expanded="false">dist</button>
+    <ul class="p-list-tree" id="sub-1" role="tabpanel" aria-hidden="true" aria-labelledby="sub-1-btn">
+      <li class="p-list-tree__item">style.css</li>
+    </ul>
+  </li>
+  <li class="p-list-tree__item p-list-tree__item--group">
+    <button class="p-list-tree__toggle" id="sub-2-btn" role="tab" aria-controls="sub-2" aria-expanded="false">node_modules</button>
+    <ul class="p-list-tree" id="sub-2" role="tabpanel" aria-hidden="true" aria-labelledby="sub-2-btn">
+      <li class="p-list-tree__item">modules</li>
+    </ul>
+  </li>
+  <li class="p-list-tree__item p-list-tree__item--group">
+    <button class="p-list-tree__toggle" id="sub-3-btn" role="tab" aria-controls="sub-3" aria-expanded="false">src</button>
+    <ul class="p-list-tree" id="sub-3" role="tabpanel" aria-hidden="true" aria-labelledby="sub-3-btn">
+      <li class="p-list-tree__item">style.scss</li>
+    </ul>
+  </li>
+  <li class="p-list-tree__item">index.html</li>
+  <li class="p-list-tree__item">package.json</li>
+  <li class="p-list-tree__item">yarn.lock</li>
+</ul>
+
+To watch for changes in your Sass files, add the following script to your `package.json`:
+
+```
+"watch-css": "yarn build-css && node-sass --watch src/*.scss --output dist"
+```
+
+Now if you open an extra terminal and run `yarn watch-css`, the CSS will be rebuilt every time your Sass files are edited and saved.
+
+For more options on configuring `node-sass`, for example minification and autoprefixing, refer to [the README.md](https://github.com/sass/node-sass).
+
+---
+
+### Webpack
+
+[Webpack](https://webpack.js.org/) is used to compile JavaScript modules, and can be used to inject Vanilla styles to the DOM. To get set up using Vanilla with Webpack, add the `webpack` and `vanilla-framework` packages to your project dependencies:
+
+```
+yarn add webpack webpack-cli vanilla-framework
+```
+
+You'll also need to install the required loaders for compiling and bundling Vanilla's Sass files:
+
+```
+yarn add node-sass css-loader sass-loader style-loader
+```
+
+Make a folder `src/`, create a file inside called `style.scss` and import Vanilla:
+
+```
+@import vanilla-framework/scss/vanilla;
+@include vanilla;
+```
+
+Now, create a `webpack.config.js` file at your project's root, and write the following:
+
+```
+var path = require('path');
+
+module.exports = {
+  mode: 'development',
+  entry: './src/index.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist')
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(scss)$/,
+        use: [
+          {
+            // Adds CSS to the DOM by injecting a `<style>` tag
+            loader: 'style-loader'
+          },
+          {
+            // Interprets `@import` and `url()` like `import/require()` and will resolve them
+            loader: 'css-loader'
+          },
+          {
+            // Loads a SASS/SCSS file and compiles it to CSS
+            loader: 'sass-loader',
+            options: {
+              // Include the path to Vanilla
+              includePaths: ['./node_modules']
+            }
+          }
+        ]
+      }
+    ]
+  }
+};
+```
+
+Create a file called `app.js` inside the `src/` folder, and write the following:
+
+```
+import './style.scss';
+```
+
+Add a build script to your `package.json` to run the webpack command:
+
+```
+"build": "webpack"
+```
+
+Now run the command with `yarn build`, which will bundle the code and put in a a `dist/` folder. At the project root, create an `index.html` with the following code:
+
+```
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>Vanilla using Webpack</title>
+</head>
+<body>
+  <section class="p-strip--light is-bordered">
+    <div class="row">
+      <h1>Hello Vanilla!</h1>
+      <p>This page has been built using Webpack!</p>
+    </div>
+  </section>
+  <script src="./dist/bundle.js"></script>
+</body>
+</html>
+```
+
+Opening this `index.html` file should display a title in Vanilla styling, despite not having any CSS.
+
+To enable hot module replacement, you need to add `webpack-dev-server` to your list of packages:
+
+```
+yarn add webpack-dev-server
+```
+
+And add a `"start"` script to your `package.json` to run it:
+
+```
+"start": "webpack-dev-server"
+```
+
+Now when you run `yarn start`, the Webpack development server will start at `http://localhost:8080/` by default. It should show the same `index.html` file as before, however now you can edit the styles in `src/style.scss` and the page will automatically refresh to reflect the changes.
+
+Your project's folder structure should now look something like this:
+
+<ul class="p-list-tree" aria-multiselectable="true" role="tablist">
+  <li class="p-list-tree__item p-list-tree__item--group">
+    <button class="p-list-tree__toggle" id="sub-4-btn" role="tab" aria-controls="sub-4" aria-expanded="false">dist</button>
+    <ul class="p-list-tree" id="sub-4" role="tabpanel" aria-hidden="true" aria-labelledby="sub-4-btn">
+      <li class="p-list-tree__item">bundle.js</li>
+    </ul>
+  </li>
+  <li class="p-list-tree__item p-list-tree__item--group">
+    <button class="p-list-tree__toggle" id="sub-5-btn" role="tab" aria-controls="sub-5" aria-expanded="false">node_modules</button>
+    <ul class="p-list-tree" id="sub-5" role="tabpanel" aria-hidden="true" aria-labelledby="sub-5-btn">
+      <li class="p-list-tree__item">modules</li>
+    </ul>
+  </li>
+  <li class="p-list-tree__item p-list-tree__item--group">
+    <button class="p-list-tree__toggle" id="sub-6-btn" role="tab" aria-controls="sub-6" aria-expanded="false">src</button>
+    <ul class="p-list-tree" id="sub-6" role="tabpanel" aria-hidden="true" aria-labelledby="sub-6-btn">
+      <li class="p-list-tree__item">app.js</li>
+      <li class="p-list-tree__item">style.scss</li>
+    </ul>
+  </li>
+  <li class="p-list-tree__item">index.html</li>
+  <li class="p-list-tree__item">package.json</li>
+  <li class="p-list-tree__item">webpack.config.js</li>
+  <li class="p-list-tree__item">yarn.lock</li>
+</ul>
+
+For more options on configuring Webpack, for example minification and autoprefixing, refer to [the docs](https://webpack.js.org/concepts/).
+
+---
+
+### Gulp
+
+To get started with [gulp-sass](https://github.com/dlmanning/gulp-sass), add the following packages to your project:
+
+```
+yarn add gulp gulp-sass vanilla-framework
+```
+
+Create a file called `gulpfile.js` in your main directory and write:
+
+```
+var gulp = require('gulp');
+var sass = require('gulp-sass');
+
+gulp.task('build-css', function() {
+  return gulp.src('./src/*.scss')
+  .pipe(sass({ includePaths: ['./node_modules'] }))
+  .pipe(gulp.dest('./dist'));
+});
+
+gulp.task('watch-css', function() {
+  gulp.watch('./src/*.scss', ['build-css']);
+});
+```
+
+Make a folder `src/`, create a file inside called `style.scss` and import Vanilla:
+
+```
+@import vanilla-framework/scss/vanilla;
+@include vanilla;
+```
+
+Now run `gulp build-css`, which will convert any Sass files in the `src/` folder to CSS in the `dist/` folder. In this case, `src/style.scss` will compile to `dist/style.css`, which can then be safely included in an HTML file. Your project's folder structure should now look something like this:
+
+<ul class="p-list-tree" aria-multiselectable="true" role="tablist">
+  <li class="p-list-tree__item p-list-tree__item--group">
+    <button class="p-list-tree__toggle" id="sub-7-btn" role="tab" aria-controls="sub-7" aria-expanded="false">dist</button>
+    <ul class="p-list-tree" id="sub-7" role="tabpanel" aria-hidden="true" aria-labelledby="sub-7-btn">
+      <li class="p-list-tree__item">style.css</li>
+    </ul>
+  </li>
+  <li class="p-list-tree__item p-list-tree__item--group">
+    <button class="p-list-tree__toggle" id="sub-8-btn" role="tab" aria-controls="sub-8" aria-expanded="false">node_modules</button>
+    <ul class="p-list-tree" id="sub-8" role="tabpanel" aria-hidden="true" aria-labelledby="sub-8-btn">
+      <li class="p-list-tree__item">modules</li>
+    </ul>
+  </li>
+  <li class="p-list-tree__item p-list-tree__item--group">
+    <button class="p-list-tree__toggle" id="sub-9-btn" role="tab" aria-controls="sub-9" aria-expanded="false">src</button>
+    <ul class="p-list-tree" id="sub-9" role="tabpanel" aria-hidden="true" aria-labelledby="sub-9-btn">
+      <li class="p-list-tree__item">style.scss</li>
+    </ul>
+  </li>
+  <li class="p-list-tree__item">gulpfile.js</li>
+  <li class="p-list-tree__item">index.html</li>
+  <li class="p-list-tree__item">package.json</li>
+  <li class="p-list-tree__item">yarn.lock</li>
+</ul>
+
+If you open an extra terminal and run `gulp watch-css`, the CSS will be rebuilt every time your Sass files are edited and saved.
+
+For more options on configuring `gulp-sass`, for example minification and autoprefixing, refer to [the README.md](https://github.com/dlmanning/gulp-sass).
+
+---
+
+### Git submodules
+
+Creating a submodule in the git repo does not add all the code to the project but includes a reference and path to include the framework. You may find this method useful if you're planing to host on Github Pages.
+
+Run this command at the root of your project (replacing vX.X.X with the [release](https://github.com/vanilla-framework/vanilla-framework/releases) you wish to use)
+
+```
+git submodule add -b vX.X.X -- git@github.com:vanilla-framework/vanilla-framework.git _sass/vanilla-framework
+```
+
+By running the following command it will pull down the framework into the correct location.
+
+```
+git submodule update
+```
+
+<script>
+  var listTreeToggle = document.querySelectorAll('.p-list-tree__toggle');
+  for (var i = 0; i < listTreeToggle.length; i++) {
+    listTreeToggle[i].addEventListener('click', function(e) {
+      e.preventDefault();
+      var listTree = this.nextElementSibling;
+      var expand = this.getAttribute('aria-expanded') === 'true' ? false : true;
+      this.setAttribute('aria-expanded', expand);
+      listTree.setAttribute('aria-hidden', !expand);
+    });
+  }
+</script>

--- a/docs/en/customising-vanilla.md
+++ b/docs/en/customising-vanilla.md
@@ -1,0 +1,63 @@
+---
+title: Customising Vanilla
+table_of_contents: true
+---
+
+## Customising Vanilla
+
+Here you will find information on customising Vanilla to suit your project.
+
+---
+
+### Overriding default settings
+
+To override the default settings you must do so *before* you include Vanilla in your main Sass file. It is good practice to include custom styles in a separate settings file. A list of configurable settings can be found in the [Related section](#related).
+
+```
+// Override default Vanilla settings in your main Sass file
+$breakpoint-medium: 900px;
+$color-accent: #7cf0ee;
+$font-base-family: 'Merriweather';
+$grid-max-width: 1440px;
+
+// ...or include it from a separate settings file in the same folder
+@import 'settings';
+
+// Import Vanilla framework
+@import 'vanilla-framework/scss/vanilla';
+
+// Include all of Vanilla Framework
+@include vanilla;
+```
+
+---
+
+### Importing individual components
+
+Your project may not warrant including all of Vanilla, in which case you can include components modularly. You must at least include `vf-base` as many components depend on the base styling. Below is an example of how to include Vanilla components on an as-needed basis:
+
+```
+// Import Vanilla framework
+@import 'vanilla-framework/scss/vanilla';
+
+// Include base Vanilla styles
+@include vf-base;
+
+// Include the components you want
+@include vf-p-buttons;
+@include vf-p-forms;
+@include vf-p-links;
+```
+
+---
+
+### Related
+
+* [Animation settings](/en/settings/animation-settings)
+* [Assets settings](/en/settings/assets-settings)
+* [Breakpoint settings](/en/settings/breakpoint-settings)
+* [Color settings](/en/settings/color-settings)
+* [Font settings](/en/settings/font-settings)
+* [Layout settings](/en/settings/layout-settings)
+* [Placeholder settings](/en/settings/placeholder-settings)
+* [Spacing settings](/en/settings/spacing-settings)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -3,73 +3,64 @@ title: Home
 homepage: true
 ---
 
-<h2>Get started</h2>
-<p>You can use Vanilla in your projects in a few different ways.</p>
-<p class="p-heading--four">
+## Get started
+
+You can use Vanilla in your projects in a few different ways.
+
+See [Building with Vanilla](/en/building-vanilla) and [Customising Vanilla](/en/customising-vanilla) for more in-depth setup instructions.
+<hr class="is-deep">
+<h3>Install</h3>
 <div class="u-equal-height">
     <div class="col-6">
-        <h3>Install via npm</h3>
-        <p>The recommended way to get Vanilla is through <a href="https://www.npmjs.com/" class="p-link--external">npm</a>:</p>
-        <pre><code>npm install --save-dev vanilla-framework</code></pre>
+        <p>The recommended way to get Vanilla is with <a href="https://www.yarnpkg.com/" class="p-link--external">yarn</a>:</p>
+        <pre><code>yarn add vanilla-framework</code></pre>
+        <p>Or <a href="https://www.npmjs.com/" class="p-link--external">npm</a>:</p>
+        <pre><code>npm install vanilla-framework</code></pre>
         <p>This will pull down the latest version into your local <code>node_modules</code> folder and save it into your project's dependencies in <code>package.json</code>.</p>
-        <p>Now when you build Sass, make sure to include modules from node_modules. E.g. for <a href="https://github.com/sass/node-sass" class="p-link--external">node-sass</a>:</p>
-        <pre><code>$ node-sass --include-path node_modules {file}.scss {file}.css</code></pre>
     </div>
     <div class="col-6">
-        <h3 class="u-hide--small" style="visibility: hidden;">&nbsp;</h3>
-        <p>Finally, reference it from your own Sass files, with optional settings:</p>
-        <pre><code>// Optionally override some settings
-$color-brand: #ffffff;
-
-// Import the framework
-@import 'vanilla-framework/scss/vanilla';
+        <p>You can now reference Vanilla from your main Sass file - note that the path to <code>node_modules</code> might be different for your project:</p>
+        <pre><code>// Import the framework
+@import 'node_modules/vanilla-framework/scss/vanilla';
 
 // Include all of Vanilla Framework
 @include vanilla;</code></pre>
-        <p><em>Note: If you don't need the whole framework, you can just include specific parts, e.g. <code>@include vf-b-forms</code>.</em></p>
+        <p><em>For information on overriding settings and importing only parts of Vanilla, see <a href="/en/customising-vanilla">Customising Vanilla</a>.</em></p>
+    </div>
+</div>
+<hr class="is-deep">
+<div class="u-equal-height">
+    <div class="col-12">
+        <h3>Hotlink</h3>
+        <p>You can add Vanilla directly to your markup:</p>
+        <pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.7.1.min.css" /&gt;</code></pre>
+    </div>
+</div>
+<hr class="is-deep">
+<div class="u-equal-height">
+    <div class="col-12">
+        <h3>Download</h3>
+        <p>Download the latest version of Vanilla from GitHub.</p>
+        <a href="https://github.com/vanilla-framework/vanilla-framework/archive/v1.7.1.zip" class="p-button--positive">Download v1.7.1</a>
     </div>
 </div>
 <hr class="is-deep">
 <div class="u-equal-height">
     <div class="col-6">
-        <h3>Hotlink</h3>
-        <p>Alternatively, you an add Vanilla directly to your markup:</p>
-        <p><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.7.1.min.css" /&gt;</code></p>
+        <h3>What's new</h3>
+        <ul class="p-list">
+            <li class="p-list__item--deep">
+                <a href="https://github.com/vanilla-framework/vanilla-framework/releases/tag/v1.7.1">Release notes: v1.7.1</a>
+            </li>
+            <li class="p-list__item--deep">
+                <a href="https://github.com/vanilla-framework/vanilla-framework/releases/tag/v1.7.0">Release notes: v1.7.0</a>
+            </li>
+            <li class="p-list__item--deep">
+                <a href="https://github.com/vanilla-framework/vanilla-framework/releases/tag/v1.6.7">Release notes: v1.6.7</a>
+            </li>
+        </ul>
     </div>
     <hr class="is-deep u-hide--medium u-hide--large">
-    <div class="col-6">
-        <h3>Download</h3>
-        <p>Download the latest version of Vanilla from <a href="https://github.com/vanilla-framework/vanilla-framework/releases/" class=" p-link--external">GitHub</a></p>
-    </div>
-</div>
-<hr class="is-deep">
-<div class="u-equal-height">
-    <div class="col-6">
-        <h3>Using with GitHub Pages via Git submodules</h3>
-        <p>Creating a submodule in the git repo does not add all the code to the project but includes a reference and path to include the framework. You may find this method useful if you're planing to host on GitHub Pages.</p>
-    </div>
-    <div class="col-6">
-        <p>Run this command at the root of your project (replacing vX.X.X with the release you wish to use)</p>
-        <pre><code>git submodule add -b vX.X.X -- git@github.com:vanilla-framework/vanilla-framework.git _sass/vanilla-framework</code></pre>
-        <p>By running the following command it will pull down the framework into the correct location:</p>
-        <pre><code>git submodule update</code></pre>
-    </div>
-</div>
-<hr class="is-deep">
-<h3>What's new</h3>
-<ul class="p-list">
-    <li class="p-list__item--deep">
-        <a href="https://github.com/vanilla-framework/vanilla-framework/releases/tag/v1.7.1">Releases: v1.7.1</a>
-    </li>
-    <li class="p-list__item--deep">
-        <a href="https://github.com/vanilla-framework/vanilla-framework/releases/tag/v1.7.0">Releases: v1.7.0</a>
-    </li>
-    <li class="p-list__item--deep">
-        <a href="https://github.com/vanilla-framework/vanilla-framework/releases/tag/v1.6.7">Releases: v1.6.7</a>
-    </li>
-</ul>
-<hr class="is-deep">
-<div class="u-equal-height">
     <div class="col-6">
         <h3>Getting help</h3>
         <ul class="p-list">
@@ -84,9 +75,7 @@ $color-brand: #ffffff;
             </li>
         </ul>
     </div>
-    <hr class="is-deep u-hide--medium u-hide--large">
-    <div class="col-6">
-        <h3>Local development</h3>
-        <p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/vanilla-framework/vanilla-framework#vanilla-framework" class="p-link--external">README.md</a>.</p>
-    </div>
 </div>
+<hr class="is-deep">
+<h3>Local development</h3>
+<p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/vanilla-framework/vanilla-framework#vanilla-framework" class="p-link--external">README.md</a>.</p>

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -1,7 +1,16 @@
 navigation:
 
-- title: Get started
-  location: index.md
+- title: Welcome
+  children:
+
+  - location: index.md
+    title: Get started
+
+  - location: building-vanilla.md
+    title: Building with Vanilla
+
+  - location: customising-vanilla.md
+    title: Customising Vanilla
 
 - title: Basics
   children:


### PR DESCRIPTION
## Done

- Added a "Building Vanilla" page, with info on:
  - Using Vanilla with node-sass, gulp-sass, Webpack and Git submodules
- Added a "Customising Vanilla" page, with info on:
  - How to configure settings
  - How to import components modularly
- Moved the Git submodules section from the "Get started" page to the "Building Vanilla" page
- Updated the index page (moved "What's new" and "Getting help" to be inline, added a Download CTA, included `yarn` as package manager)

## QA

- Pull code, `cd docs && ./run`
- Open http://0.0.0.0:8104/en/
- Check that the homepage no longer has the Git submodules section, and has a Download button
- Go to http://0.0.0.0:8104/en/building-vanilla
- Check for any spelling, grammar or information errors
- Run through the instructions for the build tools and check that they are clear and they work
- Go to http://0.0.0.0:8104/en/customising-vanilla
- Check for any spelling, grammar or information errors

## Details

Fixes #1102 

## Screenshots

### Updated homepage

![0 0 0 0_8104_en_ 10](https://user-images.githubusercontent.com/25733845/40777706-881d629c-64c6-11e8-9187-476e22bf8d00.png)


