### PR TITLE
card p:last-child – fix selector from "starts with" to "contains"

### DIFF
--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -54,7 +54,7 @@
   // p-card scoped rules should only be added if the required behaviour is not likely to be needed in any other pattern.
   // If possible, please consider adding a modifier to a base pattern, so it can be used elsewhere too.
 
-  [class^='p-card'] {
+  [class*='p-card'] {
     // Reduce margin-bottom of last text element in card to the minimum required to keep it on the baseline grid.
     h1 {
       &:last-child {


### PR DESCRIPTION
currently, ^= selector doesn't apply when .p-card is preceded by another class. Switching to *= fixes that.

## Done

Change selector from ^= to *=

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Verify that prepending a class to the p-card div doesn't cancel the small margin on the last-child text element of a card

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
