### PR TITLE
Add a stacked variant of headings with icons

### DIFF
--- a/examples/patterns/heading-icon/heading-icon-stacked.html
+++ b/examples/patterns/heading-icon/heading-icon-stacked.html
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: Heading icon
+title: Heading icon / Stacked
 category: _patterns
 ---
 
 <div class="p-heading-icon">
-  <div class="p-heading-icon__header">
+  <div class="p-heading-icon__header--stacked">
     <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a4d31b28-icon-quote.svg" />
     <h3 class="p-heading-icon__title">Lorem ipsum dolor</h3>
   </div>

--- a/examples/patterns/heading-icon/heading-icon.html
+++ b/examples/patterns/heading-icon/heading-icon.html
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Heading icon / Default
+category: _patterns
+---
+
+<div class="p-heading-icon">
+  <div class="p-heading-icon__header">
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a4d31b28-icon-quote.svg" />
+    <h3 class="p-heading-icon__title">Lorem ipsum dolor</h3>
+  </div>
+  <p>sit amet, consectetur adipisicing elit. Enim excepturi, repudiandae blanditiis odio perferendis voluptatibus dolorum, dicta illum quae ipsa voluptatum, sunt quasi? Nulla reiciendis magnam nostrum aliquam, beatae doloribus.</p>
+</div>

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -12,6 +12,10 @@
     &__header {
       display: flex;
       margin-bottom: $spv-intra--expanded;
+
+      &--stacked {
+        display: inherit;
+      }
     }
 
     &__title {
@@ -32,4 +36,3 @@
     }
   }
 }
-


### PR DESCRIPTION
## Done

Added stacked heading-icon variant.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- See that there are now two variants of the heading-icon pattern:
   - Heading icon / Default
   - Heading icon / Stacked
- Check them against the design in #1903 

## Details

Fixes #1903 
