### PR TITLE
Update checkboxes and radio buttons to match design spec

### DIFF
--- a/examples/base/forms/checkboxes.html
+++ b/examples/base/forms/checkboxes.html
@@ -4,8 +4,10 @@ title: Forms / Checkboxes
 category: _base
 ---
 <form>
-  <input type="checkbox" id="checkExample1">
+  <input type="checkbox" id="checkExample1" checked>
   <label for="checkExample1">Checkbox option 1</label>
-  <input type="checkbox" id="checkExample2" disabled="disabled">
-  <label for="checkExample2">Checkbox option 2 - disabled</label>
+  <input type="checkbox" id="checkExample2">
+  <label for="checkExample2">Checkbox option 2</label>
+  <input type="checkbox" id="checkExample3" disabled="disabled">
+  <label for="checkExample3">Checkbox option 3 - disabled</label>
 </form>

--- a/examples/base/forms/radio-buttons.html
+++ b/examples/base/forms/radio-buttons.html
@@ -4,7 +4,7 @@ title: Forms / Radio buttons
 category: _base
 ---
 <form>
-  <input type="radio" name="RadioOptions" id="Radio1" value="option1">
+  <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
   <label for="Radio1">Radio option 1</label>
   <input type="radio" name="RadioOptions" id="Radio2" value="option2">
   <label for="Radio2">Radio option 2</label>

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -72,15 +72,50 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
 
   // Default form checkbox and radio styles
   %vf-tick-elements {
-    @include vf-focus($offset: 0);
-    float: left;
-    height: map-get($line-heights, default-text);
-    margin-bottom: 0;
-    margin-right: $sph-inter--expanded;
-    margin-top: 0;
-    padding: 0;
-    vertical-align: middle;
-    width: auto;
+    $box-size: 1rem;
+    $box-offset-top: $spv-intra--condensed;
+    $label-offset--left: $sph-intra + $box-size;
+    $tick-offset-top: $box-offset-top + 3 * $px;
+    opacity: 0;
+    position: absolute;
+
+    & + label {
+      margin-bottom: $spv-inter--condensed-scaleable;
+      padding-left: $label-offset--left;
+      padding-top: 0;
+      position: relative;
+      vertical-align: middle;
+
+      // container
+      &::before {
+        border: 1px solid $color-mid-light;
+        content: '';
+        height: $box-size;
+        left: 0;
+        top: $box-offset-top;
+        width: $box-size;
+      }
+
+      // tick/circle
+      &::after {
+        content: '';
+        opacity: 0;
+      }
+
+      &::before,
+      &::after {
+        position: absolute;
+      }
+    }
+
+    &:checked + label::after {
+      opacity: 1;
+    }
+
+    &:focus + label {
+      outline: 1px solid $color-focus;
+      outline-offset: 2px;
+    }
 
     &[disabled],
     &[disabled='disabled'] {
@@ -170,18 +205,54 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
   }
 
   // Checkbox and radio inputs
-  [type='checkbox'],
-  [type='radio'] {
+  [type="checkbox"] {
     @extend %vf-tick-elements;
 
-    + label {
-      vertical-align: middle;
-      width: 100%;
+    & + label {
+      &::before,
+      &::after {
+        transition: background-color .1s;
+      }
+
+      &::before {
+        border-radius: $border-radius;
+      }
+
+      &::after {
+        border-bottom: 2px solid;
+        border-left: 2px solid;
+        color: $color-x-light;
+        height: 6px;
+        left: 3px;
+        top: $sp-unit;
+        transform: rotate(-45deg);
+        width: 10px;
+      }
+    }
+
+    &:checked + label::before {
+      background-color: $color-information;
+      border-color: $color-information;
     }
   }
 
-  [type='radio'] {
-    margin-top: $spv-nudge;
+  [type="radio"] {
+    @extend %vf-tick-elements;
+
+    & + label {
+      &::before {
+        border-radius: 50%;
+      }
+
+      &::after {
+        background-color: $color-information;
+        border-radius: 50%;
+        height: 10px;
+        left: 3px;
+        top: 7px;
+        width: 10px;
+      }
+    }
   }
 
   [type='submit'] {
@@ -243,67 +314,12 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     border: 1px solid $color-mid-light;
     border-radius: $border-radius;
     color: $color-dark;
-    padding: $spv-intra $sph-intra--condensed;
     margin-bottom: $spv-inter--scaleable;
+    padding: $spv-intra $sph-intra--condensed;
   }
 
   label {
     @extend %default-text;
     width: fit-content;
-  }
-
-  // Accessible checkbox technique from https://medium.com/claritydesignsystem/pure-css-accessible-checkboxes-and-radios-buttons-54063e759bb3
-  input[type="checkbox"] {
-    $box-size: 1rem;
-    $box-offset-top: map-get($nudges, nudge--p) + (map-get($line-heights, default-text) - $box-size) * .5;
-    $tick-offset-top: $box-offset-top + 3 * $px;
-    opacity: 0;
-    position: absolute;
-
-    & + label {
-      @include vf-focus;
-
-      $label-offset--left: $sph-intra + $box-size;
-      margin-bottom: $spv-inter--condensed-scaleable;
-      margin-top: - map-get($nudges, nudge--p);
-      padding-left: $label-offset--left;
-      position: relative;
-
-      // box
-      &::before {
-        border: 1px solid $color-mid-light;
-        border-radius: $border-radius;
-        content: "";
-        display: inline-block;
-        height: 1rem;
-        left: 0;
-        top: $box-offset-top;
-        width: 1rem;
-      }
-
-      // tick
-      &::after {
-        border-bottom: 2px solid;
-        border-left: 2px solid;
-        content: none;
-        display: inline-block;
-        height: 7px;
-        left: 2px;
-        top: 12px;
-        transform: rotate(-45deg);
-        width: 11px;
-      }
-
-      &::before,
-      &::after {
-        // Needed for the line-height to take effect
-        display: inline-block;
-        position: absolute;
-      }
-    }
-
-    &:checked + label::after {
-      content: "";
-    }
   }
 }


### PR DESCRIPTION
## Done

- Updated checkbox style to match [design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Forms)
- Updated radio button to match [design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Forms)
- Updated the examples page to show checked, unchecked and disabled

## QA

- Pull code, `./run`
- Go to http://0.0.0.0:8101/vanilla-framework/vanilla-framework/examples/base/forms/checkboxes/
- Check that it matches the [design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Forms)
- Go to http://0.0.0.0:8101/vanilla-framework/vanilla-framework/examples/base/forms/radio-buttons/
- Check that it matches the [design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Forms)
- Check that the new designs look the same cross-browser, according to [browser support](https://vanillaframework.io/browser-support)