### PR TITLE
1883: Fix right-aligned th spacing

### DIFF
--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -20,7 +20,7 @@
     text-overflow: ellipsis;
 
     @media screen and (min-width: $breakpoint-medium) {
-      &:not(:last-of-type) {
+      &:not(:last-child) {
         padding-right: $sph-intra;
       }
     }


### PR DESCRIPTION
## Done

- Fixed targetting of th and td in tables for padding-right

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/table/
- Give one of the "Header row" cells the class `u-align--right`
- Check that it has 1rem padding-right

## Details

Fixes #1883 

## Screenshots

![screenshot](https://user-images.githubusercontent.com/25733845/41711376-e4970378-753f-11e8-95cf-4a34074f68fe.png)
