### PR TITLE
Add max-width to <label> elements

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -158,4 +158,8 @@
     cursor: help;
     text-decoration: none;
   }
+
+  label {
+    @include p-max-width;
+  }
 }


### PR DESCRIPTION
## Done

Added the paragraph max width to labels for consistency in typographic elements.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/forms/form-help-text/
- Inspect the element and add enough words for the label to wrap
- See that it's now wrapping sooner

## Details
Fixes #2154 