### PR TITLE
2016 - Update button paddings with and without icon

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,6 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.8.4)
   jekyll-redirect-from
-  jekyll-watch (= 2.0.0)
 
 BUNDLED WITH
    1.16.6

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -17,9 +17,9 @@
     display: inline-block;
     font-size: 1rem;
     font-weight: 300;
-    line-height: 1;
+    line-height: map-get($line-heights, default-text);
     margin-bottom: $spv-inter--scaleable + 2 * $spv-nudge-compensation;
-    padding: $sp-unit * 1.5;
+    padding: $spv-nudge - $px $sph-intra--condensed * 1.5;
     text-align: center;
     text-decoration: none;
 
@@ -67,10 +67,6 @@
       p & + & {
         margin-top: $spv-inter--condensed-scaleable + $spv-nudge-compensation;
       }
-    }
-
-    & [class*='p-icon'] + * {
-      margin-left: $sph-intra * 0.25;
     }
   }
 }

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -146,5 +146,17 @@
 @mixin vf-button-icon {
   [class~='p-button'].has-icon {
     width: auto;
+
+    & [class*='p-icon'] {
+      // Apply negative margins to make textless button icon a square
+      &:only-child {
+        margin-left: -($px * 2);
+        margin-right: -($px * 2);
+      }
+
+      + * {
+        margin-left: $sph-intra--condensed / 2;
+      }
+    }
   }
 }

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -58,8 +58,7 @@ $social-icon-size: map-get($icon-sizes, social);
   margin: 0;
   padding: 0;
   position: relative;
-  top: -2px;
-  vertical-align: sub;
+  top: 2px;
 }
 
 %social-icon {


### PR DESCRIPTION
## Done

- Reverted top and bottom button padding to match form input elements
- Changed left and right padding to `.75rem/12px`

## QA

- Pull code
- Run `./run serve --watch`
- Go to http://0.0.0.0:8101/vanilla-framework/examples/patterns/buttons/icon/
- Check that the button with only icon is square (note it's not a *perfect* square - 38 x 36.78)
- Go to http://0.0.0.0:8101/vanilla-framework/examples/patterns/forms/form-inline/
- Check that the buttons are the same height as the form inputs
- Check both in Chrome and Firefox because there's some weirdness with how each determine inline-block spacing

## Details

Fixes #2016 

## Screenshots
![screenshot](https://user-images.githubusercontent.com/25733845/47226769-441d9500-d3b9-11e8-8e6b-f284bc6c80ef.png)

![screenshot_1](https://user-images.githubusercontent.com/25733845/47227241-42a09c80-d3ba-11e8-8791-152285da960e.png)
