### PR TITLE
Update max-width values on breakpoints

### DIFF
--- a/scss/_settings_breakpoints.scss
+++ b/scss/_settings_breakpoints.scss
@@ -1,7 +1,7 @@
 // Global breakpoints
 $breakpoint-x-small: 460px !default;
 $breakpoint-small: 620px !default;
-$breakpoint-medium: 768px !default;
-$breakpoint-large: 1030px !default;
+$breakpoint-medium: 772px !default;
+$breakpoint-large: 1036px !default;
 $breakpoint-navigation-threshold: $breakpoint-medium !default;
 $breakpoint-heading-threshold: $breakpoint-medium !default;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2133,11 +2133,7 @@ minimist@1.1.x:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
 
-minimist@^1.1.0, minimist@^1.1.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 


### PR DESCRIPTION
## Done
- Original discussions can be found here: ubuntudesign/vanilla-design#289
- Updated max-width values on: 
  - `$breakpoint-large` to 1036px
  - `$breakpoint-medium` to 772px

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check new values match on breakpoints `large` and `medium`

## Details
- Fixes issues here - https://github.com/vanilla-framework/vanilla-framework/issues/1931
