### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/amend-existing-pattern.md
+++ b/.github/ISSUE_TEMPLATE/amend-existing-pattern.md
@@ -1,0 +1,17 @@
+---
+name: Amend existing pattern
+about: This template allows users to propose an amendment to an existing pattern
+
+---
+
+## Pattern to amend
+
+Add pattern name(s) here
+
+## Visual
+
+Provide a screenshot or link to a prototype of your pattern amendment.
+
+## Context
+
+In what context does your amendment solve a problem?

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a bug report to help us improve Vanilla
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/propose-new-pattern.md
+++ b/.github/ISSUE_TEMPLATE/propose-new-pattern.md
@@ -1,0 +1,24 @@
+---
+name: Propose new pattern
+about: This template allows users to propose a new pattern
+
+---
+
+A pattern in Vanilla needs to be flexible enough that it can be used across a wide range of scenarios and shouldn't be constrained to a specific number of applications.
+
+## Visual
+
+Provide a screenshot or link to a prototype of your pattern proposal.
+
+## Context
+
+Where and when might this proposed pattern be used?
+
+## State
+
+Does this pattern have state? If so, what are the different states (e.g. accordion with closed/open states)?
+
+## Progressive enhancement
+
+A pattern should be designed small screen first. How does this pattern scale up?
+How will this pattern degrade on less competent browsers?

--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -1,0 +1,35 @@
+---
+name: Report a bug
+about: Create a bug report to help us improve Vanilla
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Github now allows for more fine-grained issue templates [1] - meaning we can tidy up the rather messy dual purpose issue template I added previously.

I've now split the issue templates into three:

- Report a bug
- Propose a new pattern
- Propose an amendment to an existing pattern

[1] https://blog.github.com/2018-05-02-issue-template-improvements/?utm_source=newsletter&utm_medium=email&utm_campaign=may-user-newsletter-2018