### PR TITLE
Fix strip borders

### DIFF
--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -37,6 +37,7 @@
   %vf-strip {
     @extend %section-padding--default;
     clear: both;
+    position: relative;
     width: 100%;
   }
 
@@ -92,8 +93,7 @@
 
 @mixin vf-p-strip-bordered {
   [class^='p-strip'].is-bordered {
-    border-bottom: 1px solid $color-mid-light;
-    margin-bottom: -#{$px};
+    @extend %vf-pseudo-border--bottom;
   }
 }
 


### PR DESCRIPTION
## Done

Changed the borders on strips - which caused issues with the baseline grid - by making p-strip position: relative by default and use %vf-pseudo-border--bottom

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/strips/is-bordered/
- See that the strip is bordered
- Add another strip to the markup with the "--light" modifier and see that the border is visible
- High five me

## Details

Fixes #2045 