### PR TITLE
Update heading widths to avoid situation where headings are narrower than paragraphs.

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -365,7 +365,7 @@
   }
 
   %vf-heading-3 {
-    @include heading-max-width--long;
+    @include heading-max-width--mid;
     font-size: pow($ms-ratio, 4) * 1rem;
     font-style: normal;
     font-weight: 300;
@@ -464,8 +464,13 @@
 }
 
 // Optimal max-width for headings (up to 3 lines of copy)
-@mixin heading-max-width--long {
+@mixin heading-max-width--mid {
   max-width: 25em;
+}
+
+// Optimal max-width for headings (up to 3 lines of copy)
+@mixin heading-max-width--long {
+  max-width: 30em;
 }
 
 // Optimal max-width for body copy


### PR DESCRIPTION
## Done

Added new heading width variable and styled h4 to have a higher max width.

Note: this may very well be obsoleted when max widths on type is removed later but this is an interim fix.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Inspect the page / edit a demo and add the following HTML to a page
- See that headings are all reasonably wide and are longer than the paragraph text.

```
<h1>h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 h1 </h1>
<h3>h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 h3 </h3>
<h4>h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 h4 </h4>
<p>p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p p </p>
```

## Details

Fixes #1852 
