### PR TITLE
Button styling and state updates

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -10,7 +10,7 @@
   %vf-button-base {
     @include vf-animation (#{background-color, border-color}, fast, in);
     @include vf-focus;
-    border-radius: $border-radius-button;
+    border-radius: $border-radius;
     border-style: solid;
     border-width: 1px;
     cursor: pointer;
@@ -81,7 +81,7 @@
 /// override colors as desired
 @mixin vf-button-pattern (
   $button-background-color: $color-x-light,
-  $button-text-color: $color-link,
+  $button-text-color: $color-x-dark,
   $button-disabled-background-color: $color-transparent,
   $button-disabled-border-color: $color-mid,
   $button-border-color: $color-mid,

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -87,7 +87,7 @@
   $button-border-color: $color-mid,
   $button-hover-background-color: $color-light,
   $button-hover-border-color: $color-mid,
-  $button-active-background-color: darken($color-mid, 20%),
+  $button-active-background-color: darken($color-light, 20%),
   $button-active-border-color: $color-mid
 
 ) {
@@ -99,7 +99,7 @@
     color: $button-text-color;
   }
 
-  &:active
+  &:active,
   &:active:hover {
     background-color: $button-active-background-color;
     border-color: $button-active-border-color;

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -85,9 +85,9 @@
   $button-disabled-background-color: $color-transparent,
   $button-disabled-border-color: $color-mid,
   $button-border-color: $color-mid,
-  $button-hover-background-color: $color-light,
+  $button-hover-background-color: darken($color-x-light, 10%),
   $button-hover-border-color: $color-mid,
-  $button-active-background-color: darken($color-light, 20%),
+  $button-active-background-color: darken($color-x-light, 20%),
   $button-active-border-color: $color-mid
 
 ) {
@@ -103,6 +103,7 @@
   &:active:hover {
     background-color: $button-active-background-color;
     border-color: $button-active-border-color;
+    transition-duration: 0s;
   }
 
   &:hover {

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -99,7 +99,8 @@
     color: $button-text-color;
   }
 
-  &:active {
+  &:active
+  &:active:hover {
     background-color: $button-active-background-color;
     border-color: $button-active-border-color;
   }

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -88,8 +88,8 @@
   $button-hover-background-color: $color-light,
   $button-hover-border-color: $color-mid,
   $button-active-background-color: darken($color-mid, 20%),
-  $button-active-border-color: $color-mid,
-  $button-active-outline: 1px solid $color-mid
+  $button-active-border-color: $color-mid
+
 ) {
   background-color: $button-background-color;
   border-color: $button-border-color;
@@ -102,7 +102,6 @@
   &:active {
     background-color: $button-active-background-color;
     border-color: $button-active-border-color;
-    outline: 1px solid $button-active-background-color;
   }
 
   &:hover {

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -87,7 +87,7 @@
   $button-border-color: $color-mid,
   $button-hover-background-color: darken($color-x-light, 10%),
   $button-hover-border-color: $color-mid,
-  $button-active-background-color: darken($color-x-light, 20%),
+  $button-active-background-color: darken($color-x-light, 15%),
   $button-active-border-color: $color-mid
 
 ) {

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -10,7 +10,7 @@
   %vf-button-base {
     @include vf-animation (#{background-color, border-color}, fast, in);
     @include vf-focus;
-    border-radius: $border-radius;
+    border-radius: $border-radius-button;
     border-style: solid;
     border-width: 1px;
     cursor: pointer;
@@ -81,12 +81,15 @@
 /// override colors as desired
 @mixin vf-button-pattern (
   $button-background-color: $color-x-light,
-  $button-text-color: $color-dark,
+  $button-text-color: $color-link,
   $button-disabled-background-color: $color-transparent,
-  $button-disabled-border-color: $color-mid-light,
-  $button-border-color: $color-mid-light,
+  $button-disabled-border-color: $color-mid,
+  $button-border-color: $color-mid,
   $button-hover-background-color: $color-light,
-  $button-hover-border-color: $color-mid-light
+  $button-hover-border-color: $color-mid,
+  $button-active-background-color: darken($color-mid, 20%),
+  $button-active-border-color: $color-mid,
+  $button-active-outline: 1px solid $color-mid
 ) {
   background-color: $button-background-color;
   border-color: $button-border-color;
@@ -96,7 +99,12 @@
     color: $button-text-color;
   }
 
-  &:active,
+  &:active {
+    background-color: $button-background-color;
+    border-color: $button-border-color;
+    outline: 1px solid $button-background-color;
+  }
+
   &:hover {
     background-color: $button-hover-background-color;
     border-color: $button-hover-border-color;

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -100,9 +100,9 @@
   }
 
   &:active {
-    background-color: $button-background-color;
-    border-color: $button-border-color;
-    outline: 1px solid $button-background-color;
+    background-color: $button-active-background-color;
+    border-color: $button-active-border-color;
+    outline: 1px solid $button-active-background-color;
   }
 
   &:hover {

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -20,8 +20,7 @@
       $button-disabled-background-color: $color-x-light,
       $button-disabled-border-color: $color-x-light,
       $button-active-background-color: darken($color-light, 20%),
-      $button-active-border-color: $color-mid,
-      $button-active-outline: 1px solid $color-mid
+      $button-active-border-color: $color-mid
     );
   }
 
@@ -40,8 +39,7 @@
       $button-hover-background-color: darken($color-light, 10%),
       $button-hover-border-color: $color-mid,
       $button-active-background-color: darken($color-light, 20%),
-      $button-active-border-color: $color-mid,
-      $button-active-outline: 1px solid $color-mid
+      $button-active-border-color: $color-mid
     );
   }
 
@@ -63,8 +61,7 @@
       $button-disabled-background-color: $color-brand,
       $button-disabled-border-color: $color-brand,
       $button-active-background-color: darken($color-brand, 20%),
-      $button-active-border-color: $color-brand,
-      $button-active-outline: 1px solid $color-brand
+      $button-active-border-color: $color-brand
     );
   }
 
@@ -86,8 +83,7 @@
       $button-disabled-background-color: $color-positive,
       $button-disabled-border-color: $color-positive,
       $button-active-background-color: darken($color-positive, 20%),
-      $button-active-border-color: $color-positive,
-      $button-active-outline: 1px solid $color-positive
+      $button-active-border-color: $color-positive
     );
   }
 
@@ -109,8 +105,7 @@
       $button-disabled-background-color: $color-negative,
       $button-disabled-border-color: $color-negative,
       $button-active-background-color: darken($color-negative, 20%),
-      $button-active-border-color: $color-negative,
-      $button-active-outline: 1px solid $color-negative
+      $button-active-border-color: $color-negative
     );
   }
 
@@ -130,8 +125,7 @@
       $button-hover-background-color: $color-light,
       $button-hover-border-color: $color-transparent,
       $button-active-background-color: darken($color-light, 20%),
-      $button-active-border-color: $color-mid,
-      $button-active-outline: 1px solid $color-mid
+      $button-active-border-color: $color-mid
     );
   }
 

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -38,15 +38,8 @@
       $button-border-color: $color-mid,
       $button-hover-background-color: darken($color-x-light, 10%),
       $button-hover-border-color: $color-mid,
-<<<<<<< HEAD
-<<<<<<< HEAD
       $button-active-background-color: darken($color-x-light, 15%),
-=======
-      $button-active-background-color: darken($color-x-light , 15%),
->>>>>>> ea0aa891393a44a3e18b8748b3f0f07588990082
-=======
-      $button-active-background-color: darken($color-x-light , 15%),
->>>>>>> ea0aa891393a44a3e18b8748b3f0f07588990082
+      $button-active-background-color: darken($color-x-light, 15%),
       $button-active-border-color: $color-mid
     );
   }

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -36,9 +36,9 @@
     @include vf-button-pattern (
       $button-disabled-border-color: $color-mid,
       $button-border-color: $color-mid,
-      $button-hover-background-color: darken($color-light, 10%),
+      $button-hover-background-color: darken($color-x-light , 10%),
       $button-hover-border-color: $color-mid,
-      $button-active-background-color: darken($color-light, 20%),
+      $button-active-background-color: darken($color-x-light , 20%),
       $button-active-border-color: $color-mid
     );
   }

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -18,7 +18,10 @@
 
     @include vf-button-pattern (
       $button-disabled-background-color: $color-x-light,
-      $button-disabled-border-color: $color-x-light
+      $button-disabled-border-color: $color-x-light,
+      $button-active-background-color: darken($color-light, 20%),
+      $button-active-border-color: $color-mid,
+      $button-active-outline: 1px solid $color-mid
     );
   }
 
@@ -32,10 +35,13 @@
     @extend %vf-button-base;
 
     @include vf-button-pattern (
-      $button-disabled-border-color: $color-mid-light,
-      $button-border-color: $color-mid-light,
+      $button-disabled-border-color: $color-mid,
+      $button-border-color: $color-mid,
       $button-hover-background-color: darken($color-light, 10%),
-      $button-hover-border-color: $color-mid-light
+      $button-hover-border-color: $color-mid,
+      $button-active-background-color: darken($color-light, 20%),
+      $button-active-border-color: $color-mid,
+      $button-active-outline: 1px solid $color-mid
     );
   }
 
@@ -55,7 +61,10 @@
       $button-hover-background-color: darken($color-brand, 10%),
       $button-hover-border-color: darken($color-brand, 10%),
       $button-disabled-background-color: $color-brand,
-      $button-disabled-border-color: $color-brand
+      $button-disabled-border-color: $color-brand,
+      $button-active-background-color: darken($color-brand, 20%),
+      $button-active-border-color: $color-brand,
+      $button-active-outline: 1px solid $color-brand
     );
   }
 
@@ -75,7 +84,10 @@
       $button-hover-background-color: darken($color-positive, 10%),
       $button-hover-border-color: darken($color-positive, 10%),
       $button-disabled-background-color: $color-positive,
-      $button-disabled-border-color: $color-positive
+      $button-disabled-border-color: $color-positive,
+      $button-active-background-color: darken($color-positive, 20%),
+      $button-active-border-color: $color-positive,
+      $button-active-outline: 1px solid $color-positive
     );
   }
 
@@ -95,7 +107,10 @@
       $button-hover-background-color: darken($color-negative, 10%),
       $button-hover-border-color: darken($color-negative, 10%),
       $button-disabled-background-color: $color-negative,
-      $button-disabled-border-color: $color-negative
+      $button-disabled-border-color: $color-negative,
+      $button-active-background-color: darken($color-negative, 20%),
+      $button-active-border-color: $color-negative,
+      $button-active-outline: 1px solid $color-negative
     );
   }
 
@@ -111,9 +126,12 @@
     @include vf-button-pattern (
       $button-background-color: $color-transparent,
       $button-border-color: $color-transparent,
-      $button-text-color: $color-dark,
+      $button-text-color: $color-link,
       $button-hover-background-color: $color-light,
-      $button-hover-border-color: $color-transparent
+      $button-hover-border-color: $color-transparent,
+      $button-active-background-color: darken($color-light, 20%),
+      $button-active-border-color: $color-mid,
+      $button-active-outline: 1px solid $color-mid
     );
   }
 

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -19,7 +19,7 @@
     @include vf-button-pattern (
       $button-disabled-background-color: $color-x-light,
       $button-disabled-border-color: $color-x-light,
-      $button-active-background-color: darken($color-light, 20%),
+      $button-active-background-color: darken($color-light, 15%),
       $button-active-border-color: $color-x-light
     );
   }
@@ -36,9 +36,13 @@
     @include vf-button-pattern (
       $button-disabled-border-color: $color-mid,
       $button-border-color: $color-mid,
-      $button-hover-background-color: darken($color-x-light , 10%),
+      $button-hover-background-color: darken($color-x-light, 10%),
       $button-hover-border-color: $color-mid,
-      $button-active-background-color: darken($color-x-light , 20%),
+<<<<<<< HEAD
+      $button-active-background-color: darken($color-x-light, 15%),
+=======
+      $button-active-background-color: darken($color-x-light , 15%),
+>>>>>>> ea0aa891393a44a3e18b8748b3f0f07588990082
       $button-active-border-color: $color-mid
     );
   }
@@ -60,8 +64,8 @@
       $button-hover-border-color: darken($color-brand, 10%),
       $button-disabled-background-color: $color-brand,
       $button-disabled-border-color: $color-brand,
-      $button-active-background-color: darken($color-brand, 20%),
-      $button-active-border-color: darken($color-brand, 20%)
+      $button-active-background-color: darken($color-brand, 15%),
+      $button-active-border-color: darken($color-brand, 15%)
     );
   }
 
@@ -82,8 +86,8 @@
       $button-hover-border-color: darken($color-positive, 10%),
       $button-disabled-background-color: $color-positive,
       $button-disabled-border-color: $color-positive,
-      $button-active-background-color: darken($color-positive, 20%),
-      $button-active-border-color: darken($color-positive, 20%)
+      $button-active-background-color: darken($color-positive, 15%),
+      $button-active-border-color: darken($color-positive, 15%)
     );
   }
 
@@ -104,8 +108,8 @@
       $button-hover-border-color: darken($color-negative, 10%),
       $button-disabled-background-color: $color-negative,
       $button-disabled-border-color: $color-negative,
-      $button-active-background-color: darken($color-negative, 20%),
-      $button-active-border-color: darken($color-negative, 20%)
+      $button-active-background-color: darken($color-negative, 15%),
+      $button-active-border-color: darken($color-negative, 15%)
     );
   }
 
@@ -122,9 +126,9 @@
       $button-background-color: $color-transparent,
       $button-border-color: $color-transparent,
       $button-text-color: $color-link,
-      $button-hover-background-color: $color-light,
+      $button-hover-background-color: darken($color-x-light, 10%),
       $button-hover-border-color: $color-transparent,
-      $button-active-background-color: darken($color-light, 20%),
+      $button-active-background-color: darken($color-light, 15%),
       $button-active-border-color: $color-transparent
     );
   }

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -39,7 +39,6 @@
       $button-hover-background-color: darken($color-x-light, 10%),
       $button-hover-border-color: $color-mid,
       $button-active-background-color: darken($color-x-light, 15%),
-      $button-active-background-color: darken($color-x-light, 15%),
       $button-active-border-color: $color-mid
     );
   }

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -20,7 +20,7 @@
       $button-disabled-background-color: $color-x-light,
       $button-disabled-border-color: $color-x-light,
       $button-active-background-color: darken($color-light, 20%),
-      $button-active-border-color: $color-mid
+      $button-active-border-color: $color-x-light
     );
   }
 
@@ -61,7 +61,7 @@
       $button-disabled-background-color: $color-brand,
       $button-disabled-border-color: $color-brand,
       $button-active-background-color: darken($color-brand, 20%),
-      $button-active-border-color: $color-brand
+      $button-active-border-color: darken($color-brand, 20%)
     );
   }
 
@@ -83,7 +83,7 @@
       $button-disabled-background-color: $color-positive,
       $button-disabled-border-color: $color-positive,
       $button-active-background-color: darken($color-positive, 20%),
-      $button-active-border-color: $color-positive
+      $button-active-border-color: darken($color-positive, 20%)
     );
   }
 
@@ -105,7 +105,7 @@
       $button-disabled-background-color: $color-negative,
       $button-disabled-border-color: $color-negative,
       $button-active-background-color: darken($color-negative, 20%),
-      $button-active-border-color: $color-negative
+      $button-active-border-color: darken($color-negative, 20%)
     );
   }
 
@@ -125,7 +125,7 @@
       $button-hover-background-color: $color-light,
       $button-hover-border-color: $color-transparent,
       $button-active-background-color: darken($color-light, 20%),
-      $button-active-border-color: $color-mid
+      $button-active-border-color: $color-transparent
     );
   }
 

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -121,7 +121,7 @@
     @include vf-button-pattern (
       $button-background-color: $color-transparent,
       $button-border-color: $color-transparent,
-      $button-text-color: $color-link,
+      $button-text-color: $color-x-dark,
       $button-hover-background-color: darken($color-x-light, 10%),
       $button-hover-border-color: $color-transparent,
       $button-active-background-color: darken($color-light, 15%),

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -2,5 +2,6 @@
 
 $bar-thickness: $px * 3 !default;
 $border-radius: $sp-unit * .25 !default;
+$border-radius-button: $sp-unit * .5 !default;
 $border: $px solid $color-mid-light !default;
 $box-shadow: 0 1px 5px 1px transparentize($color-dark, .8) !default;

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -2,6 +2,5 @@
 
 $bar-thickness: $px * 3 !default;
 $border-radius: $sp-unit * .25 !default;
-$border-radius-button: $sp-unit * .5 !default;
 $border: $px solid $color-mid-light !default;
 $box-shadow: 0 1px 5px 1px transparentize($color-dark, .8) !default;


### PR DESCRIPTION
## Done

Updates to button styling and a new active (pressed) state.
- Update `base` and `neutral` button from normal text by using link blue `$color-link`
- Change the border radius to `4px` to make them look different to text fields
- Update border colour on `neutral` button to `$color-mid`
- Added an `active` state to all buttons

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check buttons look good on styles:
  - Base, Neutral, Brand, Positive and Negative

## Details

Fixes issues here: https://github.com/vanilla-framework/vanilla-framework/issues/1932

## Visual
![buttons](https://user-images.githubusercontent.com/17748020/45700191-ce2cd080-bb63-11e8-9b59-f5cb94a3d6c5.png)

