### PR TITLE
Update `h2` heading to use Thin font-weight

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -367,7 +367,7 @@
     @include heading-max-width--short;
     font-size: pow($ms-ratio, 6) * 1rem;
     font-style: normal;
-    font-weight: 300;
+    font-weight: 100;
     line-height: map-get($line-heights, h2);
     margin-bottom: map-get($sp-after, h2) - map-get($nudges, nudge--h2);
     margin-top: 0;


### PR DESCRIPTION
## Done
- Update `h2` heading to use Thin font-weight
- Original design issue discussing decision can be found here: https://github.com/vanilla-framework/vanilla-framework/issues/2029.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/headings/
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/headings/default/
- Check you see font-weight `100` applied to h2 heading

## Details
Fixes issue #2029 

## Screenshots
![screenshot 2018-10-23 at 10 55 21](https://user-images.githubusercontent.com/17748020/47352632-31090e80-d6b2-11e8-8d6a-cb5d00eabcb6.png)
