### PR TITLE
Fix spacing at bottom of blockquotes

### DIFF
--- a/scss/_base_blockquotes.scss
+++ b/scss/_base_blockquotes.scss
@@ -4,6 +4,12 @@
 @mixin vf-b-blockquotes {
   blockquote {
     border-left: 2px solid $color-mid-dark;
+    margin-bottom: 1.1rem;
+    padding-bottom: 0.4rem;
+
+    & > :last-child {
+      margin-bottom: 0;
+    }
 
     > cite {
       display: block;

--- a/scss/_base_blockquotes.scss
+++ b/scss/_base_blockquotes.scss
@@ -4,8 +4,8 @@
 @mixin vf-b-blockquotes {
   blockquote {
     border-left: 2px solid $color-mid-dark;
-    margin-bottom: 1.1rem;
-    padding-bottom: 0.4rem;
+    margin-bottom: $spv-intra--regular;
+    padding-bottom: $spv-intra--regular;
 
     & > :last-child {
       margin-bottom: 0;

--- a/scss/_base_blockquotes.scss
+++ b/scss/_base_blockquotes.scss
@@ -5,14 +5,23 @@
   blockquote {
     border-left: 2px solid $color-mid-dark;
     margin-bottom: $spv-intra--regular;
-    padding-bottom: $spv-intra--regular;
+    margin-left: 0;
+    margin-top: 0;
+    overflow: auto; // include margins of children into it's own height
+    padding-bottom: $spv-intra;
+    padding-left: $sp-large;
 
     & > :last-child {
-      margin-bottom: 0;
+      margin-bottom: $spv-nudge-compensation;
     }
 
     > cite {
       display: block;
+      font-style: normal;
+    }
+
+    > p {
+      font-style: italic;
     }
   }
 }

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -185,23 +185,6 @@
     @include vf-heading-6;
   }
 
-  // blockquotes
-  blockquote {
-    margin-bottom: 0;
-    margin-left: 0;
-    margin-top: 0;
-    overflow: auto; // include margins of children into it's own height
-    padding-left: $sp-large;
-
-    > p {
-      font-style: italic;
-    }
-
-    > cite {
-      font-style: normal;
-    }
-  }
-
   // misc
   strong {
     @extend %bold;


### PR DESCRIPTION
## Done

Fix the bottom spacing of blockquotes.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/blockquotes/
- See that the bottom spacing is now good 

## Details

Fixes #1988 