### PR TITLE
Remove min-width for tooltips

### DIFF
--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -13,7 +13,6 @@
       display: none;
       left: 0;
       margin-bottom: 0;
-      min-width: 155px;
       padding: $spv-intra $sph-intra;
       position: absolute;
       text-align: left;


### PR DESCRIPTION
## Done

Removed the minimum width for tooltips

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/tooltips/
- Use the inspector to make the text of one of the tooltips one character
- See that the tooltip fits to the text

## Details

Fixes #1959 
