### PR TITLE
Remove the inline-block whitespace between tabs

### DIFF
--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -37,11 +37,6 @@
       position: relative;
       white-space: nowrap;
       width: 100%;
-
-      @media screen and (min-width: $breakpoint-medium) {
-        max-width: $grid-max-width;
-        overflow: hidden;
-      }
     }
 
     &__item {
@@ -52,16 +47,8 @@
       padding: 0;
       width: auto;
 
-      @media screen and (min-width: $breakpoint-medium) {
-        float: left;
-      }
-
       &:last-child {
         margin-right: $sp-xxx-large;
-
-        @media screen and (min-width: $breakpoint-medium) {
-          margin-right: 0;
-        }
       }
     }
 

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -30,8 +30,9 @@
 
     &__list {
       @extend %vf-pseudo-border--bottom;
+      font-size: 0;
       margin: 0 auto $spv-intra--scaleable;
-      overflow-x: scroll;
+      overflow-x: auto;
       padding: 0;
       position: relative;
       white-space: nowrap;
@@ -46,6 +47,7 @@
     &__item {
       display: inline-block;
       float: none;
+      font-size: 1rem;
       margin: 0;
       padding: 0;
       width: auto;

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -30,6 +30,7 @@
 
     &__list {
       @extend %vf-pseudo-border--bottom;
+      display: flex;
       font-size: 0;
       margin: 0 auto $spv-intra--scaleable;
       overflow-x: auto;


### PR DESCRIPTION
## Done
Remove the inline-block whitespace between tabs. Make the scrolling auto so it only shows when its needed.

## QA
- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/tabs/
- Check there are no spaces between the tab items on all screen sizes

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1898
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1899
