### PR TITLE
Add JS to code snippet example

### DIFF
--- a/examples/patterns/code-snippet.html
+++ b/examples/patterns/code-snippet.html
@@ -8,3 +8,40 @@ category: _patterns
   <input class="p-code-snippet__input" value="sudo apt-get update" readonly="readonly">
   <button class="p-code-snippet__action">Copy to clipboard</button>
 </div>
+
+<script>
+const copyToClipboard = str => {
+  const el = document.createElement('textarea'); // Create a <textarea> element
+  el.value = str; // Set its value to the string that you want copied
+  el.setAttribute('readonly', ''); // Make it readonly to be tamper-proof
+  el.style.position = 'absolute';
+  el.style.left = '-9999px'; // Move outside the screen to make it invisible
+  document.body.appendChild(el); // Append the <textarea> element to the HTML document
+  const selected =
+    document.getSelection().rangeCount > 0 // Check if there is any content selected previously
+      ? document.getSelection().getRangeAt(0) // Store selection if found
+      : false; // Mark as false to know no selection existed before
+  el.select(); // Select the <textarea> content
+  document.execCommand('copy'); // Copy - only works as a result of a user action (e.g. click events)
+  document.body.removeChild(el); // Remove the <textarea> element
+  if (selected) {
+    // If a selection existed before copying
+    document.getSelection().removeAllRanges(); // Unselect everything on the HTML document
+    document.getSelection().addRange(selected); // Restore the original selection
+  }
+};
+
+var codeSnippetActions = document.querySelectorAll(
+  '.p-code-snippet__action'
+);
+for (var codeSnippetAction of codeSnippetActions) {
+  codeSnippetAction.addEventListener(
+    'click',
+    function(e) {
+      const clipboardValue = this.previousSibling.previousSibling.value;
+      copyToClipboard(clipboardValue);
+    },
+    false
+  );
+}
+</script>


### PR DESCRIPTION
## Done

Added Js to the code snippet example so it works as intended and the JS can be used for reference.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/code-snippet/
- Click the copy button and verify 'sudo apt-get update' has been added to your clipboard
- Add more than one code snippet to the page and ensure you can copy each different value respectively

