### PR TITLE
Make hover state visible when navigation background is a darker colour

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -226,7 +226,7 @@ $nav-border-bottom-thickness: $px;
       }
 
       &:hover {
-        background-color: darken($color-navigation-background, 3%);
+        background-color: if(lightness($color-navigation-background) > 50, darken($color-navigation-background, 3%), lighten($color-navigation-background, 15%));
       }
     }
 


### PR DESCRIPTION
## Done

Used the lighten function to lighten the on-hover colour of nav items in darker instances of navigation

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/default/
- See that the navigation is light with slightly darker hover states on the nav items
- Edit /scss/build.scss
- Add a new line at the beginning of the file: ```$color-navigation-background: #001;```
- Wait for the CSS to be rebuilt
- Refresh the demo
- See that the nav is very dark blue and a lighter blue on hover
- Experiment with other colours

## Details

Fixes #1604 