### PR TITLE
Fix broken design spec link and update link title

### DIFF
--- a/docs/en/utilities/image-position.md
+++ b/docs/en/utilities/image-position.md
@@ -68,4 +68,4 @@ most cases it would be a strip. This only affects medium and large screen sizes.
 
 ### Design
 
-* [Image positioning design](https://github.com/ubuntudesign/vanilla-design/tree/master/Image%20positioning)
+* [Image position design](https://github.com/ubuntudesign/vanilla-design/tree/master/Image%20position)


### PR DESCRIPTION
## Done

Fix broken link for 'Image position' design spec that currently 404s.
- Update design link title from 'Image positioning design' to 'Image position design'

## Details

Fix broken links in this issue #1872  

