### PR TITLE
Fix the markdown for the share buttons section of the icons page

### DIFF
--- a/docs/en/patterns/icons.md
+++ b/docs/en/patterns/icons.md
@@ -66,15 +66,15 @@ Class name  |
 
 ### Share icons
 
-If you wish to add share icons for Twitter, Facebook, Google+ or LinkedIn, we recommend using these specific buttons:
+If you wish to add share icons for Twitter, Facebook, Google+ or LinkedIn, we recommend using the networks' official buttons:
 
-- **Twitter** - https://dev.twitter.com/web/tweet-button
-- **Facebook** - https://developers.facebook.com/docs/plugins/share-button/
-- **Google+** - https://developers.google.com/+/web/share/](https://developers.google.com/+/web/share/
-- **LinkedIn** - https://developer.linkedin.com/plugins/share](https://developer.linkedin.com/plugins/share
+- **Twitter** - [https://dev.twitter.com/web/tweet-button](https://dev.twitter.com/web/tweet-button)
+- **Facebook** - [https://developers.facebook.com/docs/plugins/share-button/](https://developers.facebook.com/docs/plugins/share-button/)
+- **Google+** - [https://developers.google.com/+/web/share/](https://developers.google.com/+/web/share/)
+- **LinkedIn** - [https://developer.linkedin.com/plugins/share](https://developer.linkedin.com/plugins/share)
 
-  <hr />
+<hr />
 
-  ### Design
+### Design
 
-  * [Icons design](https://github.com/ubuntudesign/vanilla-design/tree/master/Icons)
+* [Icons design](https://github.com/ubuntudesign/vanilla-design/tree/master/Icons)


### PR DESCRIPTION
## Done

- Fixed the broken styling of the share icons section of the icons documentation.
- Clarified the into text for the share icons

## QA

- Pull code
- `cd docs`
- Run `./run`
- Open http://0.0.0.0:8104/en/patterns/icons
- Check that the share buttons list is styled correctly

## Details

Fixes #1918 