### PR TITLE
Add canonial url to context

### DIFF
--- a/docs/app.py
+++ b/docs/app.py
@@ -8,6 +8,7 @@ import flask
 # Local packages
 import routing
 
+SITE_URL = 'https://docs.vanillaframework.io'
 
 application_root = ''
 base_dir = os.path.abspath(os.path.dirname(__file__))
@@ -94,7 +95,14 @@ def find_file_or_redirect():
     )
 
     if os.path.isfile(app.template_folder + file_path):
-        return flask.render_template(file_path)
+        (_, _, remaining_path) = routing.split_path(
+            flask.request.path, languages, versions
+        )
+        canonical_url = SITE_URL + '/en' + remaining_path
+        context = {
+            "canonical_url": canonical_url
+        }
+        return flask.render_template(file_path, **context)
     else:
         new_path = template_finder.find_alternate_path(
             local_request_path,

--- a/docs/template.html
+++ b/docs/template.html
@@ -15,6 +15,12 @@
     <meta charset="UTF-8" />
     <title>{{ title }} | {{ site_title if site_title else 'Documentation' }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% raw %}
+      {% if canonical_url %}
+        <link rel="canonical" href="{{ canonical_url }}" />
+      {% endif %}
+    {% endraw %}
+
     <link rel="icon" href="{{ site_favicon }}" type="image/x-icon" />
     <link rel="stylesheet" href="/static/css/styles.css" />
     <link rel="stylesheet" href="https://assets.ubuntu.com/v1/15be9af2-examplejs-1.1.0.css" />


### PR DESCRIPTION
# Summary 

Serve canonical url to context 

# QA

- With this version of the documentation builder https://github.com/canonical-webteam/documentation-builder/pull/131
- `yarn build`
- `./run`
- The header of every page should have a canonical url