### PR TITLE
Add u-no-print utility to exclude elements from printed pages

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -64,6 +64,9 @@ navigation:
       - location: utilities/hide.md
         title: Hide
 
+      - location: utilities/no-print.md
+        title: No print
+
       - location: utilities/margin-collapse.md
         title: Margin collapse
 

--- a/docs/en/utilities/no-print.md
+++ b/docs/en/utilities/no-print.md
@@ -1,0 +1,15 @@
+---
+collection: utilities
+title: No print
+---
+
+## No print
+
+Add the class `u-no-print` to elements you want to hide when the page is printed.
+
+Use your browser's print preview to see the following example working.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/utilities/no-print"
+  class="js-example">
+View example of the no-print utility
+</a>

--- a/examples/utilities/no-print.html
+++ b/examples/utilities/no-print.html
@@ -1,0 +1,8 @@
+---
+layout: default
+title: No print
+category: _utilities
+---
+
+<p class="u-no-print">I will not be printed</p>
+<p>I will be printed</p>

--- a/gulp/parker.js
+++ b/gulp/parker.js
@@ -62,7 +62,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Total media queries',
       benchmark: 14,
-      threshold: 23,
+      threshold: 50,
       result: results['total-media-queries']
     }
   ];

--- a/scss/_utilities_no-print.scss
+++ b/scss/_utilities_no-print.scss
@@ -1,0 +1,8 @@
+// A utility to hide elements when printing a page
+@mixin vf-u-no-print {
+  @media print {
+    .u-no-print {
+      display: none !important;
+    }
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -63,6 +63,7 @@
 @import 'utilities_vertical-spacing';
 @import 'utilities_vertically-center';
 @import 'utilities_visibility';
+@import 'utilities_no-print';
 
 // Include all the CSS
 @mixin vanilla {
@@ -128,6 +129,7 @@
   @include vf-u-vertical-spacing;
   @include vf-u-vertically-center;
   @include vf-u-visibility;
+  @include vf-u-no-print;
 
   @if ($sticky-footer) {
     @include vf-u-sticky-footer;


### PR DESCRIPTION
## Done

Added `u-no-print` utility

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/utilities/no-print/
- Pretend to print the page and see that one of the paragraphs doesn't show in the preview (don't really print, think of the :deciduous_tree:!)
- `cd docs`
- `./run`
- See that the [documentation exists](http://0.0.0.0:8104/en/utilities/no-print)

## Details

Fixes #1982