### PR TITLE
Updates to 'Icons' layout on docs

### DIFF
--- a/docs/en/patterns/icons.md
+++ b/docs/en/patterns/icons.md
@@ -109,7 +109,7 @@ Icons can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>
 When placed within `.p-strip--dark`, icon colors are reverted to ensure legibility.
 
 <section>
-  <div class="p-strip--dark is-shallow">
+<div class="p-strip--dark is-shallow" style="background-color: transparent;">
     <div class="row u-equal-height">
       <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
         <i class="p-icon--plus" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--plus</code>
@@ -242,11 +242,6 @@ When placed within `.p-strip--dark`, icon colors are reverted to ensure legibili
 
   </div>
 </section>
-
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/icons/icons-social/"
-    class="js-example">
-View example of the icon set (Social)
-</a>
 
 ### Share
 

--- a/docs/en/patterns/icons.md
+++ b/docs/en/patterns/icons.md
@@ -7,11 +7,11 @@ table_of_contents: true
 
 Icons can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>`
 
-### Default
+### Standard
 
 <section>
   <div class="p-strip is-shallow">
-    <div class="row">
+    <div class="row u-equal-height">
       <div class="p-card col-4 u-vertically-center">
         <i class="p-icon--plus" style="margin-right: 1rem;"></i><code>p-icon--plus</code>
       </div>
@@ -23,7 +23,7 @@ Icons can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>
       </div>
     </div>
 
-    <div class="row">
+    <div class="row u-equal-height">
       <div class="p-card col-4 u-vertically-center">
         <i class="p-icon--collapse" style="margin-right: 1rem;"></i><code>p-icon--collapse</code>
       </div>
@@ -31,11 +31,11 @@ Icons can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>
         <i class="p-icon--spinner" style="margin-right: 1rem;"></i><code>p-icon--spinner</code>
       </div>
       <div class="p-card col-4 u-vertically-center">
-        <i class="p-icon--contextual-menu" style="margin-right: 1rem;"></i><code>p-icon--contextual-menu</code>
+        <i class="p-icon--chevron" style="margin-right: 1rem;"></i><code>p-icon--chevron</code>
       </div>
     </div>
 
-    <div class="row">
+    <div class="row u-equal-height">
       <div class="p-card col-4 u-vertically-center">
         <i class="p-icon--close" style="margin-right: 1rem;"></i><code>p-icon--close</code>
       </div>
@@ -47,7 +47,7 @@ Icons can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>
       </div>
       </div>
 
-    <div class="row">
+    <div class="row u-equal-height">
       <div class="p-card col-4 u-vertically-center">
         <i class="p-icon--delete" style="margin-right: 1rem;"></i><code>p-icon--delete</code>
       </div>
@@ -55,11 +55,11 @@ Icons can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>
         <i class="p-icon--external-link" style="margin-right: 1rem;"></i><code>p-icon--external-link</code>
       </div>
       <div class="p-card col-4 u-vertically-center">
-        <i class="p-icon--drag" style="margin-right: 1rem;"></i><code>p-icon--drag</code>
+        <i class="p-icon--contextual-menu" style="margin-right: 1rem;"></i><code>p-icon--contextual-menu</code>
       </div>
     </div>
 
-    <div class="row">
+    <div class="row u-equal-height">
       <div class="p-card col-4 u-vertically-center">
         <i class="p-icon--menu" style="margin-right: 1rem;"></i><code>p-icon--menu</code>
       </div>
@@ -71,7 +71,7 @@ Icons can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>
       </div>
     </div>
 
-    <div class="row">
+    <div class="row u-equal-height">
       <div class="p-card col-4 u-vertically-center">
         <i class="p-icon--search" style="margin-right: 1rem;"></i><code>p-icon--search</code>
       </div>
@@ -83,7 +83,7 @@ Icons can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>
       </div>
     </div>
 
-    <div class="row">
+    <div class="row u-equal-height">
       <div class="p-card col-4 u-vertically-center">
         <i class="p-icon--question" style="margin-right: 1rem;"></i><code>p-icon--question</code>
       </div>
@@ -95,7 +95,7 @@ Icons can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>
       </div>
     </div>
 
-    <div class="row">
+    <div class="row u-equal-height">
       <div class="p-card col-4 u-vertically-center">
         <i class="p-icon--warning" style="margin-right: 1rem;"></i><code>p-icon--warning</code>
       </div>
@@ -104,17 +104,104 @@ Icons can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>
   </div>
 </section>
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/icons/icons-light/"
-    class="js-example">
-View example of the icon set (light)
-</a>
+### Standard dark
 
 When placed within `.p-strip--dark`, icon colors are reverted to ensure legibility.
 
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/icons/icons-dark/"
-    class="js-example">
-View example of the icon set (dark)
-</a>
+<section>
+  <div class="p-strip--dark is-shallow">
+    <div class="row u-equal-height">
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--plus" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--plus</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--minus" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--minus</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--expand" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--expand</code>
+      </div>
+    </div>
+
+    <div class="row u-equal-height">
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--collapse" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--collapse</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--spinner" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--spinner</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--chevron" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--chevron</code>
+      </div>
+    </div>
+
+    <div class="row u-equal-height">
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--close" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--close</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--help" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--help</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--information" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--information</code>
+      </div>
+      </div>
+
+    <div class="row u-equal-height">
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--delete" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--delete</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--external-link" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--external-link</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--contextual-menu" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--contextual-menu</code>
+      </div>
+    </div>
+
+    <div class="row u-equal-height">
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--menu" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--menu</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--code" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--code</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--copy" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--copy</code>
+      </div>
+    </div>
+
+    <div class="row u-equal-height">
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--search" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--search</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--share" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--share</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--user" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--user</code>
+      </div>
+    </div>
+
+    <div class="row u-equal-height">
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--question" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--question</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--error" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--error</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--success" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--success</code>
+      </div>
+    </div>
+
+    <div class="row u-equal-height">
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <i class="p-icon--warning" style="margin-right: 1rem;"></i><code style="color: #fff">p-icon--warning</code>
+      </div>
+    </div>
+
+  </div>
+</section>
 
 ### Social
 

--- a/docs/en/patterns/icons.md
+++ b/docs/en/patterns/icons.md
@@ -208,34 +208,34 @@ When placed within `.p-strip--dark`, icon colors are reverted to ensure legibili
 <section>
   <div class="p-strip is-shallow">
     <div class="row">
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--facebook" style="margin-right: 1rem;"></i><code>p-icon--facebook</code>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--google" style="margin-right: 1rem;"></i><code>p-icon--google</code>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--twitter" style="margin-right: 1rem;"></i><code>p-icon--twitter</code>
       </div>
     </div>
 
     <div class="row">
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--instagram" style="margin-right: 1rem;"></i><code>p-icon--instagram</code>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--linkedin" style="margin-right: 1rem;"></i><code>p-icon--linkedin</code>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--youtube" style="margin-right: 1rem;"></i><code>p-icon--youtube</code>
       </div>
     </div>
 
     <div class="row">
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--canonical" style="margin-right: 1rem;"></i><code>p-icon--canonical</code>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--ubuntu" style="margin-right: 1rem;"></i><code>p-icon--ubuntu</code>
       </div>
       </div>

--- a/docs/en/patterns/icons.md
+++ b/docs/en/patterns/icons.md
@@ -209,34 +209,34 @@ When placed within `.p-strip--dark`, icon colors are reverted to ensure legibili
   <div class="p-strip is-shallow">
     <div class="row">
       <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-        <i class="p-icon--facebook" style="margin-right: 1rem;"></i><code>p-icon--facebook</code>
+        <i class="p-icon--facebook" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--facebook</code>
       </div>
       <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-        <i class="p-icon--google" style="margin-right: 1rem;"></i><code>p-icon--google</code>
+        <i class="p-icon--google" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--google</code>
       </div>
       <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-        <i class="p-icon--twitter" style="margin-right: 1rem;"></i><code>p-icon--twitter</code>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-        <i class="p-icon--instagram" style="margin-right: 1rem;"></i><code>p-icon--instagram</code>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-        <i class="p-icon--linkedin" style="margin-right: 1rem;"></i><code>p-icon--linkedin</code>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-        <i class="p-icon--youtube" style="margin-right: 1rem;"></i><code>p-icon--youtube</code>
+        <i class="p-icon--twitter" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--twitter</code>
       </div>
     </div>
 
     <div class="row">
       <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-        <i class="p-icon--canonical" style="margin-right: 1rem;"></i><code>p-icon--canonical</code>
+        <i class="p-icon--instagram" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--instagram</code>
       </div>
       <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-        <i class="p-icon--ubuntu" style="margin-right: 1rem;"></i><code>p-icon--ubuntu</code>
+        <i class="p-icon--linkedin" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--linkedin</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
+        <i class="p-icon--youtube" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--youtube</code>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
+        <i class="p-icon--canonical" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--canonical</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
+        <i class="p-icon--ubuntu" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--ubuntu</code>
       </div>
       </div>
 

--- a/docs/en/patterns/icons.md
+++ b/docs/en/patterns/icons.md
@@ -5,66 +5,163 @@ table_of_contents: true
 
 ## Icons
 
-Icons can be added via an `<i>` element like so:
+Icons can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>`
 
-`<i class="p-icon--{name}"></i>`
+### Default
 
-Class name  |
- ------------- |
-`p-icon--plus` |
-`p-icon--minus` |
-`p-icon--expand` |
-`p-icon--collapse` |
-`p-icon--spinner` |
-`p-icon--contextual-menu` |
-`p-icon--close` |
-`p-icon--help` |
-`p-icon--information` |
-`p-icon--delete` |
-`p-icon--external` |
-`p-icon--drag` |
-`p-icon--menu` |
-`p-icon--code` |
-`p-icon--copy` |
-`p-icon--search` |
-`p-icon--share` |
-`p-icon--user` |
-`p-icon--question` |
-`p-icon--error` |
-`p-icon--success` |
-`p-icon--warning` |
+<section>
+  <div class="p-strip is-shallow">
+    <div class="row">
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--plus" style="margin-right: 1rem;"></i><code>p-icon--plus</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--minus" style="margin-right: 1rem;"></i><code>p-icon--minus</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--expand" style="margin-right: 1rem;"></i><code>p-icon--expand</code>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--collapse" style="margin-right: 1rem;"></i><code>p-icon--collapse</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--spinner" style="margin-right: 1rem;"></i><code>p-icon--spinner</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--contextual-menu" style="margin-right: 1rem;"></i><code>p-icon--contextual-menu</code>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--close" style="margin-right: 1rem;"></i><code>p-icon--close</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--help" style="margin-right: 1rem;"></i><code>p-icon--help</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--information" style="margin-right: 1rem;"></i><code>p-icon--information</code>
+      </div>
+      </div>
+
+    <div class="row">
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--delete" style="margin-right: 1rem;"></i><code>p-icon--delete</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--external-link" style="margin-right: 1rem;"></i><code>p-icon--external-link</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--drag" style="margin-right: 1rem;"></i><code>p-icon--drag</code>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--menu" style="margin-right: 1rem;"></i><code>p-icon--menu</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--code" style="margin-right: 1rem;"></i><code>p-icon--code</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--copy" style="margin-right: 1rem;"></i><code>p-icon--copy</code>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--search" style="margin-right: 1rem;"></i><code>p-icon--search</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--share" style="margin-right: 1rem;"></i><code>p-icon--share</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--user" style="margin-right: 1rem;"></i><code>p-icon--user</code>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--question" style="margin-right: 1rem;"></i><code>p-icon--question</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--error" style="margin-right: 1rem;"></i><code>p-icon--error</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--success" style="margin-right: 1rem;"></i><code>p-icon--success</code>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--warning" style="margin-right: 1rem;"></i><code>p-icon--warning</code>
+      </div>
+    </div>
+
+  </div>
+</section>
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/icons/icons-light/"
     class="js-example">
-    View example of the icon set (light)
+View example of the icon set (light)
 </a>
 
 When placed within `.p-strip--dark`, icon colors are reverted to ensure legibility.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/icons/icons-dark/"
     class="js-example">
-    View example of the icon set (dark)
+View example of the icon set (dark)
 </a>
 
-### Social icons
+### Social
 
-Class name  |
- ------------- |
-`p-icon--facebook` |
-`p-icon--google` |
-`p-icon--twitter` |
-`p-icon--instagram` |
-`p-icon--linkedin` |
-`p-icon--youtube` |
-`p-icon--canonical` |
-`p-icon--ubuntu` |
+<section>
+  <div class="p-strip is-shallow">
+    <div class="row">
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--facebook" style="margin-right: 1rem;"></i><code>p-icon--facebook</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--google" style="margin-right: 1rem;"></i><code>p-icon--google</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--twitter" style="margin-right: 1rem;"></i><code>p-icon--twitter</code>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--instagram" style="margin-right: 1rem;"></i><code>p-icon--instagram</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--linkedin" style="margin-right: 1rem;"></i><code>p-icon--linkedin</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--youtube" style="margin-right: 1rem;"></i><code>p-icon--youtube</code>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--canonical" style="margin-right: 1rem;"></i><code>p-icon--canonical</code>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <i class="p-icon--ubuntu" style="margin-right: 1rem;"></i><code>p-icon--ubuntu</code>
+      </div>
+      </div>
+
+  </div>
+</section>
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/icons/icons-social/"
     class="js-example">
-    View example of the icon set (Social)
+View example of the icon set (Social)
 </a>
 
-### Share icons
+### Share
 
 If you wish to add share icons for Twitter, Facebook, Google+ or LinkedIn, we recommend using the networks' official buttons:
 
@@ -77,4 +174,4 @@ If you wish to add share icons for Twitter, Facebook, Google+ or LinkedIn, we re
 
 ### Design
 
-* [Icons design](https://github.com/ubuntudesign/vanilla-design/tree/master/Icons)
+- [Icons design](https://github.com/ubuntudesign/vanilla-design/tree/master/Icons)

--- a/examples/patterns/icons/icons-dark.html
+++ b/examples/patterns/icons/icons-dark.html
@@ -5,8 +5,8 @@ category: _patterns
 ---
 
 <div class="row">
-  <div class="p-strip--dark">
-    <ul class="p-inline-list u-align--center u-no-margin--top">
+  <div class="p-strip--dark is-shallow">
+    <ul class="p-inline-list u-align--center u-no-margin--bottom">
       <li class="p-inline-list__item">
         <i class="p-icon--plus"></i>
       </li>

--- a/examples/patterns/icons/icons-light.html
+++ b/examples/patterns/icons/icons-light.html
@@ -5,8 +5,8 @@ category: _patterns
 ---
 
 <div class="row">
-  <div class="p-strip--light">
-    <ul class="p-inline-list u-align--center u-no-margin--top">
+  <div class="p-strip--light is-shallow">
+    <ul class="p-inline-list u-align--center u-no-margin--bottom">
       <li class="p-inline-list__item">
         <i class="p-icon--plus"></i>
       </li>

--- a/examples/patterns/icons/icons-social.html
+++ b/examples/patterns/icons/icons-social.html
@@ -5,8 +5,8 @@ category: _patterns
 ---
 
 <div class="row">
-  <div class="p-strip--light">
-    <ul class="p-inline-list u-align--center u-no-margin--top">
+  <div class="p-strip--light is-shallow">
+    <ul class="p-inline-list u-align--center u-no-margin--bottom">
       <li class="p-inline-list__item">
         <i class="p-icon--facebook"></i>
       </li>


### PR DESCRIPTION
## Done

- Updated the icon table to include classes
- New visual layout


## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/icons/
- Check that all three of the examples in the list are updated correctly on documentation
  - Light / Dark / Social

## Details
- Fixes #2058 

## Screenshots
![screenshot 2019-01-22 at 11 24 36](https://user-images.githubusercontent.com/17748020/51532567-5d126800-1e38-11e9-9a3b-a81657c7d3b9.png)
![screenshot 2019-01-22 at 11 24 45](https://user-images.githubusercontent.com/17748020/51532568-5daafe80-1e38-11e9-80e5-bb6eef053f13.png)


