### PR TITLE
Fix close button styling for all variants of notification

### DIFF
--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -8,7 +8,16 @@
     @extend %vf-has-box-shadow;
     @extend %vf-card;
     display: flex;
+    overflow: hidden;
     padding: 0;
+
+    .p-icon--close {
+      background-color: transparent;
+      background-size: map-get($icon-sizes, default);
+      border: 0;
+      margin: $sp-unit * 2 + $bar-thickness $sph-intra auto auto;
+      padding: $spv-intra;
+    }
   }
 
   @include vf-notifications-default;
@@ -43,14 +52,6 @@
     &__status::after,
     &__action::before {
       content: ' ';
-    }
-
-    .p-icon--close {
-      background-color: transparent;
-      background-size: map-get($icon-sizes, default);
-      border: 0;
-      margin: $sp-unit * 2 + $bar-thickness $sph-intra auto auto;
-      padding: $spv-intra;
     }
   }
 

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -15,7 +15,7 @@
       background-color: transparent;
       background-size: map-get($icon-sizes, default);
       border: 0;
-      margin: $sp-unit * 2 + $bar-thickness $sph-intra auto auto;
+      margin: $sp-unit * 2 $sph-intra auto auto;
       padding: $spv-intra;
     }
   }


### PR DESCRIPTION
## Done

Made the close icon work when placed in all kinds of notificaitons

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/notifications/notifications/
- See that the close button is displayed correctly
- Modify `patterns/notifications/notifications.html` and give the notification the `--positive` modifier
- See that the close button still works!

## Details

Fixes #1928
