### PR TITLE
Add 404 page content and updage nginx config to use it

### DIFF
--- a/docs/en/404.md
+++ b/docs/en/404.md
@@ -5,6 +5,6 @@ title: 404: Page not found
 <div class="p-strip is-deep">
   <div class="row">
     <h1>404: Page not found</h1>
-    <p class="p-heading--four" style="max-width: none">Sorry, we can't find the page you're looking for.<br>If you think this is an error on our site, please <a class="p-link--external" href="https://github.com/canonical-websites/vanillaframework.io/issues/new">file a bug.</a></p>
+    <p class="p-heading--four" style="max-width: 35em">Sorry, we can't find the page you're looking for.<br>If you think this is an error on our site, please <a class="p-link--external" href="https://github.com/canonical-websites/vanillaframework.io/issues/new">file a bug.</a></p>
   </div>
 </div>

--- a/docs/en/404.md
+++ b/docs/en/404.md
@@ -1,0 +1,10 @@
+---
+title: 404: Page not found
+---
+
+<div class="p-strip is-deep">
+  <div class="row">
+    <h1>404: Page not found</h1>
+    <p class="p-heading--four" style="max-width: none">Sorry, we can't find the page you're looking for.<br>If you think this is an error on our site, please <a class="p-link--external" href="https://github.com/canonical-websites/vanillaframework.io/issues/new">file a bug.</a></p>
+  </div>
+</div>

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -22,7 +22,7 @@ server {
     index index.html;
 
     # Show 404 page
-    error_page 404 /404.html;
+    error_page 404 /en/404.html;
 
     # Show commit-id
     add_header X-Commit-ID ~COMMIT_ID~ always;
@@ -61,4 +61,3 @@ server {
 
     try_files $uri $uri.html $uri/ =404;
 }
-


### PR DESCRIPTION
## Done

Added a 404 page very much like the main site one but with the docs sidebar

## QA

- Pull code
- cd into /docs
- `./run build`
- `docker build --tag vanilla-docs --build-arg COMMIT_ID=nope  .`
- `docker run -ti -p 8099:80 vanilla-docs`
- go to: http://localhost:8099/not-a-real-page
- See the error

## Details
Fixes https://github.com/canonical-websites/vanillaframework.io/issues/175