### PR TITLE
Add example of card pattern with footer

### DIFF
--- a/examples/patterns/card/with-footer.html
+++ b/examples/patterns/card/with-footer.html
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Card / With footer
+category: _patterns
+---
+
+<div class="p-card--with-footer">
+  <h2 class="p-card__title">Card / Overlay</h2>
+  <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</div>
+<footer class="p-card__footer">
+  Lorem ipsum dolor sit amet, <a href="#">lorem ipsum dolor sit&nbsp;&rsaquo;</a>
+</footer>

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -5,6 +5,7 @@
   @include vf-p-card-highlighted;
   @include vf-p-card-overlay;
   @include vf-p-card-muted;
+  @include vf-p-card-with-footer;
   @include vf-p-card-specific-content;
 }
 
@@ -47,6 +48,30 @@
     margin-bottom: $spv-inter--scaleable;
     overflow: auto;
     padding: $spv-intra--scaleable;
+  }
+}
+
+@mixin vf-p-card-with-footer {
+  .p-card--with-footer {
+    @extend %vf-card;
+    @extend %vf-is-bordered;
+    @extend %vf-has-round-corners;
+    border-bottom: 0;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    margin-bottom: 0;
+    padding: $spv-intra--scaleable - $px;
+  }
+
+  .p-card__footer {
+    @extend %vf-is-bordered;
+    @extend %vf-has-round-corners;
+    background-color: $color-light;
+    border-top: 0;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    margin-bottom: $spv-inter--scaleable;
+    padding: $spv-intra--scaleable - $px;
   }
 }
 


### PR DESCRIPTION
## Done

Added example of card pattern with footer

## QA

- Pull code
- Run `./run serve --watch`
- Open <http://0.0.0.0:8101/vanilla-framework/examples/patterns/card/with-footer/>
- See that pattern is acceptable

## Details

This pattern is in use at https://mongoose.ubuntu.com/download

## Screenshots

![screenshot from 2018-07-10 11-22-02](https://user-images.githubusercontent.com/501889/42504416-9e0e36bc-8433-11e8-8321-8783da019e54.png)

