### PR TITLE
Add a method of handling form validation for select dropdowns

### DIFF
--- a/docs/en/base/forms.md
+++ b/docs/en/base/forms.md
@@ -5,34 +5,34 @@ table_of_contents: true
 
 ## Forms
 
-Vanilla form controls have global styling defined at the HTML element level. Labels and most input types are 100% width of the ```<form>``` parent element.
+Vanilla form controls have global styling defined at the HTML element level. Labels and most input types are 100% width of the `<form>` parent element.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/form/"
     class="js-example">
-    View example of a base form
+View example of a base form
 </a>
 
 ### Input elements
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/input/"
     class="js-example">
-    View example of an input element
+View example of an input element
 </a>
 
 ### HTML5 elements
 
-Vanilla supports all HTML5 input types: ```text```, ```password```, ```datetime```, ```datetime-local```, ```date```, ```month```, ```time```, ```week```, ```color```, ```number```, ```email```, ```url```, ```search``` and ```tel```.
+Vanilla supports all HTML5 input types: `text`, `password`, `datetime`, `datetime-local`, `date`, `month`, `time`, `week`, `color`, `number`, `email`, `url`, `search` and `tel`.
 
 ### Textarea
 
-The ```<textarea>``` tag defines a multi-line text input control.
+The `<textarea>` tag defines a multi-line text input control.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/textarea/"
     class="js-example">
-    View example of an input element
+View example of an input element
 </a>
 
-Note: The attribute ```readonly``` disables the input but it still retains a default cursor.
+Note: The attribute `readonly` disables the input but it still retains a default cursor.
 
 ### Checkbox and radio button
 
@@ -40,77 +40,81 @@ Use checkboxes and radio buttons to select one or more options.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/checkboxes/"
     class="js-example">
-    View example of the base checkboxes
+View example of the base checkboxes
 </a>
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/radio-buttons/"
     class="js-example">
-    View example of the base radio buttons
+View example of the base radio buttons
 </a>
 
 ### Select
 
-Use the ```<select>``` element to create a drop-down list.
+Use the `<select>` element to create a drop-down list.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/selects/"
     class="js-example">
-    View example of the base selects
+View example of the base selects
 </a>
 
-Use the ```multiple``` attribute to create a multiple select control.
+Use the `multiple` attribute to create a multiple select control.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/select-multiple/"
     class="js-example">
-    View example of the base multiple selects
+View example of the base multiple selects
 </a>
 
 ### Fieldset
 
-You can use the ```<fieldset>``` element to divide the form into different logical sections.
+You can use the `<fieldset>` element to divide the form into different logical sections.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/fieldset/"
     class="js-example">
-    View example of the base form fieldset
+View example of the base form fieldset
 </a>
 
 ### Inline form
 
-By applying the class ```.p-form--inline``` and wrapping any form control in ```.p-form__group``` you can change the layout style of any form to be inline.
+By applying the class `.p-form--inline` and wrapping any form control in `.p-form__group` you can change the layout style of any form to be inline.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/forms/form-inline/"
     class="js-example">
-    View examples of form inline patterns
+View examples of form inline patterns
 </a>
 
 ### Stacked form
 
-By applying the class ```.p-form--stacked``` and wrapping any form control in ```.p-form__group``` you can change the layout style of any form to be stacked.
+By applying the class `.p-form--stacked` and wrapping any form control in `.p-form__group` you can change the layout style of any form to be stacked.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/forms/form-stacked/"
     class="js-example">
-    View examples of form stacked patterns
+View examples of form stacked patterns
 </a>
 
 ### Disabled state
 
-Adding the ```[disabled="disabled"]``` attribute to an input will prevent user interaction. All disabled inputs have an opacity of ```0.5``` and ```not-allowed``` cursor on hover.
+Adding the `[disabled="disabled"]` attribute to an input will prevent user interaction. All disabled inputs have an opacity of `0.5` and `not-allowed` cursor on hover.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/forms/disabled-input/"
     class="js-example">
-    View example of a disabled input
+View example of a disabled input
 </a>
 
 ### Validation classes
 
-Applying the classes ```.is-error```, ```.is-caution``` or ```.is-success``` to an input will style that element differently to provide visual feedback in case there is an error, caution or success notification related to the element.
+To use form validation feedback - which includes feedback messages, icons and border colours - wrap individual input elements in a `p-form-validation` and additionally apply the `.is-error`, `.is-caution` or `.is-success` to the wrapper as appropriate.
+
+If your form uses select elements then you will additionally need to wrap only the `<select>` element in a wrapper with the class `p-form-validation__select-wrapper` to mitigate some of the quirks of this specific HTML element across browsers.
+
+Descriptive text relating to the element's validation status should use the class `p-form-validation__message`.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/forms/form-validation/"
     class="js-example">
-    View example of form validation patterns
+View example of form validation patterns
 </a>
 
 <hr />
 
 ### Design
 
-* [Forms design](https://github.com/ubuntudesign/vanilla-design/tree/master/Forms)
+- [Forms design](https://github.com/ubuntudesign/vanilla-design/tree/master/Forms)

--- a/examples/patterns/forms/form-validation.html
+++ b/examples/patterns/forms/form-validation.html
@@ -36,4 +36,18 @@ category: _patterns
       <strong>Success:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
     </p>
   </div>
+
+  <div class="p-form-validation is-error">
+    <label for="exampleSelectInputError">Select with error</label>
+    <div class="p-form-validation__select-wrapper">
+      <select class="p-form-validation__input" id="exampleSelectInputError">
+        <option value="">--Select an option--</option>
+        <option value="apples">Apples</option>
+        <option value="oranges">Oranges</option>
+      </select>
+    </div>
+    <p class="p-form-validation__message">
+      <strong>Error:</strong> Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+    </p>
+  </div>
 </form>

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -52,7 +52,8 @@
       pointer-events: none;
       position: absolute;
       right: $sp-x-large;
-      top: $sp-unit * 1.3;
+      //top: $sp-unit * 1.3;
+      top: calc(50% - (#{$icon-size} / 2) - (#{$input-margin-bottom} / 2));
       width: $icon-size;
       z-index: 100;
     }

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -10,7 +10,7 @@
   .p-form-validation {
     @include vf-validation-wrapper;
 
-    .p-form-validation__input {
+    :not(select).p-form-validation__input {
       // Not using parent selector here as two classes are required to override atribute selectors in reset
       background-position: calc(100% - #{$sph-intra--condensed}) 50%;
       background-repeat: no-repeat;
@@ -36,24 +36,61 @@
     }
   }
 
+  .is-error .p-form-validation__select-wrapper,
+  .is-caution .p-form-validation__select-wrapper,
+  .is-success .p-form-validation__select-wrapper {
+    $icon-size: map-get($icon-sizes, default);
+    min-width: 10em;
+    position: relative;
+
+    &::after {
+      background-repeat: no-repeat;
+      content: ' ';
+      display: block;
+      height: $icon-size;
+      pointer-events: none;
+      position: absolute;
+      right: $sp-x-large;
+      top: $sp-unit * 1.3;
+      width: $icon-size;
+      z-index: 100;
+    }
+
+    .p-form-validation__input {
+      padding-right: $sp-xxxx-large;
+    }
+  }
+
   .is-error {
     .p-form-validation__input {
-      background-image: url('#{$assets-path}4b0cd7fc-icon-error.svg');
       border-color: $color-negative;
+    }
+
+    :not(select).p-form-validation__input,
+    .p-form-validation__select-wrapper::after {
+      background-image: url('#{$assets-path}4b0cd7fc-icon-error.svg');
     }
   }
 
   .is-success {
     .p-form-validation__input {
-      background-image: url('#{$assets-path}94949185-icon-success.svg');
       border-color: $color-positive;
+    }
+
+    :not(select).p-form-validation__input,
+    .p-form-validation__select-wrapper::after {
+      background-image: url('#{$assets-path}94949185-icon-success.svg');
     }
   }
 
   .is-caution {
     .p-form-validation__input {
-      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16'%3E%3Cg color='%23000'%3E%3Cpath fill='none' d='M0 0h16v16H0z'/%3E%3Cpath stroke-linejoin='round' fill='#{vf-url-friendly-color($color-caution)}' transform='matrix%282.28 0 0 2.437 -2180.8 -490.52%29' stroke='#{vf-url-friendly-color($color-caution)}' stroke-width='.848' d='M963.07 207.03h-6.15l3.08-5.33z'/%3E%3Cpath d='M7 5v5h2V5H7zm0 6v2h2v-2H7z' fill='%23111'/%3E%3C/g%3E%3C/svg%3E");
       border-color: $color-caution;
+    }
+
+    :not(select).p-form-validation__input,
+    .p-form-validation__select-wrapper::after {
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16'%3E%3Cg color='%23000'%3E%3Cpath fill='none' d='M0 0h16v16H0z'/%3E%3Cpath stroke-linejoin='round' fill='#{vf-url-friendly-color($color-caution)}' transform='matrix%282.28 0 0 2.437 -2180.8 -490.52%29' stroke='#{vf-url-friendly-color($color-caution)}' stroke-width='.848' d='M963.07 207.03h-6.15l3.08-5.33z'/%3E%3Cpath d='M7 5v5h2V5H7zm0 6v2h2v-2H7z' fill='%23111'/%3E%3C/g%3E%3C/svg%3E");
     }
   }
 }

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -45,6 +45,7 @@
 
     &::after {
       background-repeat: no-repeat;
+      background-size: contain;
       content: ' ';
       display: block;
       height: $icon-size;


### PR DESCRIPTION
## Done

Added a way of handling select dropdowns with validation states.
This requires additional markup but is the cleanest option I can find.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/forms/form-validation/
- See the dropdown error state (other states can be seen by changing the parent's class)

## Details

Fixes: #2044 
