### PR TITLE
Remove role="menubar" from <nav> in example templates and patterns

### DIFF
--- a/examples/patterns/search-box/navigation.html
+++ b/examples/patterns/search-box/navigation.html
@@ -13,7 +13,7 @@ category: _patterns
     <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
     <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
   </div>
-  <nav class="p-navigation__nav" role="menubar">
+  <nav class="p-navigation__nav">
     <span class="u-off-screen">
       <a href="#main-content">Jump to main content</a>
     </span>

--- a/examples/templates/maas-layout.html
+++ b/examples/templates/maas-layout.html
@@ -14,7 +14,7 @@ category: _templates
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav u-image-position" role="menubar">
+    <nav class="p-navigation__nav u-image-position">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>


### PR DESCRIPTION
## Done

Remove `role="menubar"` from `<nav>` elements in example layouts

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/

## Details

#1944 
