### PR TITLE
Rewrite heading classes examples to be clearer

### DIFF
--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -52,12 +52,21 @@ where _n_ is the point on the modular scale.
 ### Heading classes
 
 Heading classes can be added to text elements to give them the same visual
-appearance as the base h1-h6 heading elements without sacrificing correct
+appearance as the base `h1`-`h6` heading elements without sacrificing correct
 heading order and semantics.
 
-Heading classes are not tied to elements and can be freely mixed, for example
-you can apply the `p-heading--one` class to an `h3` element if that better
-suits your document style and tree.
+In the following example, each heading is actually a `<p>` element that has been
+modified to look like a particular heading size.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/headings/default/"
+    class="js-example">
+    View example of the heading pattern
+</a>
+
+### Mixed heading classes
+
+It is also possible to apply heading classes directly to heading elements if that
+better suits your document style and tree.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/headings/mixed/"
     class="js-example">

--- a/examples/patterns/headings/default.html
+++ b/examples/patterns/headings/default.html
@@ -4,9 +4,9 @@ title: Headings / Default
 category: _patterns
 ---
 
-<h1 class="p-heading--one">Heading one</h1>
-<h2 class="p-heading--two">Heading two</h2>
-<h3 class="p-heading--three">Heading three</h3>
-<h4 class="p-heading--four">Heading four</h4>
-<h5 class="p-heading--five">Heading five</h5>
-<h6 class="p-heading--six">Heading six</h6>
+<p class="p-heading--one">&lt;p class="p-heading--one"&gt;</p>
+<p class="p-heading--two">&lt;p class="p-heading--two"&gt;</p>
+<p class="p-heading--three">&lt;p class="p-heading--three"&gt;</p>
+<p class="p-heading--four">&lt;p class="p-heading--four"&gt;</p>
+<p class="p-heading--five">&lt;p class="p-heading--five"&gt;</p>
+<p class="p-heading--six">&lt;p class="p-heading--six"&gt;</p>

--- a/examples/patterns/headings/mixed.html
+++ b/examples/patterns/headings/mixed.html
@@ -4,9 +4,9 @@ title: Headings / Mixed classes
 category: _patterns
 ---
 
-<h6 class="p-heading--one">Heading six</h6>
-<h5 class="p-heading--two">Heading five</h5>
-<h4 class="p-heading--three">Heading four</h4>
-<h3 class="p-heading--four">Heading three</h3>
-<h2 class="p-heading--five">Heading two</h2>
-<h1 class="p-heading--six">Heading one</h1>
+<h6 class="p-heading--one">&lt;h6 class="p-heading--one"&gt;</h6>
+<h5 class="p-heading--two">&lt;h5 class="p-heading--two"&gt;</h5>
+<h4 class="p-heading--three">&lt;h4 class="p-heading--three"&gt;</h4>
+<h3 class="p-heading--four">&lt;h3 class="p-heading--four"&gt;</h3>
+<h2 class="p-heading--five">&lt;h2 class="p-heading--five"&gt;</h2>
+<h1 class="p-heading--six">&lt;h1 class="p-heading--six"&gt;</h1>


### PR DESCRIPTION
## Done

- Rewrote "Heading classes" section of typography docs page to more clearly describe what they do
- Changed the "Headings / Default" and "Headings / Mixed" examples to show the markup

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/headings/default/
- Check that the page shows the markup and is clearer on what the class is doing
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/headings/mixed/
- Check that the page shows the markup and is clearer on what the class is doing
- Run the docs app (`cd docs && ./run`)
- Go to http://0.0.0.0:8104/en/base/typography
- Check that the copy under "Heading classes" and "Mixed heading classes" is understandable
- **Note:** The examples on the docs page will show the old example (no markup)

## Details

Fixes #1832 
