### PR TITLE
1880: Remove align-self from img tags

### DIFF
--- a/scss/_base_media.scss
+++ b/scss/_base_media.scss
@@ -4,7 +4,6 @@
 @mixin vf-b-media {
 
   img {
-    align-self: flex-start;
     border: 0;
     border-radius: $border-radius;
     height: auto;

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -82,8 +82,7 @@
     }
 
     &__img {
-      // maintain image aspect ratio, but ensure it doesn't overflow in either direction
-      height: auto;
+      align-self: flex-start;
       margin-bottom: $spv-intra--scaleable;
       margin-right: $matrix-img-gutter;
       max-height: $matrix-img-width;


### PR DESCRIPTION
## Done

- Removed `align-self: flex-start;` from `img` tags
- Added it to the `.p-matrix__image` pattern

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/matrix/
- Change one of the placeholder images to non-square dimensions (e.g. 120x60)
- Check that the aspect ratio is maintained in all screen sizes

## Details

Fixes #1880 
