### PR TITLE
Remove obsolete <table> scope attributes

### DIFF
--- a/examples/base/table.html
+++ b/examples/base/table.html
@@ -4,32 +4,32 @@ title: Table
 category: _base
 ---
 <table>
-<thead>
-<tr>
-  <th></th>
-  <th scope="col">Header</th>
-  <th scope="col">Header</th>
-  <th scope="col" class="u-align--right">Header</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-  <th scope="row">Header row</th>
-  <td>Table cell</td>
-  <td>Table cell</td>
-  <td class="u-align--right">111</td>
-</tr>
-<tr>
-  <th scope="row">Header row</th>
-  <td>Table cell</td>
-  <td>Table cell</td>
-  <td class="u-align--right">222</td>
-</tr>
-<tr>
-  <th scope="row">Header row</th>
-  <td>Table cell</td>
-  <td>Table cell</td>
-  <td class="u-align--right">333</td>
-</tr>
-</tbody>
+  <thead>
+    <tr>
+      <th></th>
+      <th scope="col">Header</th>
+      <th scope="col">Header</th>
+      <th scope="col" class="u-align--right">Header</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Header row</th>
+      <td>Table cell</td>
+      <td>Table cell</td>
+      <td class="u-align--right">111</td>
+    </tr>
+    <tr>
+      <th>Header row</th>
+      <td>Table cell</td>
+      <td>Table cell</td>
+      <td class="u-align--right">222</td>
+    </tr>
+    <tr>
+      <th>Header row</th>
+      <td>Table cell</td>
+      <td>Table cell</td>
+      <td class="u-align--right">333</td>
+    </tr>
+  </tbody>
 </table>

--- a/examples/base/table.html
+++ b/examples/base/table.html
@@ -7,9 +7,9 @@ category: _base
   <thead>
     <tr>
       <th></th>
-      <th scope="col">Header</th>
-      <th scope="col">Header</th>
-      <th scope="col" class="u-align--right">Header</th>
+      <th>Header</th>
+      <th>Header</th>
+      <th class="u-align--right">Header</th>
     </tr>
   </thead>
   <tbody>

--- a/examples/patterns/tables/table-expanding.html
+++ b/examples/patterns/tables/table-expanding.html
@@ -7,11 +7,13 @@ category: _patterns
 <table class="p-table-expanding" role="grid">
     <thead>
         <tr role="row">
-            <th scope="col" id="t-name" aria-sort="none">Name</th>
-            <th scope="col" id="t-users" aria-sort="none" class="u-align--right">Users</th>
-            <th scope="col" id="t-units" aria-sort="none" class="u-align--right">Units</th>
-            <th scope="col" id="t-revenue" aria-sort="none" class="u-align--right">Actions</th>
-            <th class="u-hide"><!-- empty cell required for validation --></th>
+            <th id="t-name" aria-sort="none">Name</th>
+            <th id="t-users" aria-sort="none" class="u-align--right">Users</th>
+            <th id="t-units" aria-sort="none" class="u-align--right">Units</th>
+            <th id="t-revenue" aria-sort="none" class="u-align--right">Actions</th>
+            <th class="u-hide">
+                <!-- empty cell required for validation -->
+            </th>
         </tr>
     </thead>
     <tbody>
@@ -20,13 +22,18 @@ category: _patterns
             <td role="gridcell" aria-label="Users" class="u-align--right">8</td>
             <td role="gridcell" aria-label="Units" class="u-align--right">19</td>
             <td role="gridcell" class="u-align--right">
-                <button class="u-toggle" aria-controls="#expanded-row" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">Show</button>
+                <button class="u-toggle" aria-controls="#expanded-row" aria-expanded="false" data-shown-text="Hide"
+                    data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row" class="p-table-expanding__panel" aria-hidden="true">
                 <div class="row">
                     <div class="col-6">
                         <h3>Expanding table cell</h3>
-                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates architecto ipsa dolorum eaque rem expedita inventore voluptas odit aspernatur alias molestias facere, eum accusamus dolor, assumenda. Eaque, id! Dolorem perferendis reprehenderit eum, odio minima ad commodi earum non, iste suscipit.</p>
+                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae
+                            nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates architecto ipsa
+                            dolorum eaque rem expedita inventore voluptas odit aspernatur alias molestias facere, eum
+                            accusamus dolor, assumenda. Eaque, id! Dolorem perferendis reprehenderit eum, odio minima
+                            ad commodi earum non, iste suscipit.</p>
                     </div>
                     <div class="col-6">
                         <img src="https://via.placeholder.com/1024x325" alt="">
@@ -39,13 +46,18 @@ category: _patterns
             <td role="gridcell" aria-label="Users" class="u-align--right">12</td>
             <td role="gridcell" aria-label="Units" class="u-align--right">23</td>
             <td role="gridcell" class="u-align--right">
-                <button class="u-toggle" aria-controls="#expanded-row-2" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">Show</button>
+                <button class="u-toggle" aria-controls="#expanded-row-2" aria-expanded="false" data-shown-text="Hide"
+                    data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row-2" class="p-table-expanding__panel" aria-hidden="true">
                 <div class="row">
                     <div class="col-6">
                         <h3>Expanding table cell</h3>
-                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates architecto ipsa dolorum eaque rem expedita inventore voluptas odit aspernatur alias molestias facere, eum accusamus dolor, assumenda. Eaque, id! Dolorem perferendis reprehenderit eum, odio minima ad commodi earum non, iste suscipit.</p>
+                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae
+                            nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates architecto ipsa
+                            dolorum eaque rem expedita inventore voluptas odit aspernatur alias molestias facere, eum
+                            accusamus dolor, assumenda. Eaque, id! Dolorem perferendis reprehenderit eum, odio minima
+                            ad commodi earum non, iste suscipit.</p>
                     </div>
                     <div class="col-6">
                         <img src="https://via.placeholder.com/1024x325" alt="">
@@ -58,13 +70,18 @@ category: _patterns
             <td role="gridcell" aria-label="Users" class="u-align--right">9</td>
             <td role="gridcell" aria-label="Units" class="u-align--right">17</td>
             <td role="gridcell" class="u-align--right">
-                <button class="u-toggle" aria-controls="#expanded-row-3" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">Show</button>
+                <button class="u-toggle" aria-controls="#expanded-row-3" aria-expanded="false" data-shown-text="Hide"
+                    data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row-3" class="p-table-expanding__panel" aria-hidden="true">
                 <div class="row">
                     <div class="col-6">
                         <h3>Expanding table cell</h3>
-                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates architecto ipsa dolorum eaque rem expedita inventore voluptas odit aspernatur alias molestias facere, eum accusamus dolor, assumenda. Eaque, id! Dolorem perferendis reprehenderit eum, odio minima ad commodi earum non, iste suscipit.</p>
+                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae
+                            nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates architecto ipsa
+                            dolorum eaque rem expedita inventore voluptas odit aspernatur alias molestias facere, eum
+                            accusamus dolor, assumenda. Eaque, id! Dolorem perferendis reprehenderit eum, odio minima
+                            ad commodi earum non, iste suscipit.</p>
                     </div>
                     <div class="col-6">
                         <img src="https://via.placeholder.com/1024x325" alt="">
@@ -76,49 +93,49 @@ category: _patterns
 </table>
 
 <script>
-(function() {
-    /**
-     * Toggle target elements with aria controls, hidden and expanded
-     *
-     * @param {String} toggleCtrl
-     *
-     * @example
-     * <button class="u-toggle" aria-controls="#menu" aria-expanded="false">Toggle</button>
-     * <div id="menu" aria-hidden="true">
-     *     <p>Example menu</p>
-     * </div>
-     */
+    (function () {
+        /**
+         * Toggle target elements with aria controls, hidden and expanded
+         *
+         * @param {String} toggleCtrl
+         *
+         * @example
+         * <button class="u-toggle" aria-controls="#menu" aria-expanded="false">Toggle</button>
+         * <div id="menu" aria-hidden="true">
+         *     <p>Example menu</p>
+         * </div>
+         */
 
-    function toggle(toggleCtrl) {
+        function toggle(toggleCtrl) {
 
-        // Select all toggle control elements
-        var t = document.querySelectorAll(toggleCtrl);
+            // Select all toggle control elements
+            var t = document.querySelectorAll(toggleCtrl);
 
-        // Loop through all toggle control elements
-        for(i = 0; i < t.length; i++) {
+            // Loop through all toggle control elements
+            for (i = 0; i < t.length; i++) {
 
-            // Set click event to each toggle control element
-            t[i].addEventListener('click', function(event) {
+                // Set click event to each toggle control element
+                t[i].addEventListener('click', function (event) {
 
-                // Get toggle aria-control target
-                var target = document.querySelector(
-                    this.getAttribute('aria-controls'));
+                    // Get toggle aria-control target
+                    var target = document.querySelector(
+                        this.getAttribute('aria-controls'));
 
-                // If target hidden is already true set to fale and toggle
-                // control expanded to be true / false
-                if (target.getAttributeNode("aria-hidden").value == 'true') {
-                    this.setAttribute('aria-expanded', 'true');
-                    this.innerHTML = this.getAttribute('data-shown-text');
-                    target.setAttribute('aria-hidden', 'false');
-                } else {
-                    this.setAttribute('aria-expanded', 'false');
-                    this.innerHTML = this.getAttribute('data-hidden-text');
-                    target.setAttribute('aria-hidden', 'true');
-                }
-            });
+                    // If target hidden is already true set to fale and toggle
+                    // control expanded to be true / false
+                    if (target.getAttributeNode("aria-hidden").value == 'true') {
+                        this.setAttribute('aria-expanded', 'true');
+                        this.innerHTML = this.getAttribute('data-shown-text');
+                        target.setAttribute('aria-hidden', 'false');
+                    } else {
+                        this.setAttribute('aria-expanded', 'false');
+                        this.innerHTML = this.getAttribute('data-hidden-text');
+                        target.setAttribute('aria-hidden', 'true');
+                    }
+                });
+            }
         }
-    }
 
-    toggle('.u-toggle');
-})()
+        toggle('.u-toggle');
+    })()
 </script>

--- a/examples/patterns/tables/table-mobile-card.html
+++ b/examples/patterns/tables/table-mobile-card.html
@@ -6,9 +6,9 @@ category: _patterns
 <table class="p-table--mobile-card" role="grid">
   <thead>
     <tr role="row">
-      <th scope="col" role="columnheader" id="t-name" aria-sort="none">Name</th>
-      <th scope="col" role="columnheader" id="t-users" aria-sort="none" class="u-align--right">Users</th>
-      <th scope="col" role="columnheader" id="t-units" aria-sort="none" class="u-align--right">Units</th>
+      <th role="columnheader" id="t-name" aria-sort="none">Name</th>
+      <th role="columnheader" id="t-users" aria-sort="none" class="u-align--right">Users</th>
+      <th role="columnheader" id="t-units" aria-sort="none" class="u-align--right">Units</th>
     </tr>
   </thead>
   <tbody>

--- a/examples/patterns/tables/table-sortable.html
+++ b/examples/patterns/tables/table-sortable.html
@@ -7,10 +7,10 @@ category: _patterns
 <table class="p-table--sortable" role="grid">
   <thead>
     <tr role="row">
-      <th scope="col" role="columnheader" id="t-name" aria-sort="none">Name</th>
-      <th scope="col" role="columnheader" id="t-users" aria-sort="none" class="u-align--right">Users</th>
-      <th scope="col" role="columnheader" id="t-units" aria-sort="none" class="u-align--right">Units</th>
-      <th scope="col" role="columnheader" id="t-revenue" aria-sort="none" class="u-align--right">Revenue</th>
+      <th role="columnheader" id="t-name" aria-sort="none">Name</th>
+      <th role="columnheader" id="t-users" aria-sort="none" class="u-align--right">Users</th>
+      <th role="columnheader" id="t-units" aria-sort="none" class="u-align--right">Units</th>
+      <th role="columnheader" id="t-revenue" aria-sort="none" class="u-align--right">Revenue</th>
     </tr>
   </thead>
   <tbody>
@@ -36,7 +36,7 @@ category: _patterns
 </table>
 
 <script>
-  (function() {
+  (function () {
     /**
      * Sort a table by the column specified.
      *
@@ -81,7 +81,7 @@ category: _patterns
       if (direction === 0) {
         // Reset to the default order.
         newRows.sort(function (a, b) {
-          return  a.getAttribute('data-index') - b.getAttribute('data-index');
+          return a.getAttribute('data-index') - b.getAttribute('data-index');
         });
       } else {
         newRows.sort(function (a, b) {
@@ -111,7 +111,7 @@ category: _patterns
         });
       }
       // Append each row into the table, replacing the current elements.
-      for(var i = 0, ii = body.rows.length; i < ii; i += 1) {
+      for (var i = 0, ii = body.rows.length; i < ii; i += 1) {
         body.appendChild(newRows[i]);
       }
     }

--- a/examples/templates/maas-layout.html
+++ b/examples/templates/maas-layout.html
@@ -141,14 +141,14 @@ category: _templates
       <table class="p-table--mobile-card">
         <thead>
           <tr>
-            <th scope="col">FQDN | MAC</th>
-            <th scope="col">Power</th>
-            <th scope="col">Status</th>
-            <th scope="col">Owner | Pool</th>
-            <th scope="col" class="u-align--right">Cores</th>
-            <th scope="col" class="u-align--right">RAM(GB)</th>
-            <th scope="col" class="u-align--right">Disks</th>
-            <th scope="col" class="u-align--right">Storage(GB)</th>
+            <th>FQDN | MAC</th>
+            <th>Power</th>
+            <th>Status</th>
+            <th>Owner | Pool</th>
+            <th class="u-align--right">Cores</th>
+            <th class="u-align--right">RAM(GB)</th>
+            <th class="u-align--right">Disks</th>
+            <th class="u-align--right">Storage(GB)</th>
           </tr>
         </thead>
         <tbody>

--- a/examples/templates/maas-layout.html
+++ b/examples/templates/maas-layout.html
@@ -66,7 +66,8 @@ category: _templates
     <div class="col-4">
       <div class="u-align--right">
         <span class="p-contextual-menu">
-          <a href="#" class="p-button p-contextual-menu__toggle" aria-controls="#menu" aria-expanded="false" aria-haspopup="true">
+          <a href="#" class="p-button p-contextual-menu__toggle" aria-controls="#menu" aria-expanded="false"
+            aria-haspopup="true">
             Change pool <i class="p-icon--contextual-menu"></i>
           </a>
           <span class="p-contextual-menu__dropdown" id="menu" aria-hidden="true" aria-label="submenu">
@@ -87,21 +88,22 @@ category: _templates
   </div>
 </div>
 <div class="p-strip is-shallow">
-    <nav class="p-tabs">
-      <div class="row">
-        <ul class="p-tabs__list" role="tablist">
-          <li class="p-tabs__item" role="presentation">
-            <a href="#section1" class="p-tabs__link" tabindex="0" role="tab" aria-controls="section1" aria-selected="true">Section 1</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="#section2" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section2">Section 2</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="#section3" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section3">Section 3</a>
-          </li>
-        </ul>
-      </div>
-    </nav>
+  <nav class="p-tabs">
+    <div class="row">
+      <ul class="p-tabs__list" role="tablist">
+        <li class="p-tabs__item" role="presentation">
+          <a href="#section1" class="p-tabs__link" tabindex="0" role="tab" aria-controls="section1" aria-selected="true">Section
+            1</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="#section2" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section2">Section 2</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="#section3" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section3">Section 3</a>
+        </li>
+      </ul>
+    </div>
+  </nav>
   <div class="row">
     <div class="col-3">
       <div class="">
@@ -151,7 +153,7 @@ category: _templates
         </thead>
         <tbody>
           <tr>
-            <th aria-label="FQDN | MAC" scope="row">Machine 1</th>
+            <th aria-label="FQDN | MAC">Machine 1</th>
             <td aria-label="Power">Off</td>
             <td aria-label="Status">Ready</td>
             <td aria-label="Owner | Pool">Maria</td>
@@ -161,7 +163,7 @@ category: _templates
             <td aria-label="Storage(GB)" class="u-align--right">2</td>
           </tr>
           <tr>
-            <th aria-label="FQDN | MAC" scope="row">Machine 1</th>
+            <th aria-label="FQDN | MAC">Machine 1</th>
             <td aria-label="Power">Off</td>
             <td aria-label="Status">Ready</td>
             <td aria-label="Owner | Pool">Maria</td>
@@ -171,7 +173,7 @@ category: _templates
             <td aria-label="Storage(GB)" class="u-align--right">2</td>
           </tr>
           <tr>
-            <th aria-label="FQDN | MAC" scope="row">Machine 1</th>
+            <th aria-label="FQDN | MAC">Machine 1</th>
             <td aria-label="Power">Off</td>
             <td aria-label="Status">Ready</td>
             <td aria-label="Owner | Pool">Maria</td>
@@ -181,7 +183,7 @@ category: _templates
             <td aria-label="Storage(GB)" class="u-align--right">2</td>
           </tr>
           <tr>
-            <th aria-label="FQDN | MAC" scope="row">Machine 1</th>
+            <th aria-label="FQDN | MAC">Machine 1</th>
             <td aria-label="Power">Off</td>
             <td aria-label="Status">Ready</td>
             <td aria-label="Owner | Pool">Maria</td>
@@ -191,7 +193,7 @@ category: _templates
             <td aria-label="Storage(GB)" class="u-align--right">2</td>
           </tr>
           <tr>
-            <th aria-label="FQDN | MAC" scope="row">Machine 1</th>
+            <th aria-label="FQDN | MAC">Machine 1</th>
             <td aria-label="Power">Off</td>
             <td aria-label="Status">Ready</td>
             <td aria-label="Owner | Pool">Maria</td>
@@ -201,7 +203,7 @@ category: _templates
             <td aria-label="Storage(GB)" class="u-align--right">2</td>
           </tr>
           <tr>
-            <th aria-label="FQDN | MAC" scope="row">Machine 1</th>
+            <th aria-label="FQDN | MAC">Machine 1</th>
             <td aria-label="Power">Off</td>
             <td aria-label="Status">Ready</td>
             <td aria-label="Owner | Pool">Maria</td>


### PR DESCRIPTION
## Done

Remove obsolete `<table>` scope attributes as they were made obsolete by HTML5 [1]

[1] https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-scope

## QA

- Check through the code and ensure only scope attributes have been removed
- Check that no SCSS uses this attribute as a styling hook