### PR TITLE
Fix Design heading on Icons page

### DIFF
--- a/docs/en/patterns/icons.md
+++ b/docs/en/patterns/icons.md
@@ -73,8 +73,8 @@ If you wish to add share icons for Twitter, Facebook, Google+ or LinkedIn, we re
 - **Google+** - https://developers.google.com/+/web/share/](https://developers.google.com/+/web/share/
 - **LinkedIn** - https://developer.linkedin.com/plugins/share](https://developer.linkedin.com/plugins/share
 
-  <hr />
+<hr />
 
- ### Design
+### Design
 
   * [Icons design](https://github.com/ubuntudesign/vanilla-design/tree/master/Icons)


### PR DESCRIPTION
## Done

- Fixed Design heading on Icons page

## QA

- Pull code
- Run `cd docs && ./run`
- Open http://0.0.0.0:8104/en/patterns/icons
- Check that the Design heading shows up properly (i.e. not ### Design)

## Details

Fixes #1868 
