### PR TITLE
Add local font of ‘Ubuntu’ to all font-face calls

### DIFF
--- a/scss/_base_fontfaces.scss
+++ b/scss/_base_fontfaces.scss
@@ -4,49 +4,49 @@
       font-family: 'Ubuntu';
       font-style: normal;
       font-weight: 300;
-      src: url('#{$assets-path}e8c07df6-Ubuntu-L_W.woff2') format('woff2'), url('#{$assets-path}8619add2-Ubuntu-L_W.woff') format('woff');
+      src: local('Ubuntu'), url('#{$assets-path}e8c07df6-Ubuntu-L_W.woff2') format('woff2'), url('#{$assets-path}8619add2-Ubuntu-L_W.woff') format('woff');
     }
 
     @font-face {
       font-family: 'Ubuntu';
       font-style: normal;
       font-weight: 400;
-      src: url('#{$assets-path}fff37993-Ubuntu-R_W.woff2') format('woff2'), url('#{$assets-path}7af50859-Ubuntu-R_W.woff') format('woff');
+      src: local('Ubuntu'), url('#{$assets-path}fff37993-Ubuntu-R_W.woff2') format('woff2'), url('#{$assets-path}7af50859-Ubuntu-R_W.woff') format('woff');
     }
 
     @font-face {
       font-family: 'Ubuntu';
       font-style: italic;
       font-weight: 300;
-      src: url('#{$assets-path}f8097dea-Ubuntu-LI_W.woff2') format('woff2'), url('#{$assets-path}8be89d02-Ubuntu-LI_W.woff') format('woff');
+      src: local('Ubuntu'), url('#{$assets-path}f8097dea-Ubuntu-LI_W.woff2') format('woff2'), url('#{$assets-path}8be89d02-Ubuntu-LI_W.woff') format('woff');
     }
 
     @font-face {
       font-family: 'Ubuntu';
       font-style: italic;
       font-weight: 400;
-      src: url('#{$assets-path}fca66073-ubuntu-ri-webfont.woff2') format('woff2'), url('#{$assets-path}f0898c72-ubuntu-ri-webfont.woff') format('woff');
+      src: local('Ubuntu'), url('#{$assets-path}fca66073-ubuntu-ri-webfont.woff2') format('woff2'), url('#{$assets-path}f0898c72-ubuntu-ri-webfont.woff') format('woff');
     }
 
     @font-face {
       font-family: 'Ubuntu';
       font-style: normal;
       font-weight: 100;
-      src: url('#{$assets-path}7f100985-Ubuntu-Th_W.woff2') format('woff2'), url('#{$assets-path}502cc3a1-Ubuntu-Th_W.woff') format('woff');
+      src: local('Ubuntu'), url('#{$assets-path}7f100985-Ubuntu-Th_W.woff2') format('woff2'), url('#{$assets-path}502cc3a1-Ubuntu-Th_W.woff') format('woff');
     }
 
     @font-face {
       font-family: 'Ubuntu Mono';
       font-style: normal;
       font-weight: 300;
-      src: url('#{$assets-path}fdd692b9-UbuntuMono-R_W.woff2') format('woff2'), url('#{$assets-path}85edb898-UbuntuMono-R_W.woff') format('woff');
+      src: local('Ubuntu'), url('#{$assets-path}fdd692b9-UbuntuMono-R_W.woff2') format('woff2'), url('#{$assets-path}85edb898-UbuntuMono-R_W.woff') format('woff');
     }
 
     @font-face {
       font-family: 'Ubuntu Mono';
       font-style: normal;
       font-weight: 400;
-      src: url('#{$assets-path}fdd692b9-UbuntuMono-R_W.woff2') format('woff2'), url('#{$assets-path}85edb898-UbuntuMono-R_W.woff') format('woff');
+      src: local('Ubuntu'), url('#{$assets-path}fdd692b9-UbuntuMono-R_W.woff2') format('woff2'), url('#{$assets-path}85edb898-UbuntuMono-R_W.woff') format('woff');
     }
 
     @if $font-allow-cyrillic-greek-latin {


### PR DESCRIPTION
https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization

## Done

Add local font of ‘Ubuntu’ to all font-face calls - many of our users will be running Ubuntu as their OS so will have Ubuntu already available to them.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Ensure no Percy changes