### PR TITLE
Update <abbr> cursor to 'help'

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -207,7 +207,7 @@
 
   abbr[title] {
     border-bottom: 0.1em dotted;
-    cursor: pointer;
+    cursor: help;
     text-decoration: none;
   }
 


### PR DESCRIPTION
## Done

Update `<abbr>` cursor style to "help"

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/abbr/
- Hover over the abbreviation
- See the 'help' cursor

## Details

Fixes #1962 