### PR TITLE
Add a faded background to the tab arrow

### DIFF
--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -13,7 +13,7 @@
       content: '\203A';
       display: block;
       font-size: 2rem;
-      line-height: calc(100% + 1rem - 3px);
+      line-height: calc(100% + 1rem - #{$bar-thickness});
       padding-left: 1.5rem;
       padding-right: $sp-large;
       pointer-events: none;

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -8,18 +8,19 @@
     position: relative;
 
     &::before {
-      bottom: 0;
+      background: linear-gradient(to right, $color-transparent 0%, $color-x-light 45%, $color-x-light 100%);
       color: $color-mid-dark;
       content: '\203A';
       display: block;
       font-size: 2rem;
-      line-height: map-get($line-heights, default-text);
+      line-height: calc(100% + 1rem - 3px);
+      padding-left: 1.5rem;
       padding-right: $sp-large;
       pointer-events: none;
       position: absolute;
-      right: $sp-unit;
+      right: 0;
       text-align: right;
-      top: 15%;
+      top: 0;
       width: 1rem;
       z-index: 10;
 


### PR DESCRIPTION
## Done
Add a faded background to the tab arrow. 
Made the placement of the arrow more logical.

## QA
- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/tabs/
- Shrink the screen till the arrow goes over the text
- See there is a white gradient behind the arrow

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1900
