### PR TITLE
Remove Google + icons 

### DIFF
--- a/docs/en/patterns/icons.md
+++ b/docs/en/patterns/icons.md
@@ -212,7 +212,7 @@ When placed within `.p-strip--dark`, icon colors are reverted to ensure legibili
         <i class="p-icon--facebook" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--facebook</code>
       </div>
       <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-        <i class="p-icon--google" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--google</code>
+        <i class="p-icon--instagram" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--instagram</code>
       </div>
       <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--twitter" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--twitter</code>
@@ -220,21 +220,18 @@ When placed within `.p-strip--dark`, icon colors are reverted to ensure legibili
     </div>
 
     <div class="row">
-      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-        <i class="p-icon--instagram" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--instagram</code>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-        <i class="p-icon--linkedin" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--linkedin</code>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-        <i class="p-icon--youtube" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--youtube</code>
-      </div>
+    <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
+      <i class="p-icon--linkedin" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--linkedin</code>
+    </div>
+    <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
+      <i class="p-icon--youtube" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--youtube</code>
+    </div>
+    <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
+      <i class="p-icon--canonical" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--canonical</code>
+    </div>
     </div>
 
     <div class="row">
-      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-        <i class="p-icon--canonical" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--canonical</code>
-      </div>
       <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--ubuntu" style="margin-right: 1rem; flex-shrink: 0;"></i><code>p-icon--ubuntu</code>
       </div>
@@ -249,7 +246,6 @@ If you wish to add share icons for Twitter, Facebook, Google+ or LinkedIn, we re
 
 - [**Twitter**](https://dev.twitter.com/web/tweet-button)
 - [**Facebook**](https://developers.facebook.com/docs/plugins/share-button/)
-- [**Google+**](https://developers.google.com/+/web/share/)
 - [**LinkedIn**](https://developer.linkedin.com/plugins/share)
 
 <hr />

--- a/examples/patterns/icons/icons-social.html
+++ b/examples/patterns/icons/icons-social.html
@@ -11,9 +11,6 @@ category: _patterns
         <i class="p-icon--facebook"></i>
       </li>
       <li class="p-inline-list__item">
-        <i class="p-icon--google"></i>
-      </li>
-      <li class="p-inline-list__item">
         <i class="p-icon--twitter"></i>
       </li>
       <li class="p-inline-list__item">


### PR DESCRIPTION
## Done

Remove Google + icons from Documentation as it's soon to be canned.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/icons/icons-social/
- Check Google+ is no longer visible
- Check documentation: patterns/icons#share-icons and see that Google+ is no longer visible too

## Details

Fixes https://github.com/vanilla-framework/vanilla-framework/issues/2143

## Screenshots
![screenshot 2019-02-05 at 12 25 03](https://user-images.githubusercontent.com/17748020/52273215-185ef480-2941-11e9-9409-40deeacf12fd.png)

