### PR TITLE
Add small variant of the icon-heading pattern. Update stacked class for heading icons. Add docs.

### DIFF
--- a/docs/en/patterns/heading-icon.md
+++ b/docs/en/patterns/heading-icon.md
@@ -7,18 +7,25 @@ title: Heading icon
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon/"
   class="js-example">
-  View example of the pattern heading icons
+View example of the pattern heading icons
 </a>
 
 ## Heading icon stacked
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon-stacked/"
   class="js-example">
-  View example of the pattern heading icon stacked
+View example of the pattern heading icon stacked
+</a>
+
+## Heading icon small
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon-small/"
+  class="js-example">
+View example of the pattern heading icon small
 </a>
 
 <hr />
 
 ### Design
 
-* [Heading icon design](https://github.com/ubuntudesign/vanilla-design/tree/master/Heading%20icon)
+- [Heading icon design](https://github.com/ubuntudesign/vanilla-design/tree/master/Heading%20icon)

--- a/examples/patterns/heading-icon/heading-icon-small.html
+++ b/examples/patterns/heading-icon/heading-icon-small.html
@@ -1,13 +1,13 @@
 ---
 layout: default
-title: Heading icon / Stacked
+title: Heading icon / Small
 category: _patterns
 ---
 
-<div class="p-heading-icon">
-  <div class="p-heading-icon__header is-stacked">
+<div class="p-heading-icon--small">
+  <div class="p-heading-icon__header">
     <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a4d31b28-icon-quote.svg" />
-    <h3 class="p-heading-icon__title">Lorem ipsum dolor</h3>
+    <h4 class="p-heading-icon__title">Lorem ipsum dolor</h4>
   </div>
   <p>sit amet, consectetur adipisicing elit. Enim excepturi, repudiandae blanditiis odio perferendis voluptatibus dolorum, dicta illum quae ipsa voluptatum, sunt quasi? Nulla reiciendis magnam nostrum aliquam, beatae doloribus.</p>
 </div>

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -12,7 +12,7 @@
       display: flex;
       margin-bottom: $spv-intra--expanded;
 
-      &--stacked {
+      &.is-stacked {
         display: inherit;
       }
     }
@@ -31,6 +31,18 @@
       @media (min-width: $breakpoint-medium) {
         height: map-get($icon-sizes, heading-icon);
         width: map-get($icon-sizes, heading-icon);
+      }
+    }
+  }
+
+  .p-heading-icon--small {
+    .p-heading-icon__img {
+      height: map-get($icon-sizes, heading-icon--x-small);
+      width: map-get($icon-sizes, heading-icon--x-small);
+
+      @media (min-width: $breakpoint-medium) {
+        height: map-get($icon-sizes, heading-icon--small);
+        width: map-get($icon-sizes, heading-icon--small);
       }
     }
   }

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -112,13 +112,14 @@ $sp-after: (
 $icon-sizes: (
   accordion: $sp-unit * 1.5,
   default: $sp-unit * 2,
-  thumb--card: $sp-unit * 4,
-  social: $sp-unit * 4,
   heading-icon--small: $sp-unit * 4,
-  thumb--small: $sp-unit * 6,
+  heading-icon--x-small: $sp-unit * 3,
   heading-icon: $sp-unit * 6,
-  thumb: $sp-unit * 6,
-  thumb--large: $sp-unit * 12
+  social: $sp-unit * 4,
+  thumb--card: $sp-unit * 4,
+  thumb--large: $sp-unit * 12,
+  thumb--small: $sp-unit * 6,
+  thumb: $sp-unit * 6
 ) !default;
 
 // generic units


### PR DESCRIPTION
## Done

Added a new small variant of the heading-icon pattern and changed the stacked variant to an "is-stacked" flag class.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/heading-icon/
- Check the icon types in all viewports
- Compare to the [design specs](https://github.com/ubuntudesign/vanilla-design/issues/224)

## Details

Fixes #1890 