### PR TITLE
Set performance benchmarks and thresholds

### DIFF
--- a/gulp/lint.js
+++ b/gulp/lint.js
@@ -11,7 +11,6 @@ gulp.task('lint:sass', function() {
 
 gulp.task('lint:spellcheck', function(cb) {
   return exec('node_modules/markdown-spellcheck/bin/mdspell docs/en/**/*.md -r -n -a --en-gb', function (err, stdout, stderr) {
-    console.log(stdout);
     cb(err);
   });
 });

--- a/gulp/parker.js
+++ b/gulp/parker.js
@@ -98,21 +98,15 @@ gulp.task('parker:report', function() {
     })();
 
     console.log('\x1b[36m%s\x1b[0m', name);
-
-    if (benchmark || benchmark === 0) {
-      console.log('Benchmark: ' + benchmark);
-    }
-
-    if (threshold || threshold === 0) {
-      console.log('Threshold: ' + threshold);
-    }
-
+    console.log(
+      'Benchmark: ' + benchmark +
+      '\nThreshold: ' + threshold
+    );
     console.log(
       resultColour,
       'Result: ' + result +
       (selector ? '\nSelector: ' + selector : '')
     );
-
     console.log('------------------------------');
   });
 });


### PR DESCRIPTION
## Done

- Set performance benchmarks and thresholds according to #1858 
- Changed variable name `benchmarks` to `metrics` which I think makes more sense
- Updated report to show a different colour based on result:
  - Under benchmark: green
  - Over benchmark, under threshold: yellow
  - Over threshold: red (and test fails)
- Removed the `console.log` from `gulp/lint.js`

## QA

- Pull code
- Run `./run test`
- Check that everything passes
- Open `gulp/parker.js` and change one of the thresholds to something that will fail
- Run `./run test` and check that it fails
- Run `./run exec yarn report` and check that a simple report is generated that shows metrics that pass benchmarks (green), pass thresholds (yellow), and fail (red)

## Details

Fixes #1858 

## Screenshots

![screenshot_2](https://user-images.githubusercontent.com/25733845/41362898-76b1c6c4-6f2a-11e8-9232-b462743f8cba.png)
