### PR TITLE
Remove default hiding of reset buttons

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -177,10 +177,6 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     width: 100%;
   }
 
-  [type='reset'] {
-    display: none;
-  }
-
   [type='search'] {
     -moz-appearance: none; // sass-lint:disable-line no-vendor-prefixes
     -webkit-appearance: none; // sass-lint:disable-line no-vendor-prefixes


### PR DESCRIPTION
## Done

Unhide reset buttons by default

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/forms/form/
- Inspect the submit button and change the type to "reset"
- See that the button remains visible

## Details
Fixes #2067 
