### PR TITLE
1892: Fix mobile navigation menu on Firefox

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -58,15 +58,6 @@
     }
   }
 
-  %vf-pseudo-bar {
-    position: relative;
-
-    &::before {
-      content: '';
-      position: absolute;
-    }
-  }
-
   // Utilities
   %vf-hide-text {
     overflow: hidden;

--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -66,12 +66,17 @@
 }
 
 @mixin vf-highlight-bar($bg-color: $color-mid-dark, $position: top, $over-border: false) {
-  @extend %vf-pseudo-bar;
+  position: relative;
+
+  &::before {
+    #{$position}: 0;
+    background-color: $bg-color;
+    content: '';
+    position: absolute;
+  }
 
   @if $position == top or $position == bottom {
     &::before {
-      #{$position}: 0;
-      background-color: $bg-color;
       height: $bar-thickness;
       width: auto;
 
@@ -86,10 +91,8 @@
     }
   } @else if $position == left or $position == right {
     &::before {
-      background-color: $bg-color;
       height: auto;
       width: $bar-thickness;
-      #{$position}: 0;
 
       @if $over-border == true {
         bottom: -1px;

--- a/scss/_patterns_footer.scss
+++ b/scss/_patterns_footer.scss
@@ -3,6 +3,10 @@
 // Footer pattern styling
 @mixin vf-p-footer {
   .p-footer {
+    @if ($sticky-footer) {
+      margin-top: auto;
+    }
+
     border-top: 1px solid $color-mid-light;
     position: relative;
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -188,15 +188,8 @@ $nav-border-bottom-thickness: $px;
 
   &__banner {
     display: flex;
+    flex: 0 0 auto;
     justify-content: space-between;
-
-    @media (max-width: $breakpoint-navigation-threshold) {
-      flex: 0 0 100%;
-    }
-
-    @media (min-width: $breakpoint-navigation-threshold + 1) {
-      flex: 0 0 auto;
-    }
   }
 
   &__image {
@@ -246,7 +239,9 @@ $nav-border-bottom-thickness: $px;
     }
 
     &.is-selected > a {
-      @include vf-highlight-bar($color-navigation-active-bar, bottom, true);
+      @media (min-width: $breakpoint-navigation-threshold + 1) {
+        @include vf-highlight-bar($color-navigation-active-bar, bottom, true);
+      }
     }
   }
 


### PR DESCRIPTION
## Done

- Fixed a bug where mobile navigation menu would get messed up if used in conjunction with a sticky footer
- Fixed a bug where `$sticky-footer: true` wasn't applying `margin-top: auto`
- Removed active state from mobile menu navigation
- Moved `%pseudo-bar` styles to the `vf-highlight-bar` mixin, which is the only case in which it's used

## QA

- Pull code
- Open `scss/_vanilla.scss` and add at the top: `$sticky-footer: true`
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/default/ **in Firefox**
- Add the following code just after the `<header>`:
``` html
<footer class="p-footer">
  <p>© 2018 Company name and logo are registered trademarks of Company Ltd.</p>
  <nav class="p-footer__nav">
    <ul class="p-footer__links">
      <li class="p-footer__item">
        <a class="p-footer__link" href="#">Footer link 1</a>
      </li>
      <li class="p-footer__item">
        <a class="p-footer__link" href="#">Footer link 2</a>
      </li>
      <li class="p-footer__item">
        <a class="p-footer__link" href="#">Footer link 3</a>
      </li>
      <li class="p-footer__item">
        <a class="p-footer__link" href="#">Footer link 4</a>
      </li>
    </ul>
    <span class="u-off-screen">
      <a href="#">Go to the top of the page</a>
    </span>
  </nav>
</footer>
```
- Check that the footer actually sticks to the bottom of the page
- Check that the mobile navigation menu looks okay
- Check that the mobile navigation active state has been removed (grey bar below link)

## Details

Fixes #1892 

## Screenshots

![screenshot_3](https://user-images.githubusercontent.com/25733845/41725619-29c3fece-7568-11e8-97b2-905c0496009f.png)

