### PR TITLE
Fix missing 'default' flag in placeholders settings (#1950)

### DIFF
--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -1,6 +1,6 @@
 // Global placeholder settings
 
-$bar-thickness: $px * 3;
-$border-radius: $sp-unit * .25;
-$border: $px solid $color-mid-light;
-$box-shadow: 0 1px 5px 1px transparentize($color-dark, .8);
+$bar-thickness: $px * 3 !default;
+$border-radius: $sp-unit * .25 !default;
+$border: $px solid $color-mid-light !default;
+$box-shadow: 0 1px 5px 1px transparentize($color-dark, .8) !default;


### PR DESCRIPTION
## Done

* Added missing `!default` flag at the end of values from `_settings_placeholders.scss`;

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Open `_vanilla.scss` and add a line at the top that overwrites one of values from `_settings_placeholders.scss` 
- Check that the changes take effect on http://0.0.0.0:8101/vanilla-framework/

## Details

* Related to issue #1950 
