### PR TITLE
Fix buttons and inputs inside expanded table panel 

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -7,6 +7,15 @@
     @include vf-button-pattern;
   }
 
+  %is-small {
+    padding-bottom: $spv-nudge - $sp-unit * .5 - $px;
+    padding-top: $spv-nudge - $sp-unit * .5 - $px;
+  }
+
+  %is-v-condensed {
+    margin-bottom: $spv-nudge-compensation;
+  }
+
   %vf-button-base {
     @include vf-animation (#{background-color, border-color}, fast, in);
     @include vf-focus;
@@ -47,12 +56,6 @@
       }
     }
 
-    table & {
-      margin-bottom: $spv-nudge-compensation;
-      padding-bottom: $spv-nudge - $sp-unit * .5 - $px;
-      padding-top: $spv-nudge - $sp-unit * .5 - $px;
-    }
-
     // The following three rules address buttons nested in <p>'s;
     p & {
       margin-bottom: $spv-inter--condensed-scaleable - $spv-nudge;
@@ -67,6 +70,20 @@
       p & + & {
         margin-top: $spv-inter--condensed-scaleable + $spv-nudge-compensation;
       }
+    }
+
+    &.is-small {
+      @extend %is-small;
+    }
+
+    &.is-v-condensed {
+      @extend %is-v-condensed;
+    }
+
+    th &,
+    td:not(.p-table-expanding__panel) & {
+      @extend %is-v-condensed;
+      @extend %is-small;
     }
   }
 }

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -32,8 +32,9 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     vertical-align: baseline;
     width: 100%;
 
-    table & {
-      margin: 0 0 ($spv-intra - $spv-nudge) 0;
+    th &,
+    td:not(.p-table-expanding__panel) & {
+      margin-bottom: $spv-intra - $spv-nudge;
       padding-bottom: ($spv-nudge - $px) - $spv-intra--condensed;
       padding-top: ($spv-nudge - $px) - $spv-intra--condensed;
     }


### PR DESCRIPTION
## Done

change specificity of styling that reduces vertical padding and margin of buttons and inputs (#1919 )

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/tables/table-expanding/
- Add buttons with / without .is-v-condensed, .is-small classes
- Observe behaviour as described in #1919 
