### PR TITLE
1791 tooltip placement

### DIFF
--- a/examples/patterns/tooltips.html
+++ b/examples/patterns/tooltips.html
@@ -3,14 +3,13 @@ layout: default
 title: Tooltips
 category: _patterns
 ---
-
 <button class="p-tooltip" aria-describedby="default-tooltip">
   Bottom left tooltip
   <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Lorem ipsum dolor sit amet.</span>
 </button>
 <button class="p-tooltip p-tooltip--btm-center" aria-describedby="btm-cntr">
   Bottom center tooltip
-  <span class="p-tooltip__message" role="tooltip" id="btm-cntr">Lorem ipsum dolor sit amet, consectetur adipisicing elit.&#xa;Corrupti earum nesciunt temporibus, aut iste voluptates&#xa;obcaecati quibusdam aliquam possimus unde eos, rem!&#xa;Doloribus, praesentium amet.</span>
+  <span class="p-tooltip__message" role="tooltip" id="btm-cntr">Lorem ipsum dolor sit amet, consectetur adipisicing elit.&#xa;Corrupti earum nesciunt temporibus.</span>
 </button>
 <button class="p-tooltip p-tooltip--btm-right" aria-describedby="btm-rgt">
   Bottom right tooltip
@@ -18,7 +17,7 @@ category: _patterns
 </button>
 <button class="p-tooltip p-tooltip--left" aria-describedby="left">
   Left tooltip
-  <span class="p-tooltip__message" role="tooltip" id="left">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Corrupti earum nesciunt&#xa;temporibus, aut iste voluptates obcaecati.</span>
+  <span class="p-tooltip__message" role="tooltip" id="left">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit..</span>
 </button>
 <br />
 <br />
@@ -28,7 +27,7 @@ category: _patterns
 </button>
 <button class="p-tooltip p-tooltip--top-left" aria-describedby="tp-lft">
   Top left tooltip
-  <span class="p-tooltip__message" role="tooltip" id="tp-lft">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corrupti&#xa;earum nesciunt temporibus, aut iste voluptates obcaecati quibusdam&#xa;aliquam possimus unde eos, rem! Doloribus, praesentium amet.</span>
+  <span class="p-tooltip__message" role="tooltip" id="tp-lft">Lorem ipsum dolor sit amet, consectetur&#xa;adipisicing elit. Corrupti earum nesciunt.</span>
 </button>
 <button class="p-tooltip p-tooltip--top-center" aria-describedby="tp-cntr">
   Top center tooltip

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -11,7 +11,7 @@
       border-radius: $border-radius;
       color: $color-x-light;
       display: none;
-      left: 0;
+      left: -$sph-intra;
       margin-bottom: 0;
       padding: $spv-intra $sph-intra;
       position: absolute;
@@ -66,13 +66,13 @@
       .p-tooltip__message {
         bottom: inherit;
         left: initial;
-        right: 0;
+        right: -$sph-intra;
         top: 100%;
         transform: translateY(13px);
 
         &::before {
           left: initial;
-          right: $sp-small;
+          right: $sph-intra;
         }
       }
     }
@@ -81,7 +81,7 @@
     &--top-left {
       .p-tooltip__message {
         bottom: 100%;
-        left: 0;
+        left: -$sph-intra;
         top: initial;
         transform: translateX(0%) translateY(-13px);
 
@@ -92,8 +92,8 @@
             right: 8px solid transparent;
             top: 8px solid $color-dark;
           }
-          bottom: -1rem;
-          left: $sp-small;
+          bottom: -$sph-intra;
+          left: $sph-intra;
         }
       }
     }
@@ -113,7 +113,7 @@
             right: 8px solid transparent;
             top: 8px solid $color-dark;
           }
-          bottom: -1rem;
+          bottom: -$sph-intra;
           left: 50%;
           transform: translateX(-50%);
         }
@@ -125,7 +125,7 @@
       .p-tooltip__message {
         bottom: 100%;
         left: initial;
-        right: 0;
+        right: -$sph-intra;
         top: initial;
         transform: translateX(0%) translateY(-13px);
 
@@ -136,9 +136,9 @@
             right: 8px solid transparent;
             top: 8px solid $color-dark;
           }
-          bottom: -1rem;
+          bottom: -$sph-intra;
           left: initial;
-          right: $sp-small;
+          right: $sph-intra;
         }
       }
     }


### PR DESCRIPTION
## Done

- Updated tooltip styling to reposition left- and right-aligned variants (this brings the pointing arrow to the edge of the element, which is especially important for smaller elements like icons). See #1791 for more detail.
- Updated example tooltip markup to avoid cropping

## QA

- Pull code
- Run `./run serve --watch`
- Go to http://0.0.0.0:8101/vanilla-framework/examples/patterns/tooltips/

OR

- Go to https://vanilla-framework-vanilla-framework-pr-2152.run.demo.haus/vanilla-framework/examples/patterns/tooltips/

## Details

Fixes #1791 
Fixes #2066 
