### PR TITLE
Use 100vh instead of height 100% on body with sticky footer

### DIFF
--- a/scss/_utilities_sticky-footer.scss
+++ b/scss/_utilities_sticky-footer.scss
@@ -1,7 +1,7 @@
 @mixin vf-u-sticky-footer {
   html,
   body {
-    height: 100%;
+    min-height: 100vh;
   }
 
   body {

--- a/scss/_utilities_sticky-footer.scss
+++ b/scss/_utilities_sticky-footer.scss
@@ -1,15 +1,17 @@
 @mixin vf-u-sticky-footer {
-  html,
-  body {
-    min-height: 100vh;
-  }
+  @media screen and (min-width: $breakpoint-small) {
+    html,
+    body {
+      min-height: 100vh;
+    }
 
-  body {
-    display: flex;
-    flex-direction: column;
-  }
+    body {
+      display: flex;
+      flex-direction: column;
+    }
 
-  .p-footer {
-    flex-shrink: 0;
+    .p-footer {
+      flex-shrink: 0;
+    }
   }
 }


### PR DESCRIPTION
## Done

Updates `height: 100%` into `min-height: 100vh` for sticky footer.
Using `height: 100%` was causing layout issues (forcing body to always have the height of the viewport). For example https://github.com/canonical-webteam/global-nav/issues/62

Using `min-height: 100%` didn't do the trick, but it seems new viewport units can do what we need.
Now `html` and `body` will have minimum height of the viewport when there is little content, and will grow larger when content doesn't fit on the screen.

## QA

- Pull code
- Enable $sticky-footer
- Create an example page with sticky footer
- Run `./run serve --watch`
- Check if sticky footer works