### PR TITLE
Update example-js to 1.1.0

### DIFF
--- a/docs/template.html
+++ b/docs/template.html
@@ -17,6 +17,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="{{ site_favicon }}" type="image/x-icon" />
     <link rel="stylesheet" href="/static/css/styles.css" />
+    <link rel="stylesheet" href="https://assets.ubuntu.com/v1/15be9af2-examplejs-1.1.0.css" />
   </head>
 
   <body>
@@ -159,6 +160,6 @@
       {% endif %}
     </div>
     <script src="/static/js/scripts.js"></script>
-    <script src="https://assets.ubuntu.com/v1/7db7c898-example-1.0.5.js"></script>
+    <script src="https://assets.ubuntu.com/v1/24ef513e-example-1.1.0.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Done

- Updated the [example-js](https://github.com/canonical-webteam/example-js) script to 1.1.0, which includes a "Copy to clipboard" button
- Included relevant stylesheet in the template head

## QA

- Pull code
- Run `cd docs && ./run`
- Open http://0.0.0.0:8104/en/
- Go to any page with a large example (e.g. http://0.0.0.0:8104/en/base/table)
- Check that the example markup has a copy button in the top-right, and there is a scrollbar
- Check that clicking the copy button and pasting into a text editor works
