### PR TITLE
Update Vanilla docs with 1.8.0 content

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -33,7 +33,7 @@ See [Building with Vanilla](/en/building-vanilla) and [Customising Vanilla](/en/
     <div class="col-12">
         <h3>Hotlink</h3>
         <p>You can add Vanilla directly to your markup:</p>
-        <pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.7.1.min.css" /&gt;</code></pre>
+        <pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.8.0.min.css" /&gt;</code></pre>
     </div>
 </div>
 <hr class="is-deep">
@@ -41,7 +41,7 @@ See [Building with Vanilla](/en/building-vanilla) and [Customising Vanilla](/en/
     <div class="col-12">
         <h3>Download</h3>
         <p>Download the latest version of Vanilla from GitHub.</p>
-        <a href="https://github.com/vanilla-framework/vanilla-framework/archive/v1.7.1.zip" class="p-button--positive">Download v1.7.1</a>
+        <a href="https://github.com/vanilla-framework/vanilla-framework/archive/v1.8.0.zip" class="p-button--positive">Download v1.8.0</a>
     </div>
 </div>
 <hr class="is-deep">
@@ -50,13 +50,13 @@ See [Building with Vanilla](/en/building-vanilla) and [Customising Vanilla](/en/
         <h3>What's new</h3>
         <ul class="p-list">
             <li class="p-list__item--deep">
+                <a href="https://github.com/vanilla-framework/vanilla-framework/releases/tag/v1.8.0">Release notes: v1.8.0</a>
+            </li>
+            <li class="p-list__item--deep">
                 <a href="https://github.com/vanilla-framework/vanilla-framework/releases/tag/v1.7.1">Release notes: v1.7.1</a>
             </li>
             <li class="p-list__item--deep">
                 <a href="https://github.com/vanilla-framework/vanilla-framework/releases/tag/v1.7.0">Release notes: v1.7.0</a>
-            </li>
-            <li class="p-list__item--deep">
-                <a href="https://github.com/vanilla-framework/vanilla-framework/releases/tag/v1.6.7">Release notes: v1.6.7</a>
             </li>
         </ul>
     </div>

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -54,6 +54,9 @@ navigation:
   - location: utilities/align.md
     title: Alignment
 
+  - location: utilities/baseline-grid.md
+    title: Baseline grid
+
   - location: utilities/clearfix.md
     title: Clearfix
 

--- a/docs/en/utilities/baseline-grid.md
+++ b/docs/en/utilities/baseline-grid.md
@@ -1,0 +1,13 @@
+---
+title: Baseline grid
+table_of_contents: true
+---
+
+## Baseline grid
+
+You can apply this utility to an element (such as `<body>`) to give it a series of horizontal lines separated by one `$sp-unit`.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/baseline-grid/"
+    class="js-example">
+    View example of the baseline grid utility
+</a>

--- a/docs/en/utilities/functions.md
+++ b/docs/en/utilities/functions.md
@@ -16,7 +16,7 @@ This function is used to inject Vanilla color variables into inline vector graph
 @function vf-url-friendly-color($color) {
   @if type-of($color) != 'color' {
     @warn '#{$color} is not a color.';
-    @return false;
+    @return $color;
   } @else {
     @return '%23' + str-slice('#{$color}', 2, -1);
   }
@@ -61,20 +61,46 @@ This function raises a given number to a given power.
 
 ### Highlight bar
 
-This function adds a `3px` thick, coloured bar to the top or bottom of a component (for example in Notification, Navigation and Tab components). The `$over-border` argument determines whether the bar sits on top of a component with borders.
+This function adds a `3px` thick, coloured bar to one side of a component (for example in Notification, Navigation and Tab components). The `$over-border` argument determines whether the bar sits on top of a component with borders.
 
 ``` scss
 @mixin vf-highlight-bar($bg-color: $color-mid-dark, $position: top, $over-border: false) {
-  @extend %vf-pseudo-bar;
+  position: relative;
 
   &::before {
-    background-color: $bg-color;
     #{$position}: 0;
+    background-color: $bg-color;
+    content: '';
+    position: absolute;
+  }
 
-    @if $over-border == true {
-      left: -1px;
-      right: -1px;
-      z-index: 1;
+  @if $position == top or $position == bottom {
+    &::before {
+      height: $bar-thickness;
+      width: auto;
+
+      @if $over-border == true {
+        left: -1px;
+        right: -1px;
+        z-index: 1;
+      } @else {
+        left: 0;
+        right: 0;
+      }
+    }
+  } @else if $position == left or $position == right {
+    &::before {
+      height: auto;
+      width: $bar-thickness;
+
+      @if $over-border == true {
+        bottom: -1px;
+        top: -1px;
+        z-index: 1;
+      } @else {
+        bottom: 0;
+        top: 0;
+      }
     }
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "node-sass": "^4.5.3",
-    "vanilla-framework": "1.7.1",
+    "vanilla-framework": "1.8.0",
     "watch-cli": "^0.2.2"
   }
 }

--- a/docs/template.html
+++ b/docs/template.html
@@ -58,7 +58,7 @@
         </div>
         <div class="p-sidebar__content u-hide--small">
           <select name="version-select" id="version-select">
-            <option value="latest">v1.7.1</option>
+            <option value="latest">v1.8.0</option>
           </select>
           <form class="p-search-box" onsubmit="return false">
             <input type="search" id="search-docs" class="p-search-box__input" name="search" placeholder="Search components" oninput="filterDocs()" title="Search the documentation" required />

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1223,9 +1223,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.7.1.tgz#3649e693a57cdd9b457d9589e98aecd32218b9be"
+vanilla-framework@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.8.0.tgz#b5aacc3ce60a521b8de8f160cb505807aadc7869"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- Updated the docs app with 1.8.0 content, namely:
  - Updated the vanilla-framework package to 1.8.0
  - Updated the Functions page with the latest versions of the functions
  - Added a page for the Baseline grid utility

## QA

- Pull code
- Run `cd docs && ./run`
- Open http://0.0.0.0:8104/en/
- Check that the version in the dropdown is 1.8.0
- Check that all links on the index page work
- Go to http://0.0.0.0:8104/en/utilities/functions and check that the functions match those found in `scss/_global_functions.scss`
- Go to http://0.0.0.0:8104/en/utilities/baseline-grid and check that the page works and is clear what it does

