### PR TITLE
Add optional font-size increase on a breakpoint

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -320,6 +320,6 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     border-radius: $border-radius;
     color: $color-dark;
     margin-bottom: $spv-outer--scaleable;
-    padding: $spv-inner--small $sph-inner--small;
+    padding: calc(#{$spv-inner--small} - 1px) $sph-inner--small;
   }
 }

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -3,13 +3,9 @@
 
   %vf-heading-1 {
     @include heading-max-width--short;
-    font-size: pow($ms-ratio, 8) * 1rem;
     font-style: normal;
     font-weight: 100;
-    line-height: map-get($line-heights, h1);
-    margin-bottom: map-get($sp-after, h1) - map-get($nudges, nudge--h1);
     margin-top: -#{$sp-unit};
-    padding-top: map-get($nudges, nudge--h1);
 
     @media (max-width: $breakpoint-heading-threshold) {
       font-size: pow($ms-ratio, 6) * 1rem;
@@ -17,23 +13,43 @@
       margin-bottom: map-get($sp-after, h1-mobile) - map-get($nudges, nudge--h1-mobile);
       padding-top: map-get($nudges, nudge--h1-mobile);
     }
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      font-size: pow($ms-ratio, 8) * 1rem;
+      line-height: map-get($line-heights, h1);
+    }
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      margin-bottom: map-get($sp-after, h1) - map-get($nudges, nudge--h1);
+      padding-top: map-get($nudges, nudge--h1);
+    }
+
+    @if ($increase-fontsize-on-bigger-screens) {
+      @media (min-width: $breakpoint-x-large) {
+        margin-bottom: map-get($sp-after, h1) - map-get($nudges, nudge--h1-large);
+        padding-top: map-get($nudges, nudge--h1-large);
+      }
+    }
   }
 
   %vf-heading-2 {
     @include heading-max-width--short;
-    font-size: pow($ms-ratio, 6) * 1rem;
     font-style: normal;
     font-weight: 100;
-    line-height: map-get($line-heights, h2);
-    margin-bottom: map-get($sp-after, h2) - map-get($nudges, nudge--h2);
     margin-top: -#{$sp-unit};
-    padding-top: map-get($nudges, nudge--h2);
 
     @media (max-width: $breakpoint-heading-threshold) {
       font-size: 1.83274rem; // pow($ms-ratio, 4.5) * 1rem
       line-height: map-get($line-heights, h2-mobile);
       margin-bottom: map-get($sp-after, h2-mobile) - map-get($nudges, nudge--h2-mobile);
       padding-top: map-get($nudges, nudge--h2-mobile);
+    }
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      font-size: pow($ms-ratio, 6) * 1rem;
+      line-height: map-get($line-heights, h2);
+      margin-bottom: map-get($sp-after, h2) - map-get($nudges, nudge--h2);
+      padding-top: map-get($nudges, nudge--h2);
     }
   }
 
@@ -57,13 +73,9 @@
 
   %vf-heading-4 {
     @include heading-max-width--long;
-    font-size: pow($ms-ratio, 2) * 1rem;
     font-style: normal;
     font-weight: 300;
-    line-height: map-get($line-heights, h4);
-    margin-bottom: map-get($sp-after, h4) - map-get($nudges, nudge--h4);
     margin-top: 0;
-    padding-top: map-get($nudges, nudge--h4);
 
     @media (max-width: $breakpoint-heading-threshold) {
       font-size: 1.22176rem; // pow($ms-ratio, 1.5) * 1rem
@@ -71,11 +83,28 @@
       margin-bottom: map-get($sp-after, h4-mobile) - map-get($nudges, nudge--h4-mobile);
       padding-top: map-get($nudges, nudge--h4-mobile);
     }
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      font-size: pow($ms-ratio, 2) * 1rem;
+      line-height: map-get($line-heights, h4);
+    }
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      margin-bottom: map-get($sp-after, h4) - map-get($nudges, nudge--h4);
+      padding-top: map-get($nudges, nudge--h4);
+    }
+
+    @if ($increase-fontsize-on-bigger-screens) {
+      @media (min-width: $breakpoint-x-large) {
+        margin-bottom: map-get($sp-after, h4) - map-get($nudges, nudge--h4-large);
+        padding-top: map-get($nudges, nudge--h4-large);
+      }
+    }
   }
 
   %vf-heading-5 {
     @include p-max-width;
-    font-size: $font-base-size;
+    font-size: 1em;
     font-style: normal;
     font-weight: 500;
     line-height: map-get($line-heights, default-text);
@@ -86,7 +115,7 @@
 
   %vf-heading-6 {
     @include p-max-width;
-    font-size: $font-base-size;
+    font-size: 1em;
     font-style: italic;
     font-weight: 300;
     line-height: map-get($line-heights, default-text);
@@ -119,6 +148,7 @@
     color: $color-mid-dark;
     margin-bottom: map-get($sp-after, small) - map-get($nudges, nudge--small);
     margin-top: 0;
+    padding-top: map-get($nudges, nudge--small);
     text-transform: uppercase;
   }
 
@@ -146,15 +176,23 @@
   }
 
   %sp--ph3 {
-    padding-top: map-get($nudges, nudge--h3) + map-get($sp-before, h3);
-
     @media (max-width: $breakpoint-heading-threshold) {
       padding-top: map-get($nudges, nudge--h3-mobile) + map-get($sp-before, h3-mobile);
+    }
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      padding-top: map-get($nudges, nudge--h3) + map-get($sp-before, h3);
     }
   }
 
   %sp--ph4 {
-    padding-top: map-get($nudges, nudge--h4) + map-get($sp-before, h4);
+    @media (max-width: $breakpoint-heading-threshold) {
+      padding-top: map-get($nudges, nudge--h4-mobile) + map-get($sp-before, h4);
+    }
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      padding-top: map-get($nudges, nudge--h4) + map-get($sp-before, h4);
+    }
   }
 
   %sp--ph5 {

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -17,9 +17,6 @@
     @media (min-width: $breakpoint-heading-threshold) {
       font-size: pow($ms-ratio, 8) * 1rem;
       line-height: map-get($line-heights, h1);
-    }
-
-    @media (min-width: $breakpoint-heading-threshold) {
       margin-bottom: map-get($sp-after, h1) - map-get($nudges, nudge--h1);
       padding-top: map-get($nudges, nudge--h1);
     }
@@ -87,9 +84,6 @@
     @media (min-width: $breakpoint-heading-threshold) {
       font-size: pow($ms-ratio, 2) * 1rem;
       line-height: map-get($line-heights, h4);
-    }
-
-    @media (min-width: $breakpoint-heading-threshold) {
       margin-bottom: map-get($sp-after, h4) - map-get($nudges, nudge--h4);
       padding-top: map-get($nudges, nudge--h4);
     }
@@ -104,7 +98,7 @@
 
   %vf-heading-5 {
     @include p-max-width;
-    font-size: 1em;
+    font-size: 1rem;
     font-style: normal;
     font-weight: 500;
     line-height: map-get($line-heights, default-text);
@@ -115,7 +109,7 @@
 
   %vf-heading-6 {
     @include p-max-width;
-    font-size: 1em;
+    font-size: 1rem;
     font-style: italic;
     font-weight: 300;
     line-height: map-get($line-heights, default-text);

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -18,13 +18,26 @@
     // sass-lint:enable no-vendor-prefixes
     color: $color-dark;
     font-family: unquote($font-base-family);
-    font-size: $font-base-size;
     // sass-lint:disable no-misspelled-properties
     font-smoothing: subpixel-antialiased;
     // sass-lint:enable no-misspelled-properties
     font-weight: 300;
     // set default line height to match p
     line-height: map-get($line-heights, default-text);
+
+    @if ($increase-fontsize-on-bigger-screens) {
+      @media screen and (max-width: $breakpoint-x-large) {
+        font-size: map-get($fontsizes, base);
+      }
+
+      @media screen and (min-width: $breakpoint-x-large) {
+        font-size: map-get($fontsizes, big);
+        //the rem value is not affected by the change in font-size; it needs to be multiplied by the ratio new font-size/default font-size
+        line-height: map-get($line-heights, default-text) * $fontsize-ratio--largescreen;
+      }
+    } @else {
+      font-size: map-get($fontsizes, base);
+    }
   }
 
   // headings

--- a/scss/_patterns_article-pagination.scss
+++ b/scss/_patterns_article-pagination.scss
@@ -4,7 +4,7 @@
   %chevron-icon {
     color: $color-mid-dark;
     content: '\203A';
-    font-size: 2rem;
+    font-size: 2em;
     position: absolute;
     top: 1rem;
   }
@@ -83,10 +83,10 @@
     }
 
     &__title {
-      font-size: 1.125rem;
+      font-size: 1.125em;
 
       @media (min-width: $breakpoint-small) {
-        font-size: 1.25rem;
+        font-size: 1.25em;
       }
     }
   }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -98,11 +98,9 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
 
 // Displays item with a tick bullet
 @mixin vf-p-list-item-state {
-  $bg-pos-y: ($tick-height + if($pad-lists, $spv-list-item--inner, 0)) * 0.5;
-
   .is-ticked {
     background-image: svg-tick($color-accent);
-    background-position-y: $bg-pos-y;
+    background-position-y: 56%;
     background-repeat: no-repeat;
     background-size: $tick-height;
     padding-left: 2rem;

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -100,7 +100,7 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
 @mixin vf-p-list-item-state {
   .is-ticked {
     background-image: svg-tick($color-accent);
-    background-position-y: 56%;
+    background-position-y: 56%; // slightly off-center to align better with text.
     background-repeat: no-repeat;
     background-size: $tick-height;
     padding-left: 2rem;

--- a/scss/_settings_breakpoints.scss
+++ b/scss/_settings_breakpoints.scss
@@ -5,4 +5,4 @@ $breakpoint-medium: 772px !default;
 $breakpoint-large: 1036px !default;
 $breakpoint-navigation-threshold: $breakpoint-medium !default;
 $breakpoint-heading-threshold: $breakpoint-medium !default;
-$breakpoint-x-large: 1280px !default;
+$breakpoint-x-large: 1680px !default;

--- a/scss/_settings_breakpoints.scss
+++ b/scss/_settings_breakpoints.scss
@@ -5,4 +5,4 @@ $breakpoint-medium: 772px !default;
 $breakpoint-large: 1036px !default;
 $breakpoint-navigation-threshold: $breakpoint-medium !default;
 $breakpoint-heading-threshold: $breakpoint-medium !default;
-$breakpoint-x-large: 1440px; //speculative threshold between laptops and desktop screens that sit further away from the viewer; used to increase root font size
+$breakpoint-x-large: 1280px !default;

--- a/scss/_settings_breakpoints.scss
+++ b/scss/_settings_breakpoints.scss
@@ -5,3 +5,4 @@ $breakpoint-medium: 772px !default;
 $breakpoint-large: 1036px !default;
 $breakpoint-navigation-threshold: $breakpoint-medium !default;
 $breakpoint-heading-threshold: $breakpoint-medium !default;
+$breakpoint-x-large: 1440px; //speculative threshold between laptops and desktop screens that sit further away from the viewer; used to increase root font size

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -4,8 +4,8 @@ $font-monospace: '"Ubuntu Mono", Consolas, Monaco, Courier, monospace' !default;
 $font-heading-family: $font-base-family !default;
 $font-import: 'http://fonts.gstatic.com/s/ubuntu/v9/' !default;
 $font-allow-cyrillic-greek-latin: false !default;
-$increase-fontsize-on-bigger-screens: true;
-$fontsize-ratio--largescreen: 1.125;
+$increase-fontsize-on-bigger-screens: true !default;
+$fontsize-ratio--largescreen: 1.125 !default;
 $fontsize-largescreen: 1rem * $fontsize-ratio--largescreen;
 $fontsizes: (
   base: 16px,

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -1,7 +1,13 @@
 // Global font settings
 $font-base-family: '"Ubuntu", -apple-system, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif' !default;
 $font-monospace: '"Ubuntu Mono", Consolas, Monaco, Courier, monospace' !default;
-$font-base-size: 16px !default;
 $font-heading-family: $font-base-family !default;
 $font-import: 'http://fonts.gstatic.com/s/ubuntu/v9/' !default;
 $font-allow-cyrillic-greek-latin: false !default;
+$increase-fontsize-on-bigger-screens: true;
+$fontsize-ratio--largescreen: 1.125;
+$fontsize-largescreen: 1rem * $fontsize-ratio--largescreen;
+$fontsizes: (
+  base: 16px,
+  big: $fontsize-largescreen
+) !default;

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -103,7 +103,7 @@ $sp-after: (
   h1-mobile: $sp-unit * 2,
   h2-mobile: $sp-unit * 2,
   h3-mobile: $sp-unit * 2,
-  h4-mobile: $sp-unit * 3,
+  h4-mobile: $sp-unit * 2,
   small: $sp-unit * 2,
   small--dense: $sp-unit * 2,
   default-text: $sp-unit

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -32,7 +32,7 @@ $nudges: (
   nudge--h4: 0.05rem,
   nudge--h1-mobile: 0.165rem,
   nudge--h2-mobile: 0.1rem,
-  nudge--h3-mobile: 0,
+  nudge--h3-mobile: 0.5rem,
   nudge--h4-mobile: 0.3rem,
   nudge--p: 0.4rem,
   nudge--small: 0.2rem

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -24,13 +24,15 @@ $line-heights: (
 
 // baseline nudges for type scale ratio of (16/14) squared
 $nudges: (
+  nudge--h1-large: 0.15rem,
+  nudge--h4-large: 0,
   nudge--h1: 0.2rem,
   nudge--h2: 0.2rem,
   nudge--h3: 0.1rem,
   nudge--h4: 0.05rem,
-  nudge--h1-mobile: 0.2rem,
+  nudge--h1-mobile: 0.165rem,
   nudge--h2-mobile: 0.1rem,
-  nudge--h3-mobile: 0.5rem,
+  nudge--h3-mobile: 0,
   nudge--h4-mobile: 0.3rem,
   nudge--p: 0.4rem,
   nudge--small: 0.2rem
@@ -101,7 +103,7 @@ $sp-after: (
   h1-mobile: $sp-unit * 2,
   h2-mobile: $sp-unit * 2,
   h3-mobile: $sp-unit * 2,
-  h4-mobile: $sp-unit * 2,
+  h4-mobile: $sp-unit * 3,
   small: $sp-unit * 2,
   small--dense: $sp-unit * 2,
   default-text: $sp-unit


### PR DESCRIPTION
## Done

• Add a flag to increase font-size at a given breakpoint (currently 1440px)
• Add nudge value adjustments to headings that require it at the bigger font-size (18px)

• [drive-by] Fix inaccurate mobile nudges for h1 and h3
• [drive-by] Add space-after to h4 on mobile consistent with other headings


## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
– QA both code and visually in percy

## Details
Implements https://github.com/ubuntudesign/vanilla-squad/issues/511

## Screenshots

[if relevant, include a screenshot]
