### PR TITLE
1887 icon sizes

### DIFF
--- a/examples/patterns/media-object/media-object-circ-img.html
+++ b/examples/patterns/media-object/media-object-circ-img.html
@@ -5,7 +5,7 @@ category: _patterns
 ---
 
 <div class="p-media-object">
-  <img src="https://via.placeholder.com/72x72" class="p-media-object__image is-round">
+  <img src="https://via.placeholder.com/48x48" class="p-media-object__image is-round">
   <div class="p-media-object__details">
     <h3 class="p-media-object__title">
       <a href="#">Person name</a>

--- a/examples/patterns/media-object/media-object.html
+++ b/examples/patterns/media-object/media-object.html
@@ -5,7 +5,7 @@ category: _patterns
 ---
 
 <div class="p-media-object">
-  <img src="https://via.placeholder.com/72x72" class="p-media-object__image">
+  <img src="https://via.placeholder.com/48x48" class="p-media-object__image">
   <div class="p-media-object__details">
     <h3 class="p-media-object__title">
       <a href="#">Event title</a>

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -41,6 +41,7 @@ $social-icon-size: map-get($icon-sizes, social);
 
 /// Icons
 @mixin vf-icon-size($size) {
+  background-size: contain;
   height: $size;
   width: $size;
 }

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -114,9 +114,9 @@ $icon-sizes: (
   default: 2 * $sp-unit,
   thumb--card: 4 * $sp-unit,
   social: 5 * $sp-unit,
-  heading-icon--small: $sp-unit * 5,
+  heading-icon--small: $sp-unit * 4,
   thumb--small: $sp-unit * 6,
-  heading-icon: $sp-unit * 7.5,
+  heading-icon: $sp-unit * 6,
   thumb: $sp-unit * 6,
   thumb--large: $sp-unit * 12
 ) !default;

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -110,10 +110,10 @@ $sp-after: (
 ) !default;
 
 $icon-sizes: (
-  accordion: 1.5 * $sp-unit,
-  default: 2 * $sp-unit,
-  thumb--card: 4 * $sp-unit,
-  social: 5 * $sp-unit,
+  accordion: $sp-unit * 1.5,
+  default: $sp-unit * 2,
+  thumb--card: $sp-unit * 4,
+  social: $sp-unit * 4,
   heading-icon--small: $sp-unit * 4,
   thumb--small: $sp-unit * 6,
   heading-icon: $sp-unit * 6,

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -117,7 +117,7 @@ $icon-sizes: (
   heading-icon--small: $sp-unit * 5,
   thumb--small: $sp-unit * 6,
   heading-icon: $sp-unit * 7.5,
-  thumb: $sp-unit * 10,
+  thumb: $sp-unit * 6,
   thumb--large: $sp-unit * 12
 ) !default;
 


### PR DESCRIPTION
## Done

Updated various icon sizes across the framework and tidied the icon size list.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/

### QA on demo build
- [Media object](http://vanilla-framework-pr-1999.run.demo.haus/vanilla-framework/examples/patterns/media-object/media-object/ ) - Check that icon is 3rem
- [Heading icon](http://vanilla-framework-pr-1999.run.demo.haus/vanilla-framework/examples/patterns/heading-icon/) - Check large/medium screens: 3rem, Small screens: 2rem
-  [Social icons](http://vanilla-framework-pr-1999.run.demo.haus/vanilla-framework/examples/patterns/icons/icons-social/) - Check that icon is 2rem
- Confirm that no unexpected changes are in [Percy](https://percy.io/vanilla-framework/vanilla-framework/builds/1033224)
- Thank @deadlight for manually adding all of these links



## Details
Fixes #1887 
