### PR TITLE
Update box-shadow on form components

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -184,7 +184,7 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
   [type='search'] {
     -moz-appearance: none; // sass-lint:disable-line no-vendor-prefixes
     -webkit-appearance: none; // sass-lint:disable-line no-vendor-prefixes
-    appearance: textfield;
+    appearance: none;
     border-radius: 0;
 
     // sass-lint:disable no-vendor-prefixes
@@ -280,6 +280,7 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     padding-right: $sph-intra--expanded;
     text-indent: 0.01px;
     text-overflow: '';
+    box-shadow: none;
 
     &:hover {
       cursor: pointer;
@@ -289,6 +290,7 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     &[size] {
       background-image: none;
       height: auto;
+      box-shadow: none;
 
       option {
         font-weight: 300;

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -184,7 +184,7 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
   [type='search'] {
     -moz-appearance: none; // sass-lint:disable-line no-vendor-prefixes
     -webkit-appearance: none; // sass-lint:disable-line no-vendor-prefixes
-    appearance: none;
+    appearance: textfield;
     border-radius: 0;
 
     // sass-lint:disable no-vendor-prefixes

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -26,7 +26,6 @@
     position: relative;
 
     &__input {
-      box-shadow: none;
       flex-grow: 2;
       margin-bottom: 0; // XXX patch it stretches a box shadow and the search button.
 


### PR DESCRIPTION
## Done
Agreed that input elements retain box-shadow but control elements it will be removed, this will provide consistency across form components and usage in Vanilla.
- removed box-shadow from **forms/selects/**
- removed box-shadow from **forms/select-multiple/**
- add box-shadow to **search-box/default/** and **search-box/navigation/**

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check form components:
  - http://0.0.0.0:8101/vanilla-framework/examples/base/forms/select-multiple/
  - http://0.0.0.0:8101/vanilla-framework/examples/base/forms/selects/
  - http://0.0.0.0:8101/vanilla-framework/examples/patterns/search-box/default/

## Details

Fixes design https://github.com/ubuntudesign/vanilla-design/issues/319 and original demo proposal https://github.com/vanilla-framework/vanilla-framework/pull/2065
