### PR TITLE
Add sub-heading example to documentation

### DIFF
--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -63,6 +63,15 @@ modified to look like a particular heading size.
     View example of the heading pattern
 </a>
 
+### Sub-headings
+
+Sub-headings are used to visually convey importance beneath a heading or as a title when inserted as a divider between sections.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/sub-headings/"
+    class="js-example">
+    View example of the heading pattern
+</a>
+
 ### Mixed heading classes
 
 It is also possible to apply heading classes directly to heading elements if that

--- a/docs/en/base/typography.md
+++ b/docs/en/base/typography.md
@@ -65,7 +65,7 @@ modified to look like a particular heading size.
 
 ### Sub-headings
 
-Sub-headings are used to visually convey importance beneath a heading or as a title when inserted as a divider between sections.
+Sub-headings visually convey importance beneath a heading, or a line of text that expands on the meaning of the heading immediately before it.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/sub-headings/"
     class="js-example">

--- a/examples/base/sub-headings.html
+++ b/examples/base/sub-headings.html
@@ -6,3 +6,7 @@ category: _base
 <h1>Title</h1>
 <p class="p-heading--three">Sub-heading</p>
 <p>Lorem ipsum dolor sit amet consectetur adipiscing elit praesent justo.</p>
+
+<h2>Title</h2>
+<p class="p-heading--four">Sub-heading</p>
+<p>Lorem ipsum dolor sit amet consectetur adipiscing elit praesent justo.</p>

--- a/examples/base/sub-headings.html
+++ b/examples/base/sub-headings.html
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Sub-headings
+category: _base
+---
+<h1>Title</h1>
+<p class="p-heading--three">Sub-heading</p>
+<p>Lorem ipsum dolor sit amet consectetur adipiscing elit praesent justo.</p>


### PR DESCRIPTION
## Done

- Approved in WG group [here](https://github.com/ubuntudesign/vanilla-squad/issues/279
)
- Document sub-headings

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- [Add additional steps]

## Details

- Fixes issue here: https://github.com/ubuntudesign/vanilla-squad/issues/279
