### PR TITLE
Remove unnecessary entrypoint files

### DIFF
--- a/docs/entrypoint
+++ b/docs/entrypoint
@@ -1,5 +1,0 @@
-#! /usr/bin/env bash
-
-set -e
-
-talisker.gunicorn.gevent app:app --reload --log-level debug --timeout 9999 --access-logfile - --workers 3 --worker-class gevent --error-logfile - --bind $1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-ubuntudesign.documentation-builder==1.5.1
+ubuntudesign.documentation-builder==1.6.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,1 @@
-Flask==0.12.2
-PyYAML==3.12
-pycountry==17.9.23
-yamlordereddictloader==0.4.0
 ubuntudesign.documentation-builder==1.5.1
-talisker==0.9.13
-gunicorn[gevent]


### PR DESCRIPTION
- Since we're no longer using Flask, we don't need `entrypoint`, or the extra dependencies in `requirements.txt`.
- Use the latest documentation-builder

QA
--

`./run`, go to http://localhost:8104 and check the site runs.