### PR TITLE
Fix pre and code white space (fixes #1986) and removes white space styling from <code> 

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -26,10 +26,6 @@
     // sass-lint:enable no-vendor-prefixes property-sort-order
   }
 
-  code {
-    display: inline;
-  }
-
   pre {
     background-color: $color-light;
     border: 1px solid $color-mid-light;
@@ -39,7 +35,7 @@
     margin-bottom: $spv-outer--scaleable;
     margin-top: 0;
     overflow: auto;
-    padding: $spv-inner--small $sph-inner;
+    padding: calc(#{map-get($nudges, nudge--p-ubuntumono)} - 1px) $sph-inner calc(#{map-get($nudges, nudge--p-ubuntumono)} - 1px);
     text-align: left;
     text-shadow: none;
   }

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -20,7 +20,6 @@
     -moz-tab-size: 4;
     -o-tab-size: 4;
     tab-size: 4;
-    white-space: pre-wrap;
     word-spacing: normal;
     word-wrap: break-word;
     // sass-lint:enable no-vendor-prefixes property-sort-order
@@ -38,5 +37,6 @@
     padding: calc(#{map-get($nudges, nudge--p-ubuntumono)} - 1px) $sph-inner calc(#{map-get($nudges, nudge--p-ubuntumono)} - 1px);
     text-align: left;
     text-shadow: none;
+    white-space: pre;
   }
 }

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -8,6 +8,7 @@
     font-family: unquote($font-monospace);
     font-weight: 300;
     text-align: left;
+
   }
 
   pre,
@@ -23,6 +24,14 @@
     word-spacing: normal;
     word-wrap: break-word;
     // sass-lint:enable no-vendor-prefixes property-sort-order
+  }
+
+  code {
+    pre & {
+      // inside pre, code does not behave as an inline element;
+      // To ensure multiple lines adhere to the baseline grid, we need to make it a block element.
+      display: inline-block;
+    }
   }
 
   pre {

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -8,7 +8,6 @@
     font-family: unquote($font-monospace);
     font-weight: 300;
     text-align: left;
-
   }
 
   pre,
@@ -28,7 +27,7 @@
 
   code {
     pre & {
-      // inside pre, code does not behave as an inline element;
+      // Inside pre, code does not behave as an inline element;
       // To ensure multiple lines adhere to the baseline grid, we need to make it a block element.
       display: inline-block;
     }

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -35,6 +35,7 @@ $nudges: (
   nudge--h3-mobile: 0.5rem,
   nudge--h4-mobile: 0.3rem,
   nudge--p: 0.4rem,
+  nudge--p-ubuntumono: 0.45rem,
   nudge--small: 0.2rem
 ) !default;
 


### PR DESCRIPTION
## Done

Change white space on ```<pre>``` from pre-wrap to pre. This prevents code from wrapping when element is not wide enough.

Before:
![image](https://user-images.githubusercontent.com/2741678/53809468-b055fb00-3f4c-11e9-8384-5dccc090991b.png)


After: 
![image](https://user-images.githubusercontent.com/2741678/53809413-99170d80-3f4c-11e9-8619-95db5e7eb8ff.png)


## QA

1. Go to code example on the demo
2. Resize Screen so code sample becomes longer than available width.
3. Observe lack of wrapping

## Details
Fixes #2032 
Fixes #1986 