### PR TITLE
1879: Make media object spacing more reliable

### DIFF
--- a/examples/patterns/media-object/media-object-large.html
+++ b/examples/patterns/media-object/media-object-large.html
@@ -9,5 +9,10 @@ category: _patterns
   <div class="p-media-object__details">
     <h1 class="p-media-object__title">Title</h1>
     <p class="p-media-object__content">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <ul class="p-media-object__meta-list">
+      <li class="p-media-object__meta-list-item--location">
+        <span class="u-off-screen">Location: </span>London, UK
+      </li>
+    </ul>
   </div>
 </div>

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -1,22 +1,25 @@
+@import 'settings';
+
+%p-media-object {
+  display: flex;
+  flex-shrink: 0;
+  margin-bottom: $spv-inter--scaleable;
+}
+
+%vf-meta-list-item {
+  @extend %small-text;
+  color: $color-dark;
+  padding-left: map-get($icon-sizes, default) + $sph-intra;
+}
+
+%vf-iconed-list-item {
+  @extend %vf-meta-list-item;
+  background-position: 0 75%;
+  background-repeat: no-repeat;
+  background-size: map-get($icon-sizes, default);
+}
+
 @mixin vf-p-media-object {
-  %p-media-object {
-    display: flex;
-    flex-shrink: 0;
-    margin-bottom: $spv-inter--scaleable;
-  }
-
-  %vf-meta-list-item {
-    @extend %small-text;
-    color: $color-dark;
-    padding-left: map-get($icon-sizes, default) + $sph-intra;
-  }
-
-  %vf-iconed-list-item {
-    @extend %vf-meta-list-item;
-    background-position: 0 75%;
-    background-repeat: no-repeat;
-    background-size: map-get($icon-sizes, default);
-  }
 
   .p-media-object {
     @extend %p-media-object;

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -20,7 +20,6 @@
 }
 
 @mixin vf-p-media-object {
-
   .p-media-object {
     @extend %p-media-object;
 
@@ -38,11 +37,7 @@
 
     &__content {
       margin-bottom: $spv-nudge-compensation + $sp-unit;
-      margin-top: - $sp-unit * 2;
-
-      @media (max-width: $breakpoint-heading-threshold) {
-        margin-top: - $sp-unit;
-      }
+      margin-top: 0;
     }
 
     &__image.is-round {
@@ -51,13 +46,19 @@
 
     &__title {
       @extend %vf-heading-4;
+      margin-bottom: $sp-unit - map-get($nudges, nudge--h4-mobile);
       margin-top: -$sp-unit;
+
+      @media only screen and (min-width: $breakpoint-heading-threshold + 1) {
+        margin-bottom: - map-get($nudges, nudge--h4);
+      }
     }
 
     &__meta-list {
       list-style: none;
       margin: 0;
       padding-left: 0;
+      padding-top: $spv-intra;
     }
 
     &__meta-list-item {
@@ -89,14 +90,11 @@
 
       .p-media-object__title {
         @extend %vf-heading-1;
-        margin-top: - $sp-unit;
-      }
+        margin-bottom: $sp-unit - map-get($nudges, nudge--h1-mobile);
+        margin-top: -$sp-unit;
 
-      .p-media-object__content {
-        margin-top: - $sp-unit * 5;
-
-        @media (max-width: $breakpoint-heading-threshold) {
-          margin-top: - $sp-unit * 3;
+        @media only screen and (min-width: $breakpoint-heading-threshold + 1) {
+          margin-bottom: - map-get($nudges, nudge--h1);
         }
       }
     }

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -49,7 +49,7 @@
       margin-bottom: $sp-unit - map-get($nudges, nudge--h4-mobile);
       margin-top: -$sp-unit;
 
-      @media only screen and (min-width: $breakpoint-heading-threshold + 1) {
+      @media only screen and (min-width: $breakpoint-heading-threshold) {
         margin-bottom: - map-get($nudges, nudge--h4);
       }
     }
@@ -93,7 +93,7 @@
         margin-bottom: $sp-unit - map-get($nudges, nudge--h1-mobile);
         margin-top: -$sp-unit;
 
-        @media only screen and (min-width: $breakpoint-heading-threshold + 1) {
+        @media only screen and (min-width: $breakpoint-heading-threshold) {
           margin-bottom: - map-get($nudges, nudge--h1);
         }
       }


### PR DESCRIPTION
## Done

- Moved placeholders outside media object mixin so they can be invoked without including the whole pattern
- Updated the Media object - large example with a meta-list-item
- Made the media object spacing more flexible and reliable. You should now get nice spacing whether the content comes before or after the metadata, or whether either is present at all.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/media-object/media-object/
- Turn on the baseline grid and make sure all text sits on it nicely (check small + large screens)
- Move `<p class="p-media-object__content">` below the metadata and check that the spacing is good, and the text still sits on the baseline (check small + large screens)
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/media-object/media-object/
- Do the same checks as with the default media object

## Details

Fixes #1879 

## Screenshots

![screenshot_2](https://user-images.githubusercontent.com/25733845/41716582-cf465a6e-754e-11e8-9d9e-2d0ffc3c873b.png)

