### PR TITLE
Fix broken design spec link

### DIFF
--- a/docs/en/patterns/images.md
+++ b/docs/en/patterns/images.md
@@ -23,4 +23,4 @@ table_of_contents: true
 
 ### Design
 
-* [Image design](https://github.com/ubuntudesign/vanilla-design/tree/master/Image)
+* [Image design](https://github.com/ubuntudesign/vanilla-design/tree/master/Images)


### PR DESCRIPTION
## Done

Fix broken link for 'Images' design spec that currently 404s.

## Details

Fix broken links in this issue #1871 
