### PR TITLE
Add slanted strip pattern

### DIFF
--- a/examples/patterns/strips/slanted.html
+++ b/examples/patterns/strips/slanted.html
@@ -1,0 +1,15 @@
+---
+layout: default
+title: Strips / Slanted
+category: _patterns
+---
+
+<div class="p-strip--dark is-slanted">
+  <div class="row">
+    <div class="col-12">
+      <h2>A universal app store for Linux</h2>
+      <p>Deliver and update your app on any Linux distribution —<br class="u-hide--small"> for desktop, cloud, and Internet of Things.</p>
+      <a href="/first-snap" class="p-button--positive">Publish your app</a>
+    </div>
+  </div>
+</div>

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -132,7 +132,7 @@
 
     &::after {
       $bleed: -3px; // stretch outside to compensate for aliasing; otherwise edge of image underneath becomes visible as you resize
-      background-image: url('#{$assets-path}9efd9fc5-hero-bg-mask-snapcraft--white-orange.svg');
+      background-image: url('#{$assets-path}077b5e59-hero-bg-mask-snapcraft--white-orange--bigger-accent.svg');
       background-position: 100% 100%;
       background-repeat: no-repeat;
       bottom: $bleed;

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -26,7 +26,7 @@
 
   %section-padding--deep {
     @media only screen and (max-width: $breakpoint-large) {
-      padding: $spv-inter--deep-scaleable * 0.5 0 $spv-inter--deep-scaleable * 0.5;
+      padding: $spv-inter--deep-scaleable * 0.5 0;
     }
 
     @media only screen and (min-width: $breakpoint-large) {
@@ -46,6 +46,7 @@
   @include vf-p-strip-bordered;
   @include vf-p-strip-shallow;
   @include vf-p-strip-deep;
+  @include vf-p-strip-slanted;
 }
 
 @mixin vf-p-strip-default {
@@ -106,5 +107,49 @@
 @mixin vf-p-strip-deep {
   [class^='p-strip'].is-deep {
     @extend %section-padding--deep;
+  }
+}
+
+@mixin vf-p-strip-slanted {
+  $assets-path: 'https://assets.ubuntu.com/v1/';
+  $horizontal-edge-padding: $spv-inter--regular-scaleable;
+  $slanted-edge-padding: $horizontal-edge-padding * 2; // coloured area takes half the rectangle surface area; to visually compensate, we multiply it by 2
+
+  [class^='p-strip'].is-slanted {
+    background-image: url('#{$assets-path}a3c29307-hero-bg-snapcraft-1--nowhite.svg'); // b04b115e-hero-bg-snapcraft-1-clean.svg
+    background-position: 50% 50%;
+    overflow: hidden;
+    position: relative;
+
+    @media (max-width: $breakpoint-large) {
+      background-size: cover;
+      padding: $spv-inter--regular-scaleable 0 $slanted-edge-padding;
+    }
+    @media (min-width: $breakpoint-large) {
+      background-size: 5000px 667px; // actual svg size
+      padding: $spv-inter--regular-scaleable 0 $slanted-edge-padding;
+    }
+
+    &::after {
+      $bleed: -3px; // stretch outside to compensate for aliasing; otherwise edge of image underneath becomes visible as you resize
+      background-image: url('#{$assets-path}9efd9fc5-hero-bg-mask-snapcraft--white-orange.svg');
+      background-position: 100% 100%;
+      background-repeat: no-repeat;
+      bottom: $bleed;
+      content: '';
+      left: $bleed;
+      position: absolute;
+      right: $bleed;
+      top: $bleed;
+      z-index: 1;
+
+      @media only screen and (max-width: $breakpoint-large) {
+        background-size: auto $slanted-edge-padding;
+      }
+
+      @media only screen and (min-width: $breakpoint-large) {
+        background-size: 100%;
+      }
+    }
   }
 }


### PR DESCRIPTION
## Done

Implements the new slanted hero suru designs.
The new slanted strip is based on the spacing of the regular strip, with the bottom padding doubled. This is to account for the fact that only half of the padded area appears in colour. To maintain visual balance, the padding is doubled. This way the surface area that is part of the hero element remains the same.

There is an additional provision for breakpoints smaller than $breakpoint-large: the backround-size of the strip is fixed, rather than scaling. This is to maintain the orange accent at the same size.

The slant is constructed out of two elements - a regular rectangular background, and a pseudo element containing the slanted white mask. This is to ensure the coloured background is responsive, while the orange accent stays affixed to the screen's right edge.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/strips/slanted/
- Inspect the background, resize the screen to see how it behaves. Test in different browsers as absolutely positioned pseudo elements sometimes cause artefacts on resize in certain browsers.

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
mobile:
![image](https://user-images.githubusercontent.com/2741678/48628534-576b5280-e9af-11e8-9ca6-cb462376c832.png)

desktop:
![image](https://user-images.githubusercontent.com/2741678/48628508-428ebf00-e9af-11e8-8e65-a97969c708c1.png)


