### PR TITLE
2100 spacing variable rename

### DIFF
--- a/docs/en/settings/spacing-settings.md
+++ b/docs/en/settings/spacing-settings.md
@@ -11,55 +11,55 @@ Vanilla uses numerous spacing variables across the codebase in order to ensure c
 
 Vanilla uses a default spacing unit of `.5rem` (`8px`) as a basis to calculate spacing inside and between components, as well as the line-heights of the different type sizes.
 
-![Baseline grid example](https://assets.ubuntu.com/v1/d2c31b2d-screenshot.png "Baseline grid example")
+![Baseline grid example](https://assets.ubuntu.com/v1/d2c31b2d-screenshot.png 'Baseline grid example')
 
 The image shows the headings sitting on the baseline grid, where the space between each line is one `$sp-unit`.
 
 ### Vertical spacing
 
-The `$spv-intra` variables are used to determine vertical spacing inside components, while `$spv-inter` variables are used for spacing between components.
+The `$spv-inner` variables are used to determine vertical spacing inside components, while `$spv-outer` variables are used for spacing between components.
 
-Spacing variable | Formula | Default value
- ------------------- | ------------- |
-`$spv-intra` | `$sp-unit` | `.5rem`
-`$spv-intra--condensed` | `$spv-intra * .5` | `.25rem`
-`$spv-intra--expanded` | `$spv-intra * 1.5` | `.75rem`
-`$spv-inter--regular` | `$sp-unit * 2` | `1rem`
-`$spv-inter--condensed` | `$sp-unit` | `.5rem`
-`$spv-inter--expanded` | `$sp-unit * 3` | `1.5rem`
+| Spacing variable        | Formula            | Default value |
+| ----------------------- | ------------------ | ------------- |
+| `$spv-inner`            | `$sp-unit`         | `.5rem`       |
+| `$spv-inner--condensed` | `$spv-inner * .5`  | `.25rem`      |
+| `$spv-inner--expanded`  | `$spv-inner * 1.5` | `.75rem`      |
+| `$spv-outer--regular`   | `$sp-unit * 2`     | `1rem`        |
+| `$spv-outer--condensed` | `$sp-unit`         | `.5rem`       |
+| `$spv-outer--expanded`  | `$sp-unit * 3`     | `1.5rem`      |
 
 The following vertical spacing variables are used between a group of components and its wrapper, for example in strips.
 
-Spacing variable | Formula | Default value
- ------------------- | ------------- |
-`$spv-inter--shallow-scaleable` | `$sp-unit * 4` | `2rem`
-`$spv-inter--regular-scaleable` | `$sp-unit * 6` | `3rem`
-`$spv-inter--deep-scaleable` | `$sp-unit * 8` | `4rem`
+| Spacing variable                | Formula        | Default value |
+| ------------------------------- | -------------- | ------------- |
+| `$spv-outer--shallow-scaleable` | `$sp-unit * 4` | `2rem`        |
+| `$spv-outer--regular-scaleable` | `$sp-unit * 6` | `3rem`        |
+| `$spv-outer--deep-scaleable`    | `$sp-unit * 8` | `4rem`        |
 
 ### Horizontal spacing
 
-The `$sph-intra` variables are used to determine horizontal spacing inside components, while `$sph-inter` variables are used for spacing between components.
+The `$sph-inner` variables are used to determine horizontal spacing inside components, while `$sph-outer` variables are used for spacing between components.
 
-Spacing variable | Formula | Default value
- ------------------- | ------------- |
-`$sph-intra` | `$sp-unit * 2` | `1rem`
-`$sph-intra--condensed` | `$sp-unit` | `.5rem`
-`$sph-inter` | `$sp-unit` | `.5rem`
-`$sph-inter--expanded` | `$sp-unit * 3` | `1.5rem`
+| Spacing variable        | Formula        | Default value |
+| ----------------------- | -------------- | ------------- |
+| `$sph-inner`            | `$sp-unit * 2` | `1rem`        |
+| `$sph-inner--condensed` | `$sp-unit`     | `.5rem`       |
+| `$sph-outer`            | `$sp-unit`     | `.5rem`       |
+| `$sph-outer--expanded`  | `$sp-unit * 3` | `1.5rem`      |
 
 ### Generic units
 
 There are also generic spacing units for backwards compatibility with components created with Vanilla before `v1.7.0`.
 
-Spacing variable | Formula | Default value
- ------------------- | ------------- |
-`$sp-xx-small` | `$sp-unit * .25` | `.125rem`
-`$sp-x-small` | `$sp-unit * .5` | `.25rem`
-`$sp-small` | `$sp-unit` | `.5rem`
-`$sp-medium` | `$sp-unit * 2` | `1rem`
-`$sp-large` | `$sp-unit * 3` | `1.5rem`
-`$sp-x-large` | `$sp-unit * 4` | `2rem`
-`$sp-xx-large` | `$sp-unit * 5` | `2.5rem`
-`$sp-xxx-large` | `$sp-unit * 6` | `3rem`
-`$sp-xxxx-large` | `$sp-unit * 8` | `4rem`
-`$sp-xxxxx-large` | `$sp-unit * 12` | `6rem`
+| Spacing variable  | Formula          | Default value |
+| ----------------- | ---------------- | ------------- |
+| `$sp-xx-small`    | `$sp-unit * .25` | `.125rem`     |
+| `$sp-x-small`     | `$sp-unit * .5`  | `.25rem`      |
+| `$sp-small`       | `$sp-unit`       | `.5rem`       |
+| `$sp-medium`      | `$sp-unit * 2`   | `1rem`        |
+| `$sp-large`       | `$sp-unit * 3`   | `1.5rem`      |
+| `$sp-x-large`     | `$sp-unit * 4`   | `2rem`        |
+| `$sp-xx-large`    | `$sp-unit * 5`   | `2.5rem`      |
+| `$sp-xxx-large`   | `$sp-unit * 6`   | `3rem`        |
+| `$sp-xxxx-large`  | `$sp-unit * 8`   | `4rem`        |
+| `$sp-xxxxx-large` | `$sp-unit * 12`  | `6rem`        |

--- a/scss/_base_blockquotes.scss
+++ b/scss/_base_blockquotes.scss
@@ -4,11 +4,11 @@
 @mixin vf-b-blockquotes {
   blockquote {
     border-left: 2px solid $color-mid-dark;
-    margin-bottom: $spv-inner--regular;
+    margin-bottom: $spv-inner--medium;
     margin-left: 0;
     margin-top: 0;
     overflow: auto; // include margins of children into it's own height
-    padding-bottom: $spv-inner;
+    padding-bottom: $spv-inner--small;
     padding-left: $sp-large;
 
     & > :last-child {

--- a/scss/_base_blockquotes.scss
+++ b/scss/_base_blockquotes.scss
@@ -4,11 +4,11 @@
 @mixin vf-b-blockquotes {
   blockquote {
     border-left: 2px solid $color-mid-dark;
-    margin-bottom: $spv-intra--regular;
+    margin-bottom: $spv-inner--regular;
     margin-left: 0;
     margin-top: 0;
     overflow: auto; // include margins of children into it's own height
-    padding-bottom: $spv-intra;
+    padding-bottom: $spv-inner;
     padding-left: $sp-large;
 
     & > :last-child {

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -18,7 +18,7 @@
     font-size: 1rem;
     font-weight: 300;
     line-height: map-get($line-heights, default-text);
-    margin-bottom: $spv-inter--scaleable + 2 * $spv-nudge-compensation;
+    margin-bottom: $spv-outer--scaleable + 2 * $spv-nudge-compensation;
     padding: $spv-nudge - $px $sph-inner--condensed * 1.5;
     text-align: center;
     text-decoration: none;
@@ -43,7 +43,7 @@
       width: auto;
 
       &:not(:last-of-type):not(:only-of-type) {
-        margin-right: $sph-inter;
+        margin-right: $sph-outer;
       }
     }
 
@@ -55,17 +55,17 @@
 
     // The following three rules address buttons nested in <p>'s;
     p & {
-      margin-bottom: $spv-inter--condensed-scaleable - $spv-nudge;
+      margin-bottom: $spv-outer--condensed-scaleable - $spv-nudge;
       margin-top: -#{$spv-nudge};
     }
 
     p + p > & {
-      margin-top: $spv-inter--condensed - $spv-nudge;
+      margin-top: $spv-outer--condensed - $spv-nudge;
     }
 
     @media only screen and (max-width: $breakpoint-x-small) {
       p & + & {
-        margin-top: $spv-inter--condensed + $spv-nudge-compensation;
+        margin-top: $spv-outer--condensed + $spv-nudge-compensation;
       }
     }
   }

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -19,7 +19,7 @@
     font-weight: 300;
     line-height: map-get($line-heights, default-text);
     margin-bottom: $spv-outer--scaleable + 2 * $spv-nudge-compensation;
-    padding: $spv-nudge - $px $sph-inner--condensed * 1.5;
+    padding: $spv-nudge - $px $sph-inner--small * 1.5;
     text-align: center;
     text-decoration: none;
 

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -19,7 +19,7 @@
     font-weight: 300;
     line-height: map-get($line-heights, default-text);
     margin-bottom: $spv-inter--scaleable + 2 * $spv-nudge-compensation;
-    padding: $spv-nudge - $px $sph-intra--condensed * 1.5;
+    padding: $spv-nudge - $px $sph-inner--condensed * 1.5;
     text-align: center;
     text-decoration: none;
 

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -55,17 +55,17 @@
 
     // The following three rules address buttons nested in <p>'s;
     p & {
-      margin-bottom: $spv-outer--condensed-scaleable - $spv-nudge;
+      margin-bottom: $spv-outer--small-scaleable - $spv-nudge;
       margin-top: -#{$spv-nudge};
     }
 
     p + p > & {
-      margin-top: $spv-outer--condensed - $spv-nudge;
+      margin-top: $spv-outer--small - $spv-nudge;
     }
 
     @media only screen and (max-width: $breakpoint-x-small) {
       p & + & {
-        margin-top: $spv-outer--condensed + $spv-nudge-compensation;
+        margin-top: $spv-outer--small + $spv-nudge-compensation;
       }
     }
   }

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -33,7 +33,7 @@
     margin-bottom: $spv-inter--scaleable;
     margin-top: 0;
     overflow: auto;
-    padding: $spv-intra $sph-intra;
+    padding: $spv-inner $sph-inner;
     text-align: left;
     text-shadow: none;
   }

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -30,7 +30,7 @@
     border-radius: $border-radius;
     color: $color-dark;
     display: block;
-    margin-bottom: $spv-inter--scaleable;
+    margin-bottom: $spv-outer--scaleable;
     margin-top: 0;
     overflow: auto;
     padding: $spv-inner $sph-inner;

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -33,7 +33,7 @@
     margin-bottom: $spv-outer--scaleable;
     margin-top: 0;
     overflow: auto;
-    padding: $spv-inner $sph-inner;
+    padding: $spv-inner--small $sph-inner;
     text-align: left;
     text-shadow: none;
   }

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -26,8 +26,8 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     font-weight: 300;
     line-height: map-get($line-heights, default-text);
     min-width: 10em;
-    padding-left: $sph-inner--condensed;
-    padding-right: $sph-inner--condensed;
+    padding-left: $sph-inner--small;
+    padding-right: $sph-inner--small;
     vertical-align: baseline;
     width: 100%;
 
@@ -278,7 +278,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     background: $color-x-light
       url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB4bWxuczpza2V0Y2g9Imh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaC9ucyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBoZWlnaHQ9IjRweCIgd2lkdGg9IjEwcHgiIHZlcnNpb249IjEuMSIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHZpZXdCb3g9IjAgMCAxMCA0Ij4gPHRpdGxlPmFjY29yZGlvbi1vcGVuPC90aXRsZT4gPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+IDxnIGlkPSJmaWx0ZXItcGFuZWwiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSIgZmlsbD0ibm9uZSI+ICA8ZyBpZD0iYWNjb3JkaW9uLW9wZW4iIGZpbGw9IiM4ODgiIHNrZXRjaDp0eXBlPSJNU0FydGJvYXJkR3JvdXAiPiAgIDxwYXRoIGlkPSJjaGV2cm9uIiBza2V0Y2g6dHlwZT0iTVNTaGFwZUdyb3VwIiBkPSJtNi4zNjEgMC44NjIzYzAuNTE4IDAuMzY1IDEuMDUyIDAuNzc4MSAxLjYwMSAxLjIzOCAwLjU0OSAwLjQ1ODUgMS4wODkgMC45NTE4IDEuNjIxIDEuNDc3MiAwLjE0MiAwLjE0MDQgMC4yODEgMC4yODIxIDAuNDE1IDAuNDIyNWgtMS41NDFjLTAuMzA0LTAuMjg4OC0wLjYyLTAuNTcwOS0wLjk0Ny0wLjg0NjMtMC4xMzc5LTAuMTE2MS0wLjI3NjgtMC4yMjk3LTAuNDE2OC0wLjM0MDgtMC4xNjM2LTAuMTI5Ny0wLjMyODYtMC4yNTU4LTAuNDk1NC0wLjM3ODMtMC4wODUyLTAuMDYyNS0wLjE3MDgtMC4xMjQxLTAuMjU2OC0wLjE4NDYtMC4zOTctMC4yODIxLTAuOTM1LTAuNjI1Ny0xLjMxNS0wLjg0NzZoLTAuMDU0Yy0wLjM4IDAuMjIxOS0wLjkxOCAwLjU2NTUtMS4zMTUgMC44NDc2LTAuMzk4IDAuMjgwNy0wLjc4OCAwLjU4MjktMS4xNjkgMC45MDM3LTAuMzI3IDAuMjc1NC0wLjY0MyAwLjU1NzUtMC45NDcgMC44NDYzaC0xLjU0MWMwLjEzNS0wLjE0MDQgMC4yNzMtMC4yODIxIDAuNDE1LTAuNDIyNSAwLjUzMi0wLjUyNTQgMS4wNzItMS4wMTg3IDEuNjIxLTEuNDc3MiAwLjU1LTAuNDU5OSAxLjA4My0wLjg3MyAxLjYwMS0xLjIzOCAwLjUxOS0wLjM2NDk3IDAuOTczLTAuNjUyNDEgMS4zNjItMC44NjIzIDAuMzkgMC4yMDk4OSAwLjg0NCAwLjQ5NzMzIDEuMzYyIDAuODYyM3oiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDQuOTk5IDIpIHJvdGF0ZSgxODApIHRyYW5zbGF0ZSgtNC45OTkgLTIpIi8+ICA8L2c+IDwvZz48L3N2Zz4=')
       no-repeat;
-    background-position: right $sph-inner--condensed center;
+    background-position: right $sph-inner--small center;
     background-size: map-get($icon-sizes, accordion);
     box-shadow: none;
     color: $color-dark;
@@ -300,7 +300,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
       option {
         font-weight: 300;
         line-height: $sp-unit * 2 - 2 * $px;
-        padding: $spv-inner--small $sph-inner--condensed;
+        padding: $spv-inner--small $sph-inner--small;
       }
     }
   }
@@ -320,6 +320,6 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     border-radius: $border-radius;
     color: $color-dark;
     margin-bottom: $spv-outer--scaleable;
-    padding: $spv-inner--small $sph-inner--condensed;
+    padding: $spv-inner--small $sph-inner--small;
   }
 }

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -26,15 +26,15 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     font-weight: 300;
     line-height: map-get($line-heights, default-text);
     min-width: 10em;
-    padding-left: $sph-intra--condensed;
-    padding-right: $sph-intra--condensed;
+    padding-left: $sph-inner--condensed;
+    padding-right: $sph-inner--condensed;
     vertical-align: baseline;
     width: 100%;
 
     table & {
-      margin: 0 0 ($spv-intra - $spv-nudge) 0;
-      padding-bottom: ($spv-nudge - $px) - $spv-intra--condensed;
-      padding-top: ($spv-nudge - $px) - $spv-intra--condensed;
+      margin: 0 0 ($spv-inner - $spv-nudge) 0;
+      padding-bottom: ($spv-nudge - $px) - $spv-inner--condensed;
+      padding-top: ($spv-nudge - $px) - $spv-inner--condensed;
     }
 
     &:active {
@@ -72,8 +72,8 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
   // Default form checkbox and radio styles
   %vf-tick-elements {
     $box-size: 1rem;
-    $box-offset-top: $spv-intra--condensed;
-    $label-offset--left: $sph-intra + $box-size;
+    $box-offset-top: $spv-inner--condensed;
+    $label-offset--left: $sph-inner + $box-size;
     $tick-offset-top: $box-offset-top + 3 * $px;
     opacity: 0;
     position: absolute;
@@ -151,7 +151,7 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     &.is-required::after {
       color: $color-negative;
       content: '*';
-      left: $spv-intra--condensed;
+      left: $spv-inner--condensed;
       position: relative;
     }
 
@@ -278,12 +278,12 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     background: $color-x-light
       url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB4bWxuczpza2V0Y2g9Imh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaC9ucyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBoZWlnaHQ9IjRweCIgd2lkdGg9IjEwcHgiIHZlcnNpb249IjEuMSIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHZpZXdCb3g9IjAgMCAxMCA0Ij4gPHRpdGxlPmFjY29yZGlvbi1vcGVuPC90aXRsZT4gPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+IDxnIGlkPSJmaWx0ZXItcGFuZWwiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSIgZmlsbD0ibm9uZSI+ICA8ZyBpZD0iYWNjb3JkaW9uLW9wZW4iIGZpbGw9IiM4ODgiIHNrZXRjaDp0eXBlPSJNU0FydGJvYXJkR3JvdXAiPiAgIDxwYXRoIGlkPSJjaGV2cm9uIiBza2V0Y2g6dHlwZT0iTVNTaGFwZUdyb3VwIiBkPSJtNi4zNjEgMC44NjIzYzAuNTE4IDAuMzY1IDEuMDUyIDAuNzc4MSAxLjYwMSAxLjIzOCAwLjU0OSAwLjQ1ODUgMS4wODkgMC45NTE4IDEuNjIxIDEuNDc3MiAwLjE0MiAwLjE0MDQgMC4yODEgMC4yODIxIDAuNDE1IDAuNDIyNWgtMS41NDFjLTAuMzA0LTAuMjg4OC0wLjYyLTAuNTcwOS0wLjk0Ny0wLjg0NjMtMC4xMzc5LTAuMTE2MS0wLjI3NjgtMC4yMjk3LTAuNDE2OC0wLjM0MDgtMC4xNjM2LTAuMTI5Ny0wLjMyODYtMC4yNTU4LTAuNDk1NC0wLjM3ODMtMC4wODUyLTAuMDYyNS0wLjE3MDgtMC4xMjQxLTAuMjU2OC0wLjE4NDYtMC4zOTctMC4yODIxLTAuOTM1LTAuNjI1Ny0xLjMxNS0wLjg0NzZoLTAuMDU0Yy0wLjM4IDAuMjIxOS0wLjkxOCAwLjU2NTUtMS4zMTUgMC44NDc2LTAuMzk4IDAuMjgwNy0wLjc4OCAwLjU4MjktMS4xNjkgMC45MDM3LTAuMzI3IDAuMjc1NC0wLjY0MyAwLjU1NzUtMC45NDcgMC44NDYzaC0xLjU0MWMwLjEzNS0wLjE0MDQgMC4yNzMtMC4yODIxIDAuNDE1LTAuNDIyNSAwLjUzMi0wLjUyNTQgMS4wNzItMS4wMTg3IDEuNjIxLTEuNDc3MiAwLjU1LTAuNDU5OSAxLjA4My0wLjg3MyAxLjYwMS0xLjIzOCAwLjUxOS0wLjM2NDk3IDAuOTczLTAuNjUyNDEgMS4zNjItMC44NjIzIDAuMzkgMC4yMDk4OSAwLjg0NCAwLjQ5NzMzIDEuMzYyIDAuODYyM3oiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDQuOTk5IDIpIHJvdGF0ZSgxODApIHRyYW5zbGF0ZSgtNC45OTkgLTIpIi8+ICA8L2c+IDwvZz48L3N2Zz4=')
       no-repeat;
-    background-position: right $sph-intra--condensed center;
+    background-position: right $sph-inner--condensed center;
     background-size: map-get($icon-sizes, accordion);
     box-shadow: none;
     color: $color-dark;
     min-height: 24px;
-    padding-right: $sph-intra--expanded;
+    padding-right: $sph-inner--expanded;
     text-indent: 0.01px;
     text-overflow: '';
 
@@ -300,7 +300,7 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
       option {
         font-weight: 300;
         line-height: $sp-unit * 2 - 2 * $px;
-        padding: $spv-intra $sph-intra--condensed;
+        padding: $spv-inner $sph-inner--condensed;
       }
     }
   }
@@ -320,6 +320,6 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     border-radius: $border-radius;
     color: $color-dark;
     margin-bottom: $spv-inter--scaleable;
-    padding: $spv-intra $sph-intra--condensed;
+    padding: $spv-inner $sph-inner--condensed;
   }
 }

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -32,9 +32,9 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     width: 100%;
 
     table & {
-      margin: 0 0 ($spv-inner - $spv-nudge) 0;
-      padding-bottom: ($spv-nudge - $px) - $spv-inner--condensed;
-      padding-top: ($spv-nudge - $px) - $spv-inner--condensed;
+      margin: 0 0 ($spv-inner--small - $spv-nudge) 0;
+      padding-bottom: ($spv-nudge - $px) - $spv-inner--x-small;
+      padding-top: ($spv-nudge - $px) - $spv-inner--x-small;
     }
 
     &:active {
@@ -72,14 +72,14 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
   // Default form checkbox and radio styles
   %vf-tick-elements {
     $box-size: 1rem;
-    $box-offset-top: $spv-inner--condensed;
+    $box-offset-top: $spv-inner--x-small;
     $label-offset--left: $sph-inner + $box-size;
     $tick-offset-top: $box-offset-top + 3 * $px;
     opacity: 0;
     position: absolute;
 
     & + label {
-      margin-bottom: $spv-outer--condensed-scaleable;
+      margin-bottom: $spv-outer--small-scaleable;
       padding-left: $label-offset--left;
       padding-top: 0;
       position: relative;
@@ -145,13 +145,13 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     @extend %default-text;
     cursor: pointer;
     display: block;
-    margin-bottom: $spv-outer--condensed + $spv-nudge-compensation;
+    margin-bottom: $spv-outer--small + $spv-nudge-compensation;
     width: fit-content;
 
     &.is-required::after {
       color: $color-negative;
       content: '*';
-      left: $spv-inner--condensed;
+      left: $spv-inner--x-small;
       position: relative;
     }
 
@@ -283,7 +283,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     box-shadow: none;
     color: $color-dark;
     min-height: 24px;
-    padding-right: $sph-inner--expanded;
+    padding-right: $sph-inner--large;
     text-indent: 0.01px;
     text-overflow: '';
 
@@ -300,7 +300,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
       option {
         font-weight: 300;
         line-height: $sp-unit * 2 - 2 * $px;
-        padding: $spv-inner $sph-inner--condensed;
+        padding: $spv-inner--small $sph-inner--condensed;
       }
     }
   }
@@ -320,6 +320,6 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     border-radius: $border-radius;
     color: $color-dark;
     margin-bottom: $spv-outer--scaleable;
-    padding: $spv-inner $sph-inner--condensed;
+    padding: $spv-inner--small $sph-inner--condensed;
   }
 }

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -1,5 +1,5 @@
 @import 'settings';
-$input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
+$input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
 
 // Form element styles
 @mixin vf-b-forms {
@@ -79,7 +79,7 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     position: absolute;
 
     & + label {
-      margin-bottom: $spv-inter--condensed-scaleable;
+      margin-bottom: $spv-outer--condensed-scaleable;
       padding-left: $label-offset--left;
       padding-top: 0;
       position: relative;
@@ -145,7 +145,7 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     @extend %default-text;
     cursor: pointer;
     display: block;
-    margin-bottom: $spv-inter--condensed + $spv-nudge-compensation;
+    margin-bottom: $spv-outer--condensed + $spv-nudge-compensation;
     width: fit-content;
 
     &.is-required::after {
@@ -308,7 +308,7 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
   // Textarea styles
   textarea {
     @extend %vf-input-elements;
-    margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
+    margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     overflow: auto;
     vertical-align: top;
   }
@@ -319,7 +319,7 @@ $input-margin-bottom: $spv-inter--scaleable - $spv-nudge * 2;
     border: 1px solid $color-mid-light;
     border-radius: $border-radius;
     color: $color-dark;
-    margin-bottom: $spv-inter--scaleable;
+    margin-bottom: $spv-outer--scaleable;
     padding: $spv-inner $sph-inner--condensed;
   }
 }

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -6,7 +6,7 @@
     background-color: $color-mid-light;
     border: 0;
     height: 1px;
-    margin-bottom: $spv-intra--scaleable - $px;
+    margin-bottom: $spv-inner--scaleable - $px;
     margin-top: 0;
     position: relative;
     width: 100%;
@@ -23,7 +23,7 @@
       background: $color-mid-light;
       content: '';
       height: 1px;
-      margin-bottom: $spv-intra--scaleable - $px;
+      margin-bottom: $spv-inner--scaleable - $px;
       width: 100%;
     }
   }

--- a/scss/_base_lists.scss
+++ b/scss/_base_lists.scss
@@ -14,10 +14,10 @@
 
   ol,
   ul {
-    margin-bottom: $spv-inter--scaleable;
-    margin-left: $sph-inter;
+    margin-bottom: $spv-outer--scaleable;
+    margin-left: $sph-outer;
     margin-top: 0;
-    padding-left: $sph-inter;
+    padding-left: $sph-outer;
 
     nav & {
       list-style: none;

--- a/scss/_base_lists.scss
+++ b/scss/_base_lists.scss
@@ -33,7 +33,7 @@
 
   dd {
     @extend %paragraph;
-    margin-left: $sph-intra;
+    margin-left: $sph-inner;
   }
 
   dt {

--- a/scss/_base_media.scss
+++ b/scss/_base_media.scss
@@ -15,7 +15,7 @@
   }
 
   figure {
-    margin-bottom: $spv-inter--scaleable;
+    margin-bottom: $spv-outer--scaleable;
     margin-left: 0;
     width: 100%;
 

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -29,7 +29,7 @@
 
   %vf-card {
     @extend %vf-bg--x-light;
-    margin-bottom: $spv-inter--scaleable;
+    margin-bottom: $spv-outer--scaleable;
     overflow: auto; // prevent overflow of child margins
     padding: $spv-inner--regular;
   }

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -31,7 +31,7 @@
     @extend %vf-bg--x-light;
     margin-bottom: $spv-outer--scaleable;
     overflow: auto; // prevent overflow of child margins
-    padding: $spv-inner--regular;
+    padding: $spv-inner--medium;
   }
 
   // Bars and borders

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -31,7 +31,7 @@
     @extend %vf-bg--x-light;
     margin-bottom: $spv-inter--scaleable;
     overflow: auto; // prevent overflow of child margins
-    padding: $spv-intra--regular;
+    padding: $spv-inner--regular;
   }
 
   // Bars and borders

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -21,7 +21,7 @@
 
     @media screen and (min-width: $breakpoint-medium) {
       &:not(:last-child) {
-        padding-right: $sph-intra;
+        padding-right: $sph-inner;
       }
     }
   }
@@ -30,7 +30,7 @@
     th {
       @extend %muted-heading;
       line-height: map-get($line-heights, small);
-      padding-bottom: $spv-intra--regular - map-get($nudges, nudge--small);
+      padding-bottom: $spv-inner--regular - map-get($nudges, nudge--small);
     }
 
     tr {
@@ -49,7 +49,7 @@
 
   //accordion, table
   %single-border-text-vpadding--scaling {
-    padding-bottom: $spv-intra--condensed--scaleable - $px;
-    padding-top: $spv-intra--condensed--scaleable;
+    padding-bottom: $spv-inner--condensed--scaleable - $px;
+    padding-top: $spv-inner--condensed--scaleable;
   }
 }

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -30,7 +30,7 @@
     th {
       @extend %muted-heading;
       line-height: map-get($line-heights, small);
-      padding-bottom: $spv-inner--regular - map-get($nudges, nudge--small);
+      padding-bottom: $spv-inner--medium - map-get($nudges, nudge--small);
     }
 
     tr {
@@ -49,7 +49,7 @@
 
   //accordion, table
   %single-border-text-vpadding--scaling {
-    padding-bottom: $spv-inner--condensed--scaleable - $px;
-    padding-top: $spv-inner--condensed--scaleable;
+    padding-bottom: $spv-inner--x-small--scaleable - $px;
+    padding-top: $spv-inner--x-small--scaleable;
   }
 }

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -5,7 +5,7 @@
   table {
     border: 0;
     border-collapse: collapse;
-    margin-bottom: $spv-inter--scaleable;
+    margin-bottom: $spv-outer--scaleable;
     overflow-x: auto;
     table-layout: fixed;
     width: 100%;

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -23,18 +23,18 @@
       @extend %single-border-text-vpadding--scaling;
       @include vf-focus;
 
-      $calculated-height: $multi * $spv-intra--condensed * 2 - $px + map-get($line-heights, default-text);
+      $calculated-height: $multi * $spv-inner--condensed * 2 - $px + map-get($line-heights, default-text);
       $offset-top: ($calculated-height - $icon-size) * 0.5;
       background: {
-        position: top $offset-top right $sph-intra;
+        position: top $offset-top right $sph-inner;
         repeat: no-repeat;
       }
       background-color: inherit;
       border: 0;
       border-radius: 0;
       margin-bottom: 0;
-      padding-left: $sph-intra;
-      padding-right: $sph-intra;
+      padding-left: $sph-inner;
+      padding-right: $sph-inner;
       text-align: left;
       transition-duration: 0s;
       width: 100%;
@@ -56,7 +56,7 @@
       border-bottom: 1px solid $color-mid-light;
       margin: 0;
       overflow: auto; // include child margins into its height
-      padding-left: $sph-intra * 2;
+      padding-left: $sph-inner * 2;
 
       // Hides panel content
       &[aria-hidden='true'] {

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -9,7 +9,7 @@
   .p-accordion {
     &__list {
       list-style-type: none;
-      margin: 0 0 $spv-inter--scaleable 0;
+      margin: 0 0 $spv-outer--scaleable 0;
       padding: 0;
     }
 

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -23,7 +23,7 @@
       @extend %single-border-text-vpadding--scaling;
       @include vf-focus;
 
-      $calculated-height: $multi * $spv-inner--condensed * 2 - $px + map-get($line-heights, default-text);
+      $calculated-height: $multi * $spv-inner--x-small * 2 - $px + map-get($line-heights, default-text);
       $offset-top: ($calculated-height - $icon-size) * 0.5;
       background: {
         position: top $offset-top right $sph-inner;

--- a/scss/_patterns_breadcrumbs.scss
+++ b/scss/_patterns_breadcrumbs.scss
@@ -12,7 +12,7 @@
       @extend %default-text;
 
       display: inline-block;
-      margin-bottom: $spv-outer--condensed-scaleable - $spv-nudge;
+      margin-bottom: $spv-outer--small-scaleable - $spv-nudge;
 
       &:not(:first-of-type) {
         text-indent: $sph-outer;

--- a/scss/_patterns_breadcrumbs.scss
+++ b/scss/_patterns_breadcrumbs.scss
@@ -12,10 +12,10 @@
       @extend %default-text;
 
       display: inline-block;
-      margin-bottom: $spv-inter--condensed-scaleable - $spv-nudge;
+      margin-bottom: $spv-outer--condensed-scaleable - $spv-nudge;
 
       &:not(:first-of-type) {
-        text-indent: $sph-inter;
+        text-indent: $sph-outer;
       }
 
       &:not(:first-of-type)::before {

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -155,7 +155,7 @@
       }
 
       + * {
-        margin-left: $sph-inner--condensed / 2;
+        margin-left: $sph-inner--small / 2;
       }
     }
   }

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -155,7 +155,7 @@
       }
 
       + * {
-        margin-left: $sph-intra--condensed / 2;
+        margin-left: $sph-inner--condensed / 2;
       }
     }
   }

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -137,7 +137,7 @@
 @mixin vf-button-inline {
   [class~='p-button'].is-inline {
     @media (min-width: $breakpoint-medium) {
-      margin-left: $sph-inter;
+      margin-left: $sph-outer;
       width: auto;
     }
   }

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -33,7 +33,7 @@
   .p-card--overlay {
     background: transparentize($color-x-light, 0.1);
     color: $color-dark;
-    margin-bottom: $spv-inter--scaleable;
+    margin-bottom: $spv-outer--scaleable;
     overflow: auto;
     padding: $spv-inner--regular;
   }
@@ -44,7 +44,7 @@
     @extend %vf-bg--light;
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
-    margin-bottom: $spv-inter--scaleable;
+    margin-bottom: $spv-outer--scaleable;
     overflow: auto;
     padding: $spv-inner--regular;
   }
@@ -123,7 +123,7 @@
   }
 
   .p-card__image {
-    margin-bottom: $spv-inter--condensed-scaleable;
+    margin-bottom: $spv-outer--condensed-scaleable;
     vertical-align: top;
     width: 100%;
   }

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -13,7 +13,7 @@
     @extend %vf-card;
     @extend %vf-is-bordered;
     @extend %vf-has-round-corners;
-    padding: $spv-inner--regular - $px;
+    padding: $spv-inner--medium - $px;
   }
 }
 
@@ -35,7 +35,7 @@
     color: $color-dark;
     margin-bottom: $spv-outer--scaleable;
     overflow: auto;
-    padding: $spv-inner--regular;
+    padding: $spv-inner--medium;
   }
 }
 
@@ -46,7 +46,7 @@
     @extend %vf-has-round-corners;
     margin-bottom: $spv-outer--scaleable;
     overflow: auto;
-    padding: $spv-inner--regular;
+    padding: $spv-inner--medium;
   }
 }
 
@@ -123,14 +123,14 @@
   }
 
   .p-card__image {
-    margin-bottom: $spv-outer--condensed-scaleable;
+    margin-bottom: $spv-outer--small-scaleable;
     vertical-align: top;
     width: 100%;
   }
 
   .p-card__header {
     border-bottom: 1px solid $color-mid-light;
-    margin-bottom: $spv-inner--regular;
+    margin-bottom: $spv-inner--medium;
 
     > .p-link--soft {
       display: inline-block;
@@ -144,7 +144,7 @@
 
   .p-card__header {
     border-bottom: 1px solid $color-mid-light;
-    margin-bottom: $spv-inner--regular;
+    margin-bottom: $spv-inner--medium;
 
     > .p-link--soft {
       display: inline-block;

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -13,7 +13,7 @@
     @extend %vf-card;
     @extend %vf-is-bordered;
     @extend %vf-has-round-corners;
-    padding: $spv-intra--regular - $px;
+    padding: $spv-inner--regular - $px;
   }
 }
 
@@ -35,7 +35,7 @@
     color: $color-dark;
     margin-bottom: $spv-inter--scaleable;
     overflow: auto;
-    padding: $spv-intra--regular;
+    padding: $spv-inner--regular;
   }
 }
 
@@ -46,7 +46,7 @@
     @extend %vf-has-round-corners;
     margin-bottom: $spv-inter--scaleable;
     overflow: auto;
-    padding: $spv-intra--regular;
+    padding: $spv-inner--regular;
   }
 }
 
@@ -130,7 +130,7 @@
 
   .p-card__header {
     border-bottom: 1px solid $color-mid-light;
-    margin-bottom: $spv-intra--regular;
+    margin-bottom: $spv-inner--regular;
 
     > .p-link--soft {
       display: inline-block;
@@ -144,7 +144,7 @@
 
   .p-card__header {
     border-bottom: 1px solid $color-mid-light;
-    margin-bottom: $spv-intra--regular;
+    margin-bottom: $spv-inner--regular;
 
     > .p-link--soft {
       display: inline-block;

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -22,7 +22,7 @@ $cc-button-size: 36 * $px;
       color: $color-mid-dark;
       font-family: unquote($font-monospace);
       line-height: map-get($line-heights, default-text);
-      padding: 0 $cc-button-size + $sph-intra--condensed 0 $sph-intra * 1.5;
+      padding: 0 $cc-button-size + $sph-inner--condensed 0 $sph-inner * 1.5;
       width: 100%;
     }
 
@@ -32,9 +32,9 @@ $cc-button-size: 36 * $px;
       display: block;
       left: 0;
       line-height: map-get($line-heights, default-text);
-      padding: 0 $cc-button-size + $sph-intra--condensed 0 $sph-intra--condensed;
+      padding: 0 $cc-button-size + $sph-inner--condensed 0 $sph-inner--condensed;
       position: absolute;
-      top: $spv-intra--condensed;
+      top: $spv-inner--condensed;
       width: 1rem;
     }
 

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -22,7 +22,7 @@ $cc-button-size: 36 * $px;
       color: $color-mid-dark;
       font-family: unquote($font-monospace);
       line-height: map-get($line-heights, default-text);
-      padding: 0 $cc-button-size + $sph-inner--condensed 0 $sph-inner * 1.5;
+      padding: 0 $cc-button-size + $sph-inner--small 0 $sph-inner * 1.5;
       width: 100%;
     }
 
@@ -32,7 +32,7 @@ $cc-button-size: 36 * $px;
       display: block;
       left: 0;
       line-height: map-get($line-heights, default-text);
-      padding: 0 $cc-button-size + $sph-inner--condensed 0 $sph-inner--condensed;
+      padding: 0 $cc-button-size + $sph-inner--small 0 $sph-inner--small;
       position: absolute;
       top: $spv-inner--x-small;
       width: 1rem;

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -34,7 +34,7 @@ $cc-button-size: 36 * $px;
       line-height: map-get($line-heights, default-text);
       padding: 0 $cc-button-size + $sph-inner--condensed 0 $sph-inner--condensed;
       position: absolute;
-      top: $spv-inner--condensed;
+      top: $spv-inner--x-small;
       width: 1rem;
     }
 

--- a/scss/_patterns_code-numbered.scss
+++ b/scss/_patterns_code-numbered.scss
@@ -8,7 +8,7 @@ $sidebar-width: 4.5rem !default;
 
     .code-line {
       display: inline-block;
-      padding: $spv-inner $sph-inner 0 ($sidebar-width + $sph-inner);
+      padding: $spv-inner--small $sph-inner 0 ($sidebar-width + $sph-inner);
       position: relative;
       width: 100%;
 
@@ -19,7 +19,7 @@ $sidebar-width: 4.5rem !default;
 
       &:last-of-type,
       &:last-of-type::before {
-        padding-bottom: $spv-inner;
+        padding-bottom: $spv-inner--small;
       }
 
       &::before {
@@ -31,7 +31,7 @@ $sidebar-width: 4.5rem !default;
         display: inline-block;
         height: 100%;
         left: 0;
-        padding: $spv-inner $sph-inner 0 $sph-inner;
+        padding: $spv-inner--small $sph-inner 0 $sph-inner;
         pointer-events: none;
         position: absolute;
         text-align: right;

--- a/scss/_patterns_code-numbered.scss
+++ b/scss/_patterns_code-numbered.scss
@@ -8,7 +8,7 @@ $sidebar-width: 4.5rem !default;
 
     .code-line {
       display: inline-block;
-      padding: $spv-intra $sph-intra 0 ($sidebar-width + $sph-intra);
+      padding: $spv-inner $sph-inner 0 ($sidebar-width + $sph-inner);
       position: relative;
       width: 100%;
 
@@ -19,7 +19,7 @@ $sidebar-width: 4.5rem !default;
 
       &:last-of-type,
       &:last-of-type::before {
-        padding-bottom: $spv-intra;
+        padding-bottom: $spv-inner;
       }
 
       &::before {
@@ -31,7 +31,7 @@ $sidebar-width: 4.5rem !default;
         display: inline-block;
         height: 100%;
         left: 0;
-        padding: $spv-intra $sph-intra 0 $sph-intra;
+        padding: $spv-inner $sph-inner 0 $sph-inner;
         pointer-events: none;
         position: absolute;
         text-align: right;

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -63,7 +63,7 @@
     }
 
     &__toggle {
-      margin-bottom: $spv-intra;
+      margin-bottom: $spv-inner;
     }
 
     &__link {

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -63,7 +63,7 @@
     }
 
     &__toggle {
-      margin-bottom: $spv-inner;
+      margin-bottom: $spv-inner--small;
     }
 
     &__link {

--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -8,7 +8,7 @@
 
     &__block {
       @media (max-width: $breakpoint-medium) {
-        padding-bottom: $spv-inter--scaleable;
+        padding-bottom: $spv-outer--scaleable;
 
         &:not(:first-child) {
           border-top: 1px solid $color-mid-light;

--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -12,7 +12,7 @@
 
         &:not(:first-child) {
           border-top: 1px solid $color-mid-light;
-          padding-top: $spv-intra--scaleable - $px; // border compensation
+          padding-top: $spv-inner--scaleable - $px; // border compensation
         }
       }
 

--- a/scss/_patterns_footer.scss
+++ b/scss/_patterns_footer.scss
@@ -11,12 +11,12 @@
     position: relative;
 
     @media only screen and (max-width: $breakpoint-large) {
-      padding-bottom: $spv-inter--regular-scaleable * 0.5;
-      padding-top: $spv-inter--regular-scaleable * 0.5;
+      padding-bottom: $spv-outer--regular-scaleable * 0.5;
+      padding-top: $spv-outer--regular-scaleable * 0.5;
     }
     @media only screen and (min-width: $breakpoint-large) {
-      padding-bottom: $spv-inter--regular-scaleable;
-      padding-top: $spv-inter--regular-scaleable;
+      padding-bottom: $spv-outer--regular-scaleable;
+      padding-top: $spv-outer--regular-scaleable;
     }
 
     &__copy {

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -12,7 +12,7 @@
 
     :not(select).p-form-validation__input {
       // Not using parent selector here as two classes are required to override atribute selectors in reset
-      background-position: calc(100% - #{$sph-inner--condensed}) 50%;
+      background-position: calc(100% - #{$sph-inner--small}) 50%;
       background-repeat: no-repeat;
     }
 

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -12,7 +12,7 @@
 
     :not(select).p-form-validation__input {
       // Not using parent selector here as two classes are required to override atribute selectors in reset
-      background-position: calc(100% - #{$sph-intra--condensed}) 50%;
+      background-position: calc(100% - #{$sph-inner--condensed}) 50%;
       background-repeat: no-repeat;
     }
 

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -21,11 +21,11 @@ $shelves-column-name: $grid-col-name;
   // Demo helper
   [grid-demo] [class*='col-'] {
     background: $color-mid-light;
-    margin-bottom: $spv-intra;
+    margin-bottom: $spv-inner;
   }
 
   [grid-outline] [class*='col-'] {
     outline: 1px solid $color-x-light;
-    padding: $spv-intra $sph-intra--condensed;
+    padding: $spv-inner $sph-inner--condensed;
   }
 }

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -26,6 +26,6 @@ $shelves-column-name: $grid-col-name;
 
   [grid-outline] [class*='col-'] {
     outline: 1px solid $color-x-light;
-    padding: $spv-inner--small $sph-inner--condensed;
+    padding: $spv-inner--small $sph-inner--small;
   }
 }

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -21,11 +21,11 @@ $shelves-column-name: $grid-col-name;
   // Demo helper
   [grid-demo] [class*='col-'] {
     background: $color-mid-light;
-    margin-bottom: $spv-inner;
+    margin-bottom: $spv-inner--small;
   }
 
   [grid-outline] [class*='col-'] {
     outline: 1px solid $color-x-light;
-    padding: $spv-inner $sph-inner--condensed;
+    padding: $spv-inner--small $sph-inner--condensed;
   }
 }

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -2,7 +2,7 @@
 
 @mixin vf-p-heading-icon {
   .p-heading-icon {
-    margin-bottom: $spv-outer--regular;
+    margin-bottom: $spv-outer--medium;
 
     @media (min-width: $breakpoint-medium) {
       margin-bottom: 0;
@@ -22,7 +22,7 @@
     &__img {
       flex-shrink: 0;
       height: map-get($icon-sizes, heading-icon--small);
-      margin-bottom: $spv-inner;
+      margin-bottom: $spv-inner--small;
       margin-right: $sph-inner;
       width: map-get($icon-sizes, heading-icon--small);
 
@@ -32,7 +32,7 @@
 
       @media (min-width: $breakpoint-medium) {
         height: map-get($icon-sizes, heading-icon);
-        margin-top: -#{$spv-inner};
+        margin-top: -#{$spv-inner--small};
         width: map-get($icon-sizes, heading-icon);
       }
     }
@@ -44,7 +44,7 @@
       width: map-get($icon-sizes, heading-icon--x-small);
 
       @media (max-width: $breakpoint-medium) {
-        margin-top: $spv-inner--condensed;
+        margin-top: $spv-inner--x-small;
       }
 
       @media (min-width: $breakpoint-medium) {

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -22,8 +22,8 @@
     &__img {
       flex-shrink: 0;
       height: map-get($icon-sizes, heading-icon--small);
-      margin-bottom: $spv-intra;
-      margin-right: $sph-intra;
+      margin-bottom: $spv-inner;
+      margin-right: $sph-inner;
       width: map-get($icon-sizes, heading-icon--small);
 
       @media (max-width: $breakpoint-medium) {
@@ -32,7 +32,7 @@
 
       @media (min-width: $breakpoint-medium) {
         height: map-get($icon-sizes, heading-icon);
-        margin-top: -#{$spv-intra};
+        margin-top: -#{$spv-inner};
         width: map-get($icon-sizes, heading-icon);
       }
     }
@@ -44,7 +44,7 @@
       width: map-get($icon-sizes, heading-icon--x-small);
 
       @media (max-width: $breakpoint-medium) {
-        margin-top: $spv-intra--condensed;
+        margin-top: $spv-inner--condensed;
       }
 
       @media (min-width: $breakpoint-medium) {

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -2,7 +2,7 @@
 
 @mixin vf-p-heading-icon {
   .p-heading-icon {
-    margin-bottom: $spv-inter--regular;
+    margin-bottom: $spv-outer--regular;
 
     @media (min-width: $breakpoint-medium) {
       margin-bottom: 0;

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -1,6 +1,6 @@
 @import 'settings';
 $tick-height: 0.875rem; // 14px value from svg as rem so it can be used in calculations
-$spv-list-item--inner: 0.25 * $spv-inter--condensed-scaleable; // padding top and bottom for lists containing loose text.
+$spv-list-item--inner: 0.25 * $spv-outer--condensed-scaleable; // padding top and bottom for lists containing loose text.
 
 // Default list styling
 // Mixin for basic styled lists

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -1,6 +1,6 @@
 @import 'settings';
 $tick-height: 0.875rem; // 14px value from svg as rem so it can be used in calculations
-$spv-list-item--inner: 0.25 * $spv-outer--condensed-scaleable; // padding top and bottom for lists containing loose text.
+$spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bottom for lists containing loose text.
 
 // Default list styling
 // Mixin for basic styled lists

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -196,9 +196,9 @@ $spv-list-item--inner: 0.25 * $spv-inter--condensed-scaleable; // padding top an
   // sass-lint:disable no-qualifying-elements
   h#{$i}.p-stepped-list__title {
     // sass-lint:enable no-qualifying-elements
-    margin-left: $bullet-width + $sph-intra;
+    margin-left: $bullet-width + $sph-inner;
     @media (max-width: $breakpoint-heading-threshold) {
-      margin-left: $bullet-width-mobile + $sph-intra;
+      margin-left: $bullet-width-mobile + $sph-inner;
     }
 
     &::before {

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -17,8 +17,8 @@
       border-top: 1px solid $color-mid-light;
       display: flex;
       flex: 1 1 auto;
-      padding-bottom: $spv-intra--scaleable;
-      padding-top: $spv-intra--scaleable - $px;
+      padding-bottom: $spv-inner--scaleable;
+      padding-top: $spv-inner--scaleable - $px;
 
       @media (min-width: $breakpoint-small) {
         display: flex;
@@ -32,8 +32,8 @@
 
       @media (min-width: $breakpoint-medium) {
         border-right: 1px solid $color-mid-light;
-        padding-left: $spv-intra--scaleable;
-        padding-right: $spv-intra--scaleable;
+        padding-left: $spv-inner--scaleable;
+        padding-right: $spv-inner--scaleable;
         width: 33.333%;
 
         &:empty {
@@ -83,7 +83,7 @@
 
     &__img {
       align-self: flex-start;
-      margin-bottom: $spv-intra--scaleable;
+      margin-bottom: $spv-inner--scaleable;
       margin-right: $matrix-img-gutter;
       max-height: $matrix-img-width;
       max-width: $matrix-img-width;
@@ -94,7 +94,7 @@
       display: flex;
       flex: 1 1 auto;
       flex-direction: column;
-      padding-right: $sph-intra;
+      padding-right: $sph-inner;
 
       @media (min-width: $breakpoint-large) {
         width: calc(100% - #{$matrix-img-width + $matrix-img-gutter});

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -4,12 +4,12 @@
 @mixin vf-p-matrix {
   .p-matrix {
     $matrix-img-width: map-get($icon-sizes, thumb--small);
-    $matrix-img-gutter: $sph-inter;
+    $matrix-img-gutter: $sph-outer;
 
     display: flex;
     flex-wrap: wrap;
     list-style: none;
-    margin-bottom: $spv-inter--scaleable;
+    margin-bottom: $spv-outer--scaleable;
     margin-left: 0;
     padding-left: 0;
 

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -9,7 +9,7 @@
 %vf-meta-list-item {
   @extend %small-text;
   color: $color-dark;
-  padding-left: map-get($icon-sizes, default) + $sph-intra;
+  padding-left: map-get($icon-sizes, default) + $sph-inner;
 }
 
 %vf-iconed-list-item {
@@ -52,7 +52,7 @@
       list-style: none;
       margin: 0;
       padding-left: 0;
-      padding-top: $spv-intra;
+      padding-top: $spv-inner;
     }
 
     &__meta-list-item {

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -3,7 +3,7 @@
 %p-media-object {
   display: flex;
   flex-shrink: 0;
-  margin-bottom: $spv-inter--scaleable;
+  margin-bottom: $spv-outer--scaleable;
 }
 
 %vf-meta-list-item {
@@ -28,7 +28,7 @@
       border-radius: $border-radius;
       flex-basis: inherit;
       flex-shrink: 0;
-      margin-right: $sph-inter;
+      margin-right: $sph-outer;
       max-height: map-get($icon-sizes, thumb);
       max-width: map-get($icon-sizes, thumb);
       vertical-align: middle;

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -52,7 +52,7 @@
       list-style: none;
       margin: 0;
       padding-left: 0;
-      padding-top: $spv-inner;
+      padding-top: $spv-inner--small;
     }
 
     &__meta-list-item {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -73,7 +73,6 @@ $nav-border-bottom-thickness: $px;
       @extend %vf-heading-3;
       display: flex;
       flex: 0 0 auto;
-      // margin: $spv-inner--large $sph-inner $spv-outer--scaleable $grid-margin-width;
       margin-left: 0;
 
       .p-navigation__image {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -73,7 +73,7 @@ $nav-border-bottom-thickness: $px;
       @extend %vf-heading-3;
       display: flex;
       flex: 0 0 auto;
-      // margin: $spv-inner--expanded $sph-inner $spv-inter--scaleable $grid-margin-width;
+      // margin: $spv-inner--expanded $sph-inner $spv-outer--scaleable $grid-margin-width;
       margin-left: 0;
 
       .p-navigation__image {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -73,7 +73,7 @@ $nav-border-bottom-thickness: $px;
       @extend %vf-heading-3;
       display: flex;
       flex: 0 0 auto;
-      // margin: $spv-intra--expanded $sph-intra $spv-inter--scaleable $grid-margin-width;
+      // margin: $spv-inner--expanded $sph-inner $spv-inter--scaleable $grid-margin-width;
       margin-left: 0;
 
       .p-navigation__image {
@@ -197,7 +197,7 @@ $nav-border-bottom-thickness: $px;
       position: relative;
 
       @media (max-width: $breakpoint-navigation-threshold) {
-        padding: $spv-intra--expanded $grid-margin-width;
+        padding: $spv-inner--expanded $grid-margin-width;
 
         &::before {
           background: $border-color;
@@ -212,7 +212,7 @@ $nav-border-bottom-thickness: $px;
 
       @media (min-width: $breakpoint-navigation-threshold + 1) {
         border-left: 1px solid $border-color;
-        padding: $spv-intra--expanded $sph-intra;
+        padding: $spv-inner--expanded $sph-inner;
 
         &::before {
           background: $border-color;
@@ -254,7 +254,7 @@ $nav-border-bottom-thickness: $px;
     display: flex;
     flex: 0 0 auto;
     height: 3rem;
-    margin: 0 $sph-intra 0 $grid-margin-width;
+    margin: 0 $sph-inner 0 $grid-margin-width;
 
     .p-navigation__link {
       display: flex;
@@ -280,16 +280,16 @@ $nav-border-bottom-thickness: $px;
 
     @media (max-width: $breakpoint-navigation-threshold) {
       flex: 1 0 auto;
-      margin: -1px $grid-margin-width $spv-intra $grid-margin-width;
+      margin: -1px $grid-margin-width $spv-inner $grid-margin-width;
       order: -1;
     }
 
     @media (min-width: $breakpoint-navigation-threshold + 1) {
       // align baselines of menu items and input text
-      $input-gap-top: $spv-intra--expanded - $spv-nudge;
+      $input-gap-top: $spv-inner--expanded - $spv-nudge;
       display: flex;
       flex: 1 1 auto;
-      margin: $input-gap-top $sph-intra auto auto;
+      margin: $input-gap-top $sph-inner auto auto;
       max-width: 20rem;
       order: 1;
     }
@@ -327,8 +327,8 @@ $nav-border-bottom-thickness: $px;
     &--open,
     &--close {
       display: none;
-      margin: 0 $grid-margin-width auto $sph-intra;
-      padding: $spv-intra--expanded 0;
+      margin: 0 $grid-margin-width auto $sph-inner;
+      padding: $spv-inner--expanded 0;
     }
 
     &--open {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -73,7 +73,7 @@ $nav-border-bottom-thickness: $px;
       @extend %vf-heading-3;
       display: flex;
       flex: 0 0 auto;
-      // margin: $spv-inner--expanded $sph-inner $spv-outer--scaleable $grid-margin-width;
+      // margin: $spv-inner--large $sph-inner $spv-outer--scaleable $grid-margin-width;
       margin-left: 0;
 
       .p-navigation__image {
@@ -197,7 +197,7 @@ $nav-border-bottom-thickness: $px;
       position: relative;
 
       @media (max-width: $breakpoint-navigation-threshold) {
-        padding: $spv-inner--expanded $grid-margin-width;
+        padding: $spv-inner--large $grid-margin-width;
 
         &::before {
           background: $border-color;
@@ -212,7 +212,7 @@ $nav-border-bottom-thickness: $px;
 
       @media (min-width: $breakpoint-navigation-threshold + 1) {
         border-left: 1px solid $border-color;
-        padding: $spv-inner--expanded $sph-inner;
+        padding: $spv-inner--large $sph-inner;
 
         &::before {
           background: $border-color;
@@ -280,13 +280,13 @@ $nav-border-bottom-thickness: $px;
 
     @media (max-width: $breakpoint-navigation-threshold) {
       flex: 1 0 auto;
-      margin: -1px $grid-margin-width $spv-inner $grid-margin-width;
+      margin: -1px $grid-margin-width $spv-inner--small $grid-margin-width;
       order: -1;
     }
 
     @media (min-width: $breakpoint-navigation-threshold + 1) {
       // align baselines of menu items and input text
-      $input-gap-top: $spv-inner--expanded - $spv-nudge;
+      $input-gap-top: $spv-inner--large - $spv-nudge;
       display: flex;
       flex: 1 1 auto;
       margin: $input-gap-top $sph-inner auto auto;
@@ -328,7 +328,7 @@ $nav-border-bottom-thickness: $px;
     &--close {
       display: none;
       margin: 0 $grid-margin-width auto $sph-inner;
-      padding: $spv-inner--expanded 0;
+      padding: $spv-inner--large 0;
     }
 
     &--open {

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -34,7 +34,7 @@
     @include vf-highlight-bar($color-mid-dark);
 
     & + & {
-      margin-top: $spv-inter--scaleable; // negate bottom margin
+      margin-top: $spv-outer--scaleable; // negate bottom margin
     }
 
     &__response {

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -15,8 +15,8 @@
       background-color: transparent;
       background-size: map-get($icon-sizes, default);
       border: 0;
-      margin: $sp-unit * 2 $sph-intra auto auto;
-      padding: $spv-intra;
+      margin: $sp-unit * 2 $sph-inner auto auto;
+      padding: $spv-inner;
     }
   }
 
@@ -39,10 +39,10 @@
 
     &__response {
       @extend %default-text;
-      background-position: $sph-intra $spv-intra--condensed--scaleable + $spv-nudge + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default));
+      background-position: $sph-inner $spv-inner--condensed--scaleable + $spv-nudge + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default));
       background-repeat: no-repeat;
       background-size: map-get($icon-sizes, default);
-      padding: $spv-intra--condensed--scaleable + $spv-nudge $sph-intra $spv-intra--condensed--scaleable;
+      padding: $spv-inner--condensed--scaleable + $spv-nudge $sph-inner $spv-inner--condensed--scaleable;
     }
 
     &__status {
@@ -70,7 +70,7 @@
     .p-notification__response {
       // prettier-ignore
       background-image: url("data:image/svg+xml,%3Csvg width='17px' height='17px' viewBox='0 0 17 17' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='notification-success' transform='translate(1.000000, 1.000000)'%3E%3Cg id='Page-3---colours'%3E%3Cg id='Notifications---single'%3E%3Cg id='Group'%3E%3Cg id='ICON'%3E%3Ccircle id='circle6710' stroke='" + vf-url-friendly-color($color-positive) + "' stroke-width='1.5' fill='" + vf-url-friendly-color($color-positive) + "' cx='7.2500086' cy='7.2500086' r='7.2500086'%3E%3C/circle%3E%3Cpolygon id='path6712' fill='" + vf-url-friendly-color($color-x-light) + "' points='11.0502986 4.1734486 10.9843986 4.2311486 6.2496486 8.3783686 3.4740786 5.9974286 2.6350186 6.9463086 6.2503386 10.7500186 11.7500086 4.9627786 11.0502986 4.1734886'%3E%3C/polygon%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
-      padding-left: 2 * $sph-intra + map-get($icon-sizes, default);
+      padding-left: 2 * $sph-inner + map-get($icon-sizes, default);
     }
   }
 }
@@ -84,7 +84,7 @@
     .p-notification__response {
       // prettier-ignore
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16'%3E%3Cg color='%23000'%3E%3Cpath fill='none' d='M0 0h16v16H0z'/%3E%3Cpath stroke-linejoin='round' fill='#{vf-url-friendly-color($color-caution)}' transform='matrix%282.28 0 0 2.437 -2180.8 -490.52%29' stroke='#{vf-url-friendly-color($color-caution)}' stroke-width='.848' d='M963.07 207.03h-6.15l3.08-5.33z'/%3E%3Cpath d='M7 5v5h2V5H7zm0 6v2h2v-2H7z' fill='%23111'/%3E%3C/g%3E%3C/svg%3E");
-      padding-left: 2 * $sph-intra + map-get($icon-sizes, default);
+      padding-left: 2 * $sph-inner + map-get($icon-sizes, default);
     }
   }
 }
@@ -99,7 +99,7 @@
       .p-notification__response {
         // prettier-ignore
         background-image: url("data:image/svg+xml,%3Csvg width='17px' height='17px' viewBox='0 0 17 17' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='notification-warning' transform='translate(1.000000, 1.000000)'%3E%3Cg id='Page-3---colours'%3E%3Cg id='Notifications---single'%3E%3Cg id='Group'%3E%3Cg id='ICON'%3E%3Ccircle id='circle5432' stroke='" + vf-url-friendly-color($color-caution) + "' stroke-width='1.5' fill='" + vf-url-friendly-color($color-caution) + "' cx='7.2500086' cy='7.2500086' r='7.2500086'%3E%3C/circle%3E%3Cpath d='M6.2500086,3.2500086 L6.2500086,8.2500086 L8.2500086,8.2500086 L8.2500086,3.2500086 L6.2500086,3.2500086 L6.2500086,3.2500086 L6.2500086,3.2500086 Z M6.2500086,9.2500086 L6.2500086,11.2500086 L8.2500086,11.2500086 L8.2500086,9.2500086 L6.2500086,9.2500086 L6.2500086,9.2500086 L6.2500086,9.2500086 Z' id='rect5434' fill='" + vf-url-friendly-color($color-x-light) + "'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
-        padding-left: 2 * $sph-intra + map-get($icon-sizes, default);
+        padding-left: 2 * $sph-inner + map-get($icon-sizes, default);
       }
     }
   }
@@ -114,7 +114,7 @@
     .p-notification__response {
       // prettier-ignore
       background-image: url("data:image/svg+xml,%3Csvg width='16px' height='17px' viewBox='0 0 16 17' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cg id='Page-3---colours' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='Notifications---single' transform='translate(-215.000000, -271.000000)'%3E%3Cg id='Group' transform='translate(205.000000, 254.000000)'%3E%3Cg id='ICON' transform='translate(10.000000, 17.000000)'%3E%3Crect id='rect6415' x='0' y='0.36218' width='16' height='16'%3E%3C/rect%3E%3Ccircle id='circle6417' stroke='" + vf-url-friendly-color($color-negative) + "' stroke-width='1.5' fill='" + vf-url-friendly-color($color-negative) + "' cx='8' cy='8.36218' r='7.2500086'%3E%3C/circle%3E%3Cpath d='M5.00001,5.36218 L11.00001,11.36218' id='path6479-8' stroke='" + vf-url-friendly-color($color-x-light) + "' stroke-width='1.5'%3E%3C/path%3E%3Cpath d='M11.00001,5.36218 L5.00001,11.36218' id='path6481-8' stroke='" + vf-url-friendly-color($color-x-light) + "' stroke-width='1.5'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
-      padding-left: 2 * $sph-intra + map-get($icon-sizes, default);
+      padding-left: 2 * $sph-inner + map-get($icon-sizes, default);
     }
   }
 }

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -16,7 +16,7 @@
       background-size: map-get($icon-sizes, default);
       border: 0;
       margin: $sp-unit * 2 $sph-inner auto auto;
-      padding: $spv-inner;
+      padding: $spv-inner--small;
     }
   }
 
@@ -39,10 +39,10 @@
 
     &__response {
       @extend %default-text;
-      background-position: $sph-inner $spv-inner--condensed--scaleable + $spv-nudge + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default));
+      background-position: $sph-inner $spv-inner--x-small--scaleable + $spv-nudge + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default));
       background-repeat: no-repeat;
       background-size: map-get($icon-sizes, default);
-      padding: $spv-inner--condensed--scaleable + $spv-nudge $sph-inner $spv-inner--condensed--scaleable;
+      padding: $spv-inner--x-small--scaleable + $spv-nudge $sph-inner $spv-inner--x-small--scaleable;
     }
 
     &__status {

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -10,7 +10,7 @@
     border-width: 1px;
     color: $color-x-dark;
     display: block;
-    padding: $spv-intra $sph-intra;
+    padding: $spv-inner $sph-inner;
     text-decoration: none;
 
     &.is-disabled {
@@ -43,16 +43,16 @@
     padding-left: 0;
 
     &__item {
-      margin-right: $sph-intra--condensed;
+      margin-right: $sph-inner--condensed;
       width: auto;
 
       &:first-child,
       &:nth-last-child(2) {
-        margin-right: $sph-intra;
+        margin-right: $sph-inner;
       }
 
       &--truncation {
-        margin: 0.3rem $sph-intra 0 $sph-intra--condensed;
+        margin: 0.3rem $sph-inner 0 $sph-inner--condensed;
       }
     }
 
@@ -63,8 +63,8 @@
     &__link--previous,
     &__link--next {
       @extend %pagination-link;
-      padding-left: $sph-intra--condensed;
-      padding-right: $sph-intra--condensed;
+      padding-left: $sph-inner--condensed;
+      padding-right: $sph-inner--condensed;
     }
 
     &__link--previous .p-icon--contextual-menu {

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -10,7 +10,7 @@
     border-width: 1px;
     color: $color-x-dark;
     display: block;
-    padding: $spv-inner $sph-inner;
+    padding: $spv-inner--small $sph-inner;
     text-decoration: none;
 
     &.is-disabled {

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -43,7 +43,7 @@
     padding-left: 0;
 
     &__item {
-      margin-right: $sph-inner--condensed;
+      margin-right: $sph-inner--small;
       width: auto;
 
       &:first-child,
@@ -52,7 +52,7 @@
       }
 
       &--truncation {
-        margin: 0.3rem $sph-inner 0 $sph-inner--condensed;
+        margin: 0.3rem $sph-inner 0 $sph-inner--small;
       }
     }
 
@@ -63,8 +63,8 @@
     &__link--previous,
     &__link--next {
       @extend %pagination-link;
-      padding-left: $sph-inner--condensed;
-      padding-right: $sph-inner--condensed;
+      padding-left: $sph-inner--small;
+      padding-right: $sph-inner--small;
     }
 
     &__link--previous .p-icon--contextual-menu {

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -9,7 +9,7 @@
 
 @mixin vf-pull-quote {
   border: 0;
-  margin: $spv-inter--scaleable 0 $spv-inter--scaleable + $sp-unit;
+  margin: $spv-outer--scaleable 0 $spv-outer--scaleable + $sp-unit;
   overflow: visible;
   position: relative;
 }
@@ -17,7 +17,7 @@
 // Pull quote styling
 @mixin vf-p-pull-quotes {
   .p-pull-quote {
-    padding: 0 $sph-inter * 2;
+    padding: 0 $sph-outer * 2;
 
     .p-pull-quote__quote {
       @extend %vf-heading-4;
@@ -42,7 +42,7 @@
   }
 
   .p-pull-quote--small {
-    padding: 0 $sph-inter * 1.5;
+    padding: 0 $sph-outer * 1.5;
 
     .p-pull-quote__quote {
       @extend %default-text;
@@ -63,7 +63,7 @@
   }
 
   .p-pull-quote--large {
-    padding: 0 $sph-inter * 2.5;
+    padding: 0 $sph-outer * 2.5;
 
     .p-pull-quote__quote {
       @extend %vf-heading-3;

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -95,7 +95,7 @@
 
     .p-pull-quote__citation {
       font-style: italic;
-      margin-top: $spv-intra--condensed--scaleable;
+      margin-top: $spv-inner--condensed--scaleable;
     }
   }
 
@@ -103,7 +103,7 @@
     &:first-of-type::before {
       @include vf-quote-mark;
       content: '\201C'; // Unicode for left double quotation mark +  1/2 em space
-      left: $spv-intra--condensed;
+      left: $spv-inner--condensed;
       top: 0.5rem;
 
       @media (max-width: $breakpoint-heading-threshold) {
@@ -118,7 +118,7 @@
     &:last-of-type::after {
       @include vf-quote-mark;
       content: '\201E';
-      margin-left: $spv-intra;
+      margin-left: $spv-inner;
     }
   }
 }

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -95,7 +95,7 @@
 
     .p-pull-quote__citation {
       font-style: italic;
-      margin-top: $spv-inner--condensed--scaleable;
+      margin-top: $spv-inner--x-small--scaleable;
     }
   }
 
@@ -103,7 +103,7 @@
     &:first-of-type::before {
       @include vf-quote-mark;
       content: '\201C'; // Unicode for left double quotation mark +  1/2 em space
-      left: $spv-inner--condensed;
+      left: $spv-inner--x-small;
       top: 0.5rem;
 
       @media (max-width: $breakpoint-heading-threshold) {
@@ -118,7 +118,7 @@
     &:last-of-type::after {
       @include vf-quote-mark;
       content: '\201E';
-      margin-left: $spv-inner;
+      margin-left: $spv-inner--small;
     }
   }
 }

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -22,7 +22,7 @@
   .p-search-box {
     box-shadow: inset 0 1px 2px $color-input-shadow;
     display: flex;
-    margin-bottom: $spv-inter--scaleable + $spv-nudge-compensation * 2;
+    margin-bottom: $spv-outer--scaleable + $spv-nudge-compensation * 2;
     position: relative;
 
     &__input {

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -3,34 +3,34 @@
 @mixin vf-p-strip {
   %section-padding--shallow {
     @media only screen and (max-width: $breakpoint-large) {
-      padding-bottom: $spv-inter--shallow-scaleable * 0.5;
-      padding-top: $spv-inter--shallow-scaleable * 0.5;
+      padding-bottom: $spv-outer--shallow-scaleable * 0.5;
+      padding-top: $spv-outer--shallow-scaleable * 0.5;
     }
     @media only screen and (min-width: $breakpoint-large) {
-      padding-bottom: $spv-inter--shallow-scaleable;
-      padding-top: $spv-inter--shallow-scaleable;
+      padding-bottom: $spv-outer--shallow-scaleable;
+      padding-top: $spv-outer--shallow-scaleable;
     }
   }
 
   // used in strips and footer
   %section-padding--default {
     @media only screen and (max-width: $breakpoint-large) {
-      padding-bottom: $spv-inter--regular-scaleable * 0.5;
-      padding-top: $spv-inter--regular-scaleable * 0.5;
+      padding-bottom: $spv-outer--regular-scaleable * 0.5;
+      padding-top: $spv-outer--regular-scaleable * 0.5;
     }
     @media only screen and (min-width: $breakpoint-large) {
-      padding-bottom: $spv-inter--regular-scaleable;
-      padding-top: $spv-inter--regular-scaleable;
+      padding-bottom: $spv-outer--regular-scaleable;
+      padding-top: $spv-outer--regular-scaleable;
     }
   }
 
   %section-padding--deep {
     @media only screen and (max-width: $breakpoint-large) {
-      padding: $spv-inter--deep-scaleable * 0.5 0 $spv-inter--deep-scaleable * 0.5;
+      padding: $spv-outer--deep-scaleable * 0.5 0 $spv-outer--deep-scaleable * 0.5;
     }
 
     @media only screen and (min-width: $breakpoint-large) {
-      padding: $spv-inter--deep-scaleable 0;
+      padding: $spv-outer--deep-scaleable 0;
     }
   }
 

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -29,7 +29,7 @@ $knob-size: $sp-unit * 3;
       background: linear-gradient(to right, $color-information 50%, $color-mid-light 50%);
       box-shadow: inset 0 2px 5px 0 transparentize($color-dark, 0.8);
       height: $knob-size;
-      margin: $spv-nudge-compensation 0 $spv-outer--condensed-scaleable 0;
+      margin: $spv-nudge-compensation 0 $spv-outer--small-scaleable 0;
       position: relative;
       width: $knob-size * 2;
 

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -29,7 +29,7 @@ $knob-size: $sp-unit * 3;
       background: linear-gradient(to right, $color-information 50%, $color-mid-light 50%);
       box-shadow: inset 0 2px 5px 0 transparentize($color-dark, 0.8);
       height: $knob-size;
-      margin: $spv-nudge-compensation 0 $spv-inter--condensed-scaleable 0;
+      margin: $spv-nudge-compensation 0 $spv-outer--condensed-scaleable 0;
       position: relative;
       width: $knob-size * 2;
 

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -25,7 +25,7 @@
         border-top: 1px solid $color-mid-light;
         display: flex;
         flex-wrap: wrap;
-        margin: -1px 0 $spv-inter--condensed;
+        margin: -1px 0 $spv-outer--condensed;
         width: 100%;
       }
 

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -25,7 +25,7 @@
         border-top: 1px solid $color-mid-light;
         display: flex;
         flex-wrap: wrap;
-        margin: -1px 0 $spv-outer--condensed;
+        margin: -1px 0 $spv-outer--small;
         width: 100%;
       }
 
@@ -52,7 +52,7 @@
             content: attr(aria-label);
             display: block;
             flex: 0 1 auto;
-            margin-bottom: $spv-inner - map-get($nudges, nudge--small);
+            margin-bottom: $spv-inner--small - map-get($nudges, nudge--small);
             width: 100%;
           }
         }

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -52,7 +52,7 @@
             content: attr(aria-label);
             display: block;
             flex: 0 1 auto;
-            margin-bottom: $spv-intra - map-get($nudges, nudge--small);
+            margin-bottom: $spv-inner - map-get($nudges, nudge--small);
             width: 100%;
           }
         }

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -33,7 +33,7 @@
       @extend %vf-pseudo-border--bottom;
       display: flex;
       font-size: 0;
-      margin: 0 auto $spv-intra--scaleable;
+      margin: 0 auto $spv-inner--scaleable;
       overflow-x: auto;
       padding: 0;
       position: relative;
@@ -57,7 +57,7 @@
     &__link {
       color: $color-x-dark;
       display: inline-block;
-      padding: $spv-intra--expanded $sph-intra;
+      padding: $spv-inner--expanded $sph-inner;
 
       &:visited,
       &:active,

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -57,7 +57,7 @@
     &__link {
       color: $color-x-dark;
       display: inline-block;
-      padding: $spv-inner--expanded $sph-inner;
+      padding: $spv-inner--large $sph-inner;
 
       &:visited,
       &:active,

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -13,7 +13,7 @@
       display: none;
       left: -$sph-inner;
       margin-bottom: 0;
-      padding: $spv-inner $sph-inner;
+      padding: $spv-inner--small $sph-inner;
       position: absolute;
       text-align: left;
       text-decoration: initial;

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -11,9 +11,9 @@
       border-radius: $border-radius;
       color: $color-x-light;
       display: none;
-      left: -$sph-intra;
+      left: -$sph-inner;
       margin-bottom: 0;
-      padding: $spv-intra $sph-intra;
+      padding: $spv-inner $sph-inner;
       position: absolute;
       text-align: left;
       text-decoration: initial;
@@ -31,7 +31,7 @@
         bottom: 100%;
         content: '';
         height: 0;
-        left: $sph-intra;
+        left: $sph-inner;
         pointer-events: none;
         position: absolute;
         width: 0;
@@ -66,13 +66,13 @@
       .p-tooltip__message {
         bottom: inherit;
         left: initial;
-        right: -$sph-intra;
+        right: -$sph-inner;
         top: 100%;
         transform: translateY(13px);
 
         &::before {
           left: initial;
-          right: $sph-intra;
+          right: $sph-inner;
         }
       }
     }
@@ -81,7 +81,7 @@
     &--top-left {
       .p-tooltip__message {
         bottom: 100%;
-        left: -$sph-intra;
+        left: -$sph-inner;
         top: initial;
         transform: translateX(0%) translateY(-13px);
 
@@ -92,8 +92,8 @@
             right: 8px solid transparent;
             top: 8px solid $color-dark;
           }
-          bottom: -$sph-intra;
-          left: $sph-intra;
+          bottom: -$sph-inner;
+          left: $sph-inner;
         }
       }
     }
@@ -113,7 +113,7 @@
             right: 8px solid transparent;
             top: 8px solid $color-dark;
           }
-          bottom: -$sph-intra;
+          bottom: -$sph-inner;
           left: 50%;
           transform: translateX(-50%);
         }
@@ -125,7 +125,7 @@
       .p-tooltip__message {
         bottom: 100%;
         left: initial;
-        right: -$sph-intra;
+        right: -$sph-inner;
         top: initial;
         transform: translateX(0%) translateY(-13px);
 
@@ -136,9 +136,9 @@
             right: 8px solid transparent;
             top: 8px solid $color-dark;
           }
-          bottom: -$sph-intra;
+          bottom: -$sph-inner;
           left: initial;
-          right: $sph-intra;
+          right: $sph-inner;
         }
       }
     }

--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -1,5 +1,5 @@
 // Global grid settings
-$grid-margin-width: $sph-outer--expanded !default;
+$grid-margin-width: $sph-outer--large !default;
 $grid-columns: 12 !default;
 $grid-gutter-column-ratio: 1.61803398875 !default; // golden ratio
 $grid-gutter-width: 100% / ($grid-columns * $grid-gutter-column-ratio + ($grid-columns - 1)) !default; // gutter expressed as percentage of full width

--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -1,5 +1,5 @@
 // Global grid settings
-$grid-margin-width: $sph-inter--expanded !default;
+$grid-margin-width: $sph-outer--expanded !default;
 $grid-columns: 12 !default;
 $grid-gutter-column-ratio: 1.61803398875 !default; // golden ratio
 $grid-gutter-width: 100% / ($grid-columns * $grid-gutter-column-ratio + ($grid-columns - 1)) !default; // gutter expressed as percentage of full width

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -49,12 +49,12 @@ $spv-nudge-compensation: $sp-unit - $spv-nudge !default;
 
 // 1. VERTICAL SPACING
 // 1.1 Vertical spacing inside components
-$spv-intra--condensed: $sp-unit * 0.5 !default; // buttons margins inside table,
-$spv-intra--condensed--scaleable: $spv-intra--condensed * $multi !default;
-$spv-intra: $sp-unit !default;
-$spv-intra--regular: $sp-unit * 2;
-$spv-intra--scaleable: $spv-intra * $multi !default;
-$spv-intra--expanded: $spv-intra * 1.5 !default; //vertical padding in: navigation, tabs
+$spv-inner--condensed: $sp-unit * 0.5 !default; // buttons margins inside table,
+$spv-inner--condensed--scaleable: $spv-inner--condensed * $multi !default;
+$spv-inner: $sp-unit !default;
+$spv-inner--regular: $sp-unit * 2;
+$spv-inner--scaleable: $spv-inner * $multi !default;
+$spv-inner--expanded: $spv-inner * 1.5 !default; //vertical padding in: navigation, tabs
 
 // 1.2 Vertical spacing between components
 $spv-inter--condensed: $sp-unit * 1 !default; //labels
@@ -69,11 +69,11 @@ $spv-inter--deep-scaleable: $sp-unit * 2 * (4 + $multi) !default;
 
 // 2. HORIZONTAL SPACING
 // 2.1 Horizontal spacing inside components
-$sph-intra--condensed: $sp-unit !default; // input-elements,
-$sph-intra: $sp-unit * 2 !default; // buttons, accordions, tabs, menu, card padding, stepped-list bullet offset
-$sph-intra--expanded: $sp-unit * 3 !default;
+$sph-inner--condensed: $sp-unit !default; // input-elements,
+$sph-inner: $sp-unit * 2 !default; // buttons, accordions, tabs, menu, card padding, stepped-list bullet offset
+$sph-inner--expanded: $sp-unit * 3 !default;
 // 2.2 Horizontal spacing outside components
-$sph-inter: $sph-intra !default;
+$sph-inter: $sph-inner !default;
 $sph-inter--expanded: $sp-unit * 3 !default; // checboxes, radios, list bullets
 
 $sp-before: (

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -49,17 +49,17 @@ $spv-nudge-compensation: $sp-unit - $spv-nudge !default;
 
 // 1. VERTICAL SPACING
 // 1.1 Vertical spacing inside components
-$spv-inner--condensed: $sp-unit * 0.5 !default; // buttons margins inside table,
-$spv-inner--condensed--scaleable: $spv-inner--condensed * $multi !default;
-$spv-inner: $sp-unit !default;
-$spv-inner--regular: $sp-unit * 2;
-$spv-inner--scaleable: $spv-inner * $multi !default;
-$spv-inner--expanded: $spv-inner * 1.5 !default; //vertical padding in: navigation, tabs
+$spv-inner--x-small: $sp-unit * 0.5 !default; // buttons margins inside table,
+$spv-inner--x-small--scaleable: $spv-inner--x-small * $multi !default;
+$spv-inner--small: $sp-unit !default;
+$spv-inner--medium: $sp-unit * 2;
+$spv-inner--scaleable: $spv-inner--small * $multi !default;
+$spv-inner--large: $spv-inner--small * 1.5 !default; //vertical padding in: navigation, tabs
 
 // 1.2 Vertical spacing between components
-$spv-outer--condensed: $sp-unit * 1 !default; //labels
-$spv-outer--condensed-scaleable: $sp-unit * $multi !default;
-$spv-outer--regular: $sp-unit * 2 !default;
+$spv-outer--small: $sp-unit * 1 !default; //labels
+$spv-outer--small-scaleable: $sp-unit * $multi !default;
+$spv-outer--medium: $sp-unit * 2 !default;
 $spv-outer--scaleable: $sp-unit * (1 + $multi) !default;
 
 // 1.3 Vertical spacing between a group of components and its wrapper - strips, views, entire page
@@ -71,10 +71,10 @@ $spv-outer--deep-scaleable: $sp-unit * 2 * (4 + $multi) !default;
 // 2.1 Horizontal spacing inside components
 $sph-inner--condensed: $sp-unit !default; // input-elements,
 $sph-inner: $sp-unit * 2 !default; // buttons, accordions, tabs, menu, card padding, stepped-list bullet offset
-$sph-inner--expanded: $sp-unit * 3 !default;
+$sph-inner--large: $sp-unit * 3 !default;
 // 2.2 Horizontal spacing outside components
 $sph-outer: $sph-inner !default;
-$sph-outer--expanded: $sp-unit * 3 !default; // checboxes, radios, list bullets
+$sph-outer--large: $sp-unit * 3 !default; // checboxes, radios, list bullets
 
 $sp-before: (
   h1: $sp-unit * 3,

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -69,7 +69,7 @@ $spv-outer--deep-scaleable: $sp-unit * 2 * (4 + $multi) !default;
 
 // 2. HORIZONTAL SPACING
 // 2.1 Horizontal spacing inside components
-$sph-inner--condensed: $sp-unit !default; // input-elements,
+$sph-inner--small: $sp-unit !default; // input-elements,
 $sph-inner: $sp-unit * 2 !default; // buttons, accordions, tabs, menu, card padding, stepped-list bullet offset
 $sph-inner--large: $sp-unit * 3 !default;
 // 2.2 Horizontal spacing outside components

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -57,15 +57,15 @@ $spv-inner--scaleable: $spv-inner * $multi !default;
 $spv-inner--expanded: $spv-inner * 1.5 !default; //vertical padding in: navigation, tabs
 
 // 1.2 Vertical spacing between components
-$spv-inter--condensed: $sp-unit * 1 !default; //labels
-$spv-inter--condensed-scaleable: $sp-unit * $multi !default;
-$spv-inter--regular: $sp-unit * 2 !default;
-$spv-inter--scaleable: $sp-unit * (1 + $multi) !default;
+$spv-outer--condensed: $sp-unit * 1 !default; //labels
+$spv-outer--condensed-scaleable: $sp-unit * $multi !default;
+$spv-outer--regular: $sp-unit * 2 !default;
+$spv-outer--scaleable: $sp-unit * (1 + $multi) !default;
 
 // 1.3 Vertical spacing between a group of components and its wrapper - strips, views, entire page
-$spv-inter--shallow-scaleable: $sp-unit * 2 * $multi !default;
-$spv-inter--regular-scaleable: $sp-unit * 2 * (2 + $multi) !default;
-$spv-inter--deep-scaleable: $sp-unit * 2 * (4 + $multi) !default;
+$spv-outer--shallow-scaleable: $sp-unit * 2 * $multi !default;
+$spv-outer--regular-scaleable: $sp-unit * 2 * (2 + $multi) !default;
+$spv-outer--deep-scaleable: $sp-unit * 2 * (4 + $multi) !default;
 
 // 2. HORIZONTAL SPACING
 // 2.1 Horizontal spacing inside components
@@ -73,8 +73,8 @@ $sph-inner--condensed: $sp-unit !default; // input-elements,
 $sph-inner: $sp-unit * 2 !default; // buttons, accordions, tabs, menu, card padding, stepped-list bullet offset
 $sph-inner--expanded: $sp-unit * 3 !default;
 // 2.2 Horizontal spacing outside components
-$sph-inter: $sph-inner !default;
-$sph-inter--expanded: $sp-unit * 3 !default; // checboxes, radios, list bullets
+$sph-outer: $sph-inner !default;
+$sph-outer--expanded: $sp-unit * 3 !default; // checboxes, radios, list bullets
 
 $sp-before: (
   h1: $sp-unit * 3,

--- a/scss/_utilities_baseline-grid.scss
+++ b/scss/_utilities_baseline-grid.scss
@@ -23,9 +23,9 @@
     }
 
     &__toggle {
-      bottom: $spv-inter--scaleable;
+      bottom: $spv-outer--scaleable;
       position: fixed;
-      right: $sph-inter--expanded;
+      right: $sph-outer--expanded;
       z-index: 101;
     }
   }

--- a/scss/_utilities_baseline-grid.scss
+++ b/scss/_utilities_baseline-grid.scss
@@ -25,7 +25,7 @@
     &__toggle {
       bottom: $spv-outer--scaleable;
       position: fixed;
-      right: $sph-outer--expanded;
+      right: $sph-outer--large;
       z-index: 101;
     }
   }

--- a/scss/_utilities_embedded-media.scss
+++ b/scss/_utilities_embedded-media.scss
@@ -4,7 +4,7 @@
 @mixin vf-u-embedded-media {
   .u-embedded-media {
     height: 0;
-    margin-top: $spv-inner;
+    margin-top: $spv-inner--small;
     max-width: 100%;
     overflow: hidden;
     padding-bottom: 56.25%;

--- a/scss/_utilities_embedded-media.scss
+++ b/scss/_utilities_embedded-media.scss
@@ -4,7 +4,7 @@
 @mixin vf-u-embedded-media {
   .u-embedded-media {
     height: 0;
-    margin-top: $spv-intra;
+    margin-top: $spv-inner;
     max-width: 100%;
     overflow: hidden;
     padding-bottom: 56.25%;


### PR DESCRIPTION
## Done

Renamed spacing variables based on various requests for simplification and memorability.

The changes mostly follow these rules:
- Intra/Inter -> Inner/Outer
- Condensed -> Small / x-small (depends how it's used and if there are multiple levels)
- Expanded -> Large
- Regular -> Medium
- (unmodified) -> Medium

I've kept the `--scaleable` modifier, which is chained with the other sizes.

One exception to the S/M/L rule is the vertical outer spacing which uses shallow/deep to keep in line with the p-strip (and elsewhere) terminology

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- See that everything is the same

## Details

Fixes #2100 
Fixes #2140 
Fixes #1923