### PR TITLE
Align anchor tags that follow a button properly

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -36,6 +36,7 @@
     }
 
     @media only screen and (max-width: $breakpoint-x-small) {
+      margin-bottom: $spv-inter--condensed-scaleable + 2 * $spv-nudge-compensation;
       width: 100%;
     }
 
@@ -66,6 +67,16 @@
     @media only screen and (max-width: $breakpoint-x-small) {
       p & + & {
         margin-top: $spv-inter--condensed-scaleable + $spv-nudge-compensation;
+      }
+    }
+
+    & + a {
+      margin-left: $sph-inter--expanded;
+
+      @media only screen and (max-width: $breakpoint-x-small) {
+        display: block;
+        margin-left: 0;
+        text-align: center;
       }
     }
   }


### PR DESCRIPTION
## Done

- Added a small bit of sass to the base button pattern that aligns any anchor tags that immediately follow it
- I'm not sure if it's considered bad practice to target `a`'s in the button sass file, but it was the easiest way to target every instance of button (`<button>`, `<a class="p-button--positive">`, etc)
- Reduced margin-bottom of buttons on small screens by .5rem

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/button/
- Add `<a>Link</a>` directly after the button
- Check that on large screens, the link is horizontally aligned, and there is a margin between it and the button
- On small screens (<460px), check that the link is centered and directly below the button
- On small screens, check that the margin-bottom on the button is 1.2rem

## Details

Fixes #1840 

## Screenshots

![screenshot_5](https://user-images.githubusercontent.com/25733845/41051279-8e96d20c-69ad-11e8-969b-a66167e3880f.png)

![screenshot_6](https://user-images.githubusercontent.com/25733845/41051285-92fafe9a-69ad-11e8-8953-cd9f74c34ef3.png)

