### PR TITLE
1882: Fix padding in tooltip message

### DIFF
--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -14,10 +14,7 @@
       left: 0;
       margin-bottom: 0;
       min-width: 155px;
-      padding-bottom: $sp-unit * 2 - map-get($nudges, nudge--small);
-      padding-left: $spv-intra--scaleable;
-      padding-right: $spv-intra--scaleable;
-      padding-top: map-get($nudges, nudge--small) + $sp-unit;
+      padding: $spv-intra $sph-intra;
       position: absolute;
       text-align: left;
       text-decoration: initial;


### PR DESCRIPTION
## Done

- Changed padding in tooltip message to be .5rem top and bottom

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/tooltips/
- Hover over any of the buttons
- Check that the padding-top is the same as padding-bottom (0.5rem)

## Details

Fixes #1882 

## Screenshots

![screenshot_1](https://user-images.githubusercontent.com/25733845/41711884-196bd5f0-7541-11e8-8a14-114b793637b0.png)

