### PR TITLE
Consistent margin applied to link and button on p-contextual-menu

### DIFF
--- a/examples/patterns/contextual-menu.html
+++ b/examples/patterns/contextual-menu.html
@@ -4,9 +4,9 @@ title: Contextual menu
 category: _patterns
 ---
 
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Modi natus <span class="p-contextual-menu">
-    <a href="#" class="p-contextual-menu__toggle" aria-controls="#menu" aria-expanded="false" aria-haspopup="true">Link</a>
-    <span class="p-contextual-menu__dropdown" id="menu" aria-hidden="true" aria-label="submenu">
+<span class="p-contextual-menu--left">
+    <button href="#" class="p-contextual-menu__toggle" aria-controls="#menu-1" aria-expanded="false" aria-haspopup="true">Button menu left</button>
+    <span class="p-contextual-menu__dropdown" id="menu-1" aria-hidden="true" aria-label="submenu">
         <span class="p-contextual-menu__group">
             <a href="#" class="p-contextual-menu__link">Link</a>
             <a href="#" class="p-contextual-menu__link">Link</a>
@@ -18,9 +18,9 @@ category: _patterns
             <a href="#" class="p-contextual-menu__link">Link</a>
         </span>
     </span>
-</span> atque eligendi deleniti hic, dolores veritatis reiciendis officiis illo, facere facilis accusamus similique nulla nesciunt. Nemo reprehenderit officia assumenda error enim. Recusandae reiciendis ipsum, mollitia illo iusto excepturi alias dolore fugit eligendi nostrum, unde architecto consequuntur similique quo! Maxime iusto facere, commodi iste fuga officiis.</p>
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Modi natus atque eligendi deleniti hic, dolores veritatis reiciendis <span class="p-contextual-menu--left">
-    <a href="#" class="p-contextual-menu__toggle" aria-controls="#menu-2" aria-expanded="false" aria-haspopup="true">Link</a>
+</span>
+<span class="p-contextual-menu--center">
+    <button href="#" class="p-contextual-menu__toggle" aria-controls="#menu-2" aria-expanded="false" aria-haspopup="true">Button menu center</button>
     <span class="p-contextual-menu__dropdown" id="menu-2" aria-hidden="true" aria-label="submenu">
         <span class="p-contextual-menu__group">
             <a href="#" class="p-contextual-menu__link">Link</a>
@@ -33,22 +33,66 @@ category: _patterns
             <a href="#" class="p-contextual-menu__link">Link</a>
         </span>
     </span>
-</span> officiis illo, facere facilis accusamus similique nulla nesciunt. Nemo reprehenderit officia assumenda error enim. Recusandae reiciendis ipsum, mollitia illo iusto excepturi alias dolore fugit eligendi nostrum, unde architecto consequuntur similique quo! Maxime iusto facere, commodi iste fuga officiis.</p>
-<p>Lorem ipsum dolor sit amet <span class="p-contextual-menu--center">
-  <a href="#" class="p-contextual-menu__toggle" aria-controls="#menu-3" aria-expanded="false" aria-haspopup="true">Link</a>
-  <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" aria-label="submenu">
-      <span class="p-contextual-menu__group">
-          <a href="#" class="p-contextual-menu__link">Link</a>
-          <a href="#" class="p-contextual-menu__link">Link</a>
-          <a href="#" class="p-contextual-menu__link">Link</a>
-      </span>
-      <span class="p-contextual-menu__group">
-          <a href="#" class="p-contextual-menu__link">Link</a>
-          <a href="#" class="p-contextual-menu__link">Link</a>
-          <a href="#" class="p-contextual-menu__link">Link</a>
-      </span>
-  </span>
-</span>, consectetur adipisicing elit. Modi natus atque eligendi deleniti hic, dolores veritatis reiciendis officiis illo, facere facilis accusamus similique nulla nesciunt. Nemo reprehenderit officia assumenda error enim. Recusandae reiciendis ipsum, mollitia illo iusto excepturi alias dolore fugit eligendi nostrum, unde architecto consequuntur similique quo! Maxime iusto facere, commodi iste fuga officiis.</p>
+</span>
+<span class="p-contextual-menu">
+    <button href="#" class="p-contextual-menu__toggle" aria-controls="#menu-3" aria-expanded="false" aria-haspopup="true">Button menu right</button>
+    <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+        </span>
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+        </span>
+    </span>
+</span>
+
+<p>Lorem ipsum dolor sit amet consectetur adipiscing elit <span class="p-contextual-menu--left">
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="#menu-4" aria-expanded="false" aria-haspopup="true">link menu left</a>
+    <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+        </span>
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+        </span>
+    </span>
+</span> nunc dolor. Arcu molestie non arcu porttitor <span class="p-contextual-menu--center">
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="#menu-5" aria-expanded="false" aria-haspopup="true">link menu center</a>
+    <span class="p-contextual-menu__dropdown" id="menu-5" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+        </span>
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+        </span>
+    </span>
+</span> volutpat rutrum ipsum nunc lacus ligula ornare et diam <span class="p-contextual-menu">
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="#menu-6" aria-expanded="false" aria-haspopup="true">link menu right</a>
+    <span class="p-contextual-menu__dropdown" id="menu-6" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+        </span>
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+            <a href="#" class="p-contextual-menu__link">Link</a>
+        </span>
+    </span>
+</span> vel eu..</p>
 
 <script>
 

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -62,6 +62,10 @@
       }
     }
 
+    &__toggle {
+      margin-bottom: $spv-intra;
+    }
+
     &__link {
       border: 0;
       clear: both;


### PR DESCRIPTION
## Done
Since buttons have a margin-bottom by default the dropdown was displaying way below the button.
- Added margin-bottom: `$spv-intra;` to toggle so it's applied across link and button
- Updated example layout to show both buttons and links

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check button and link margin between contextual menu 

## Details
- Fixes issue raised here: https://github.com/vanilla-framework/vanilla-framework/issues/1927

## Screenshots
![screen shot 2018-09-21 at 12 32 24](https://user-images.githubusercontent.com/17748020/45878845-71672b00-bd9a-11e8-9848-9db5fd9b2aef.png)

