### PR TITLE
Remove  $px  var in preparation for font-size change

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -19,7 +19,7 @@
     font-weight: 300;
     line-height: map-get($line-heights, default-text);
     margin-bottom: $spv-outer--scaleable + 2 * $spv-nudge-compensation;
-    padding: $spv-nudge - $px $sph-inner--small * 1.5;
+    padding: calc(#{$spv-nudge} - 1px) $sph-inner--small * 1.5;
     text-align: center;
     text-decoration: none;
 
@@ -49,8 +49,8 @@
 
     table & {
       margin-bottom: $spv-nudge-compensation;
-      padding-bottom: $spv-nudge - $sp-unit * 0.5 - $px;
-      padding-top: $spv-nudge - $sp-unit * 0.5 - $px;
+      padding-bottom: calc(#{$spv-nudge - $sp-unit * 0.5} - 1px);
+      padding-top: calc(#{$spv-nudge - $sp-unit * 0.5} - 1px);
     }
 
     // The following three rules address buttons nested in <p>'s;

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -6,8 +6,8 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
   // Used in buttons, inputs
   %bordered-text-vertical-padding {
     margin-bottom: $input-margin-bottom;
-    padding-bottom: $spv-nudge - $px;
-    padding-top: $spv-nudge - $px;
+    padding-bottom: calc(#{$spv-nudge} - 1px);
+    padding-top: calc(#{$spv-nudge} - 1px);
   }
 
   // Default form input element styles
@@ -33,8 +33,8 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
 
     table & {
       margin: 0 0 ($spv-inner--small - $spv-nudge) 0;
-      padding-bottom: ($spv-nudge - $px) - $spv-inner--x-small;
-      padding-top: ($spv-nudge - $px) - $spv-inner--x-small;
+      padding-bottom: calc(#{$spv-nudge - $spv-inner--x-small} - 1px);
+      padding-top: calc(#{$spv-nudge - $spv-inner--x-small} - 1px);
     }
 
     &:active {
@@ -74,7 +74,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     $box-size: 1rem;
     $box-offset-top: $spv-inner--x-small;
     $label-offset--left: $sph-inner + $box-size;
-    $tick-offset-top: $box-offset-top + 3 * $px;
+    $tick-offset-top: calc(#{$box-offset-top} + 0.1875rem);
     opacity: 0;
     position: absolute;
 
@@ -223,11 +223,11 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
         border-bottom: 2px solid;
         border-left: 2px solid;
         color: $color-x-light;
-        height: 6px;
-        left: 3px;
+        height: 0.375rem;
+        left: 0.1875rem;
         top: $sp-unit;
         transform: rotate(-45deg);
-        width: 10px;
+        width: 0.625rem;
       }
     }
 
@@ -248,10 +248,10 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
       &::after {
         background-color: $color-information;
         border-radius: 50%;
-        height: 10px;
-        left: 3px;
-        top: 7px;
-        width: 10px;
+        height: 0.65rem;
+        left: 0.1875rem;
+        top: 0.4375rem;
+        width: 0.65rem;
       }
     }
   }
@@ -299,7 +299,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
 
       option {
         font-weight: 300;
-        line-height: $sp-unit * 2 - 2 * $px;
+        line-height: calc(#{$sp-unit * 2} - 2px);
         padding: $spv-inner--small $sph-inner--small;
       }
     }

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -6,7 +6,7 @@
     background-color: $color-mid-light;
     border: 0;
     height: 1px;
-    margin-bottom: $spv-inner--scaleable - $px;
+    margin-bottom: calc(#{$spv-inner--scaleable} - 1px);
     margin-top: 0;
     position: relative;
     width: 100%;
@@ -23,7 +23,7 @@
       background: $color-mid-light;
       content: '';
       height: 1px;
-      margin-bottom: $spv-inner--scaleable - $px;
+      margin-bottom: calc(#{$spv-inner--scaleable} - 1px);
       width: 100%;
     }
   }

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -38,7 +38,7 @@
   %vf-pseudo-border {
     background-color: $color-mid-light;
     content: '';
-    height: $px;
+    height: 1px;
     left: 0;
     position: absolute;
     right: 0;

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -49,7 +49,7 @@
 
   //accordion, table
   %single-border-text-vpadding--scaling {
-    padding-bottom: $spv-inner--x-small--scaleable - $px;
+    padding-bottom: calc(#{$spv-inner--x-small--scaleable} - 1px);
     padding-top: $spv-inner--x-small--scaleable;
   }
 }

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -24,9 +24,8 @@
       @include vf-focus;
 
       $calculated-height: $multi * $spv-inner--x-small * 2 + map-get($line-heights, default-text);
-      $offset-top: calc(#{($calculated-height - $icon-size) * 0.5} - 1px);
       background: {
-        position: top $offset-top right $sph-inner;
+        position: top 50% right $sph-inner;
         repeat: no-repeat;
       }
       background-color: inherit;

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -23,8 +23,8 @@
       @extend %single-border-text-vpadding--scaling;
       @include vf-focus;
 
-      $calculated-height: $multi * $spv-inner--x-small * 2 - $px + map-get($line-heights, default-text);
-      $offset-top: ($calculated-height - $icon-size) * 0.5;
+      $calculated-height: $multi * $spv-inner--x-small * 2 + map-get($line-heights, default-text);
+      $offset-top: calc(#{($calculated-height - $icon-size) * 0.5} - 1px);
       background: {
         position: top $offset-top right $sph-inner;
         repeat: no-repeat;

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -150,8 +150,8 @@
     & [class*='p-icon'] {
       // Apply negative margins to make textless button icon a square
       &:only-child {
-        margin-left: -($px * 2);
-        margin-right: -($px * 2);
+        margin-left: -2px;
+        margin-right: -2px;
       }
 
       + * {

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -13,7 +13,7 @@
     @extend %vf-card;
     @extend %vf-is-bordered;
     @extend %vf-has-round-corners;
-    padding: $spv-inner--medium - $px;
+    padding: calc(#{$spv-inner--medium} - 1px);
   }
 }
 

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -1,7 +1,7 @@
 @import 'settings';
 @import 'patterns_icons';
 
-$cc-button-size: 36 * $px;
+$cc-button-size: 36px;
 
 @mixin vf-p-code-copyable {
   .p-code-copyable {
@@ -22,7 +22,7 @@ $cc-button-size: 36 * $px;
       color: $color-mid-dark;
       font-family: unquote($font-monospace);
       line-height: map-get($line-heights, default-text);
-      padding: 0 $cc-button-size + $sph-inner--small 0 $sph-inner * 1.5;
+      padding: 0 calc(#{$cc-button-size} + #{$sph-inner--small}) 0 $sph-inner * 1.5;
       width: 100%;
     }
 
@@ -32,7 +32,7 @@ $cc-button-size: 36 * $px;
       display: block;
       left: 0;
       line-height: map-get($line-heights, default-text);
-      padding: 0 $cc-button-size + $sph-inner--small 0 $sph-inner--small;
+      padding: 0 calc(#{$cc-button-size} + #{$sph-inner--small}) 0 $sph-inner--small;
       position: absolute;
       top: $spv-inner--x-small;
       width: 1rem;

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -63,7 +63,7 @@
     }
 
     &__toggle {
-      margin-bottom: $spv-inner--small;
+      margin-bottom: $spv-inner--small + ($spv-nudge-compensation * 2);
     }
 
     &__link {

--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -12,7 +12,7 @@
 
         &:not(:first-child) {
           border-top: 1px solid $color-mid-light;
-          padding-top: $spv-inner--scaleable - $px; // border compensation
+          padding-top: calc(#{$spv-inner--scaleable} - 1px); // border compensation
         }
       }
 

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -98,12 +98,13 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
 
 // Displays item with a tick bullet
 @mixin vf-p-list-item-state {
-  $bg-pos-y: if($pad-lists, $spv-list-item--inner + (map-get($line-heights, default-text) - $tick-height) * 0.5, (map-get($line-heights, default-text) - $tick-height) * 0.5);
+  $bg-pos-y: ($tick-height + if($pad-lists, $spv-list-item--inner, 0)) * 0.5;
 
   .is-ticked {
     background-image: svg-tick($color-accent);
     background-position-y: $bg-pos-y;
     background-repeat: no-repeat;
+    background-size: $tick-height;
     padding-left: 2rem;
   }
 }

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -18,7 +18,7 @@
       display: flex;
       flex: 1 1 auto;
       padding-bottom: $spv-inner--scaleable;
-      padding-top: $spv-inner--scaleable - $px;
+      padding-top: calc(#{$spv-inner--scaleable} - 1px);
 
       @media (min-width: $breakpoint-small) {
         display: flex;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -1,6 +1,6 @@
 @import 'settings';
 
-$nav-border-bottom-thickness: $px;
+$nav-border-bottom-thickness: 1px;
 
 // Default header styling
 @mixin vf-p-navigation {

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -1,6 +1,6 @@
 // Global placeholder settings
 
-$bar-thickness: $px * 3 !default;
+$bar-thickness: 3px !default;
 $border-radius: $sp-unit * 0.25 !default;
-$border: $px solid $color-mid-light !default;
+$border: 1px solid $color-mid-light !default;
 $box-shadow: 0 1px 5px 1px transparentize($color-dark, 0.8) !default;

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -8,7 +8,6 @@ $sp-unit-ratio: 0.5 !default;
 
 // Baseline grid settings
 $sp-unit: 1rem * $sp-unit-ratio !default;
-$px: 0.0625rem !default; // 1px as rem; useful in calculations where sizes are defined in rems.
 
 $line-heights: (
   h1: 7 * $sp-unit,

--- a/scss/_utilities_vertical-spacing.scss
+++ b/scss/_utilities_vertical-spacing.scss
@@ -5,7 +5,7 @@
   %u-vertical-spacer {
     content: '';
     display: block;
-    height: $px; // needed so any margin applied is taken as part of the flow
+    height: 1px; // needed so any margin applied is taken as part of the flow
     position: relative;
   }
 
@@ -19,7 +19,7 @@
         // For predictable results, use single margin direction (https://csswizardry.com/2012/06/single-direction-margin-declarations/)
         // From vanilla 1.7 forward, margin direction is bottom.
 
-        margin-top: $sp-unit * $i - $px; // subtracting the element height, which is set to 1px above.
+        margin-top: calc(#{$sp-unit * $i} - 1px); // subtracting the element height, which is set to 1px above.
       }
     }
   }


### PR DESCRIPTION
## Done

To be able to change the :root font-size on a breakpoint, we need to remove any variables that assume 1 rem is a constant value. This is because any calculations will be wrong once that value changes from 16 to e.g. 18.

In our case, the only such variable is $px, which is used where the presence of a bordr shouldn't ypset the vertical rhythm. E.g. the padding on a button is calculated as
```{padding top in rems} -  $px, where $px is .0625rem (1/16 of a rem)```

This pr changes these calculations to:
```calc(#{rem-value} - 1px)```

[List of work items including drive-bys]
In some places as in the checkbox, px values are converted to rem values, so they scale properly as well.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Verify nothing looks broken

## Details

This takes care of https://github.com/ubuntudesign/vanilla-squad/issues/510 and a small subset of https://github.com/ubuntudesign/vanilla-squad/issues/509