### PR TITLE
Add new heading icon stacked example

### DIFF
--- a/docs/en/patterns/heading-icon.md
+++ b/docs/en/patterns/heading-icon.md
@@ -10,6 +10,13 @@ title: Heading icon
   View example of the pattern heading icons
 </a>
 
+## Heading icon stacked
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon-stacked/"
+  class="js-example">
+  View example of the pattern heading icon stacked
+</a>
+
 <hr />
 
 ### Design


### PR DESCRIPTION
## Done

Added example to documentation for new component.
## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check you can see Heading icon stacked example

## Details

Fixes issue #1903 
