### PR TITLE
Change h1 font-weight to 100

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -347,7 +347,7 @@
     @include heading-max-width--short;
     font-size: pow($ms-ratio, 8) * 1rem;
     font-style: normal;
-    font-weight: 300;
+    font-weight: 100;
     line-height: map-get($line-heights, h1);
     margin-bottom: map-get($sp-after, h1) - map-get($nudges, nudge--h1);
     margin-top: 0;


### PR DESCRIPTION
## Done

- Changed h1 font-weight to 100 (thin)

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/headings/default/
- Check that the top heading has `font-weight: 100`

## Details

Fixes #1841 
