### PR TITLE
Fix broken design spec link and update link title

### DIFF
--- a/docs/en/patterns/inline-images.md
+++ b/docs/en/patterns/inline-images.md
@@ -16,4 +16,4 @@ The Inline images pattern can be used to showcase a group of related images, suc
 
 ### Design
 
-* [Image design](https://github.com/ubuntudesign/vanilla-design/tree/master/Image)
+* [Inline images design](https://github.com/ubuntudesign/vanilla-design/tree/master/Inline%20images)


### PR DESCRIPTION
## Done

Fix broken link for 'Inline images' design spec that currently 404s.
- Update design link title from 'Image design' to 'Inline image design'

## Details

Fix broken links in this issue #1873   
