### PR TITLE
Example docs link updated

### DIFF
--- a/docs/en/patterns/code-copyable.md
+++ b/docs/en/patterns/code-copyable.md
@@ -7,7 +7,7 @@ table_of_contents: false
 
 Code copyable should be used when presenting the user with a small snippet of code that they will likely want to copy and paste.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/code-copyable/"
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/code-snippet/"
     class="js-example">
     View example of the code copyable pattern
 </a>


### PR DESCRIPTION
## Done
- Updated docs link example so it doesn't 404

## QA
- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check that correct link is displaying
  - https://vanilla-framework.github.io/vanilla-framework/examples/patterns/code-snippet/

## Details
Fixes issue https://github.com/vanilla-framework/vanilla-framework/issues/1965