### PR TITLE
Remove media query so that .u-vertically-center works at all viewports

### DIFF
--- a/scss/_utilities_vertically-center.scss
+++ b/scss/_utilities_vertically-center.scss
@@ -2,14 +2,12 @@
 
 // Vertically align
 @mixin vf-u-vertically-center {
-  @media (min-width: $breakpoint-medium) {
-    .u-vertically-center {
-      align-items: center !important;
-      display: flex !important;
+  .u-vertically-center {
+    align-items: center !important;
+    display: flex !important;
 
-      > img {
-        align-self: center !important;
-      }
+    > img {
+      align-self: center !important;
     }
   }
 }


### PR DESCRIPTION
## Done

Remove media query so that .u-vertically-center works at all viewports

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/utilities/vertically-center/
- Resize to a mobile viewport and see that the example is vertically centred

## Details

Fixes #2132