### PR TITLE
Override th line-height to keep table borders on the baseline grid

### DIFF
--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -1,4 +1,6 @@
 // Base
+@import 'base_placeholders';
+@import 'base_typography';
 @import 'base_blockquotes';
 @import 'base_box-sizing';
 @import 'base_button';
@@ -8,15 +10,15 @@
 @import 'base_links';
 @import 'base_lists';
 @import 'base_media';
-@import 'base_placeholders';
 @import 'base_reset';
 @import 'base_tables';
-@import 'base_typography';
 
 @mixin vf-base {
   // Reset
   @include vf-b-reset;
   // Base
+  @include vf-b-placeholders;
+  @include vf-b-typography;
   @include vf-b-blockquotes;
   @include vf-b-box-sizing;
   @include vf-b-button;
@@ -26,7 +28,5 @@
   @include vf-b-links;
   @include vf-b-lists;
   @include vf-b-media;
-  @include vf-b-placeholders;
   @include vf-b-tables;
-  @include vf-b-typography;
 }

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -142,9 +142,11 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
   }
 
   label {
+    @extend %default-text;
     cursor: pointer;
     display: block;
     margin-bottom: $spv-inter--condensed + $spv-nudge-compensation;
+    width: fit-content;
 
     &.is-required::after {
       color: $color-negative;
@@ -319,10 +321,5 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     color: $color-dark;
     margin-bottom: $spv-inter--scaleable;
     padding: $spv-intra $sph-intra--condensed;
-  }
-
-  label {
-    @extend %default-text;
-    width: fit-content;
   }
 }

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -29,12 +29,7 @@
   thead {
     th {
       @extend %muted-heading;
-
-      // XXX 23 01 2019 Lyubomir Popov: because of include order, to override the line height specificity needs to be increased;
-      // Once this is fixed the table part of the selector can be dropped: https://github.com/vanilla-framework/vanilla-framework/pull/2126
-      table & {
-        line-height: map-get($line-heights, table-headers);
-      }
+      line-height: map-get($line-heights, table-headers);
     }
 
     tr {

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -29,6 +29,12 @@
   thead {
     th {
       @extend %muted-heading;
+
+      // XXX 23 01 2019 Lyubomir Popov: because of include order, to override the line height specificity needs to be increased;
+      // Once this is fixed the table part of the selector can be dropped: https://github.com/vanilla-framework/vanilla-framework/pull/2126
+      table & {
+        line-height: map-get($line-heights, table-headers);
+      }
     }
 
     tr {

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -20,7 +20,8 @@ $line-heights: (
   h3-mobile: 4 * $sp-unit,
   h4-mobile: 3 * $sp-unit,
   default-text: 3 * $sp-unit,
-  small: $sp-unit * 2.5
+  small: $sp-unit * 2.5,
+  table-headers: $sp-unit * 2
 ) !default;
 
 // baseline nudges for type scale ratio of (16/14) squared


### PR DESCRIPTION
## Done

Corrects vertical rhythm by setting the line-height of table headers to 1rem (from 1.25rem)

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/base/table/
- Turn baseline grid on
- Observe table row borders sitting properly on baseline grid
