### PR TITLE
Add button has-icon state class

### DIFF
--- a/docs/en/patterns/buttons.md
+++ b/docs/en/patterns/buttons.md
@@ -63,6 +63,15 @@ Should you wish to place a button after a line of inline text, as a CTA for exam
     View example of the inline button pattern
 </a>
 
+### Icon button
+
+Should you wish to place an icon in a button. You will not want to button to become full width on small screens. Therefore, you can add the state class `has-icon` to the button.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/buttons/icon/"
+    class="js-example">
+    View example of the icon button pattern
+</a>
+
 <hr />
 
 ### Design

--- a/examples/patterns/buttons/icon.html
+++ b/examples/patterns/buttons/icon.html
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Buttons / Icon
+category: _patterns
+---
+<button class="p-button has-icon">
+  <i class="p-icon--chevron"></i>
+</button>

--- a/examples/patterns/buttons/icon.html
+++ b/examples/patterns/buttons/icon.html
@@ -4,5 +4,9 @@ title: Buttons / Icon
 category: _patterns
 ---
 <button class="p-button has-icon">
-  <i class="p-icon--chevron"></i>
+  <i class="p-icon--plus"></i>
+</button>
+
+<button class="p-button has-icon">
+  <i class="p-icon--plus"></i> <span>Button with icon</span>
 </button>

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -17,9 +17,9 @@
     display: inline-block;
     font-size: 1rem;
     font-weight: 300;
-    line-height: map-get($line-heights, default-text);
+    line-height: 1;
     margin-bottom: $spv-inter--scaleable + 2 * $spv-nudge-compensation;
-    padding: $spv-nudge - $px $sph-intra;
+    padding: $sp-unit * 1.5;
     text-align: center;
     text-decoration: none;
 
@@ -67,6 +67,10 @@
       p & + & {
         margin-top: $spv-inter--condensed-scaleable + $spv-nudge-compensation;
       }
+    }
+
+    & [class*="p-icon"] + * {
+      margin-left: $sph-intra * .25;
     }
   }
 }

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -9,6 +9,7 @@
   @include vf-button-negative;
   @include vf-button-base;
   @include vf-button-inline;
+  @include vf-button-icon;
 }
 
 @mixin vf-button-plain {
@@ -122,11 +123,16 @@
 }
 
 @mixin vf-button-inline {
-  [class^="p-button"].is-inline {
-
+  [class~="p-button"].is-inline {
     @media (min-width: $breakpoint-medium) {
       margin-left: $sph-inter;
       width: auto;
     }
+  }
+}
+
+@mixin vf-button-icon {
+  [class~="p-button"].has-icon {
+    width: auto;
   }
 }


### PR DESCRIPTION
## Done
Add a button state class `has-icon` which stops the button from going full width on small screens.

## QA
- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/buttons/icon/
- Check that the button never goes full width at any screen size

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1922
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1902
