### PR TITLE
Align tick elements to baseline grid

### DIFF
--- a/examples/templates/tick-element-comparison.html
+++ b/examples/templates/tick-element-comparison.html
@@ -1,0 +1,96 @@
+---
+layout: default
+title: Forms / Tick elements
+category: _templates
+---
+<div class="p-strip is-shallow u-no-padding--top">
+  <div class="row">
+    <p>By default, checkbox and radio labels align with paragraphs.</p>
+  </div>
+  <div class="row">
+    <div class="col-3">
+      <input type="checkbox" id="checkExample1" checked>
+      <label for="checkExample1">Checkbox option 1</label>
+      <input type="checkbox" id="checkExample2">
+      <label for="checkExample2">Checkbox option 2</label>
+      <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
+      <label for="Radio1">Radio option 1</label>
+      <input type="radio" name="RadioOptions" id="Radio2" value="option2">
+      <label for="Radio2">Radio option 2</label>
+    </div>
+    <div class="col-3">
+      <input type="radio" name="RadioOptions" id="Radio1" value="option1" >
+      <label for="Radio1">Radio option 1</label>
+      <input type="radio" name="RadioOptions" id="Radio2" value="option2">
+      <label for="Radio2">Radio option 2</label>
+      <input type="checkbox" id="checkExample1" checked>
+      <label for="checkExample1">Checkbox option 1</label>
+      <input type="checkbox" id="checkExample2">
+      <label for="checkExample2">Checkbox option 2</label>
+    </div>
+    <div class="col-3">
+      <p>Paragraph</p>
+      <button>Button</button>
+    </div>
+  </div>
+</div>
+<div class="p-strip is-shallow u-no-padding--top">
+  <div class="row">
+    <hr>
+    <p>In padded containers (table cells, some list items), checkboxes and labels need to align with text not wrapped in a tag. Use class "is-inline-label" on the label to achieve that.</p>
+  </div>
+</div>
+<div class="p-strip is-shallow u-no-padding--top">
+  <div class="row">
+    <table class="p-table--mobile-card">
+      <thead>
+        <tr>
+          <th>
+            <form>
+              <input type="checkbox" id="checkExample1" checked="">
+              <label for="checkExample1" class="is-inline-label">lbl</label>
+            </form>
+          </th>
+          <th>Power</th>
+          <th>Status</th>
+          <th>Owner | Pool</th>
+          <th class="u-align--right">Cores</th>
+          <th class="u-align--right">RAM(GB)</th>
+          <th class="u-align--right">Disks</th>
+          <th class="u-align--right">Storage(GB)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th aria-label="FQDN | MAC">
+            <form>
+              <input type="checkbox" id="checkExample1" checked="">
+              <label for="checkExample1" class="is-inline-label">lbl</label>
+            </form>
+          </th>
+          <td aria-label="Power">Off</td>
+          <td aria-label="Status">Ready</td>
+          <td aria-label="Owner | Pool">Maria</td>
+          <td aria-label="Cores" class="u-align--right">8</td>
+          <td aria-label="RAM(GB)" class="u-align--right">16</td>
+          <td aria-label="Disks" class="u-align--right">2</td>
+          <td aria-label="Storage(GB)" class="u-align--right">2</td>
+        </tr>
+        <tr>
+          <th aria-label="FQDN | MAC">
+            <form>
+              <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
+              <label for="Radio1" class="is-inline-label">lbl</label>
+            </form>
+          </th>
+          <td aria-label="Power">Off</td>
+          <td aria-label="Status">Ready</td>
+          <td aria-label="Owner | Pool">Maria</td>
+          <td aria-label="Cores" class="u-align--right">8</td>
+          <td aria-label="RAM(GB)" class="u-align--right">16</td>
+          <td aria-label="Disks" class="u-align--right">2</td>
+          <td aria-label="Storage(GB)" class="u-align--right">2</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>

--- a/examples/templates/tick-element-comparison.html
+++ b/examples/templates/tick-element-comparison.html
@@ -19,18 +19,14 @@ category: _templates
       <label for="Radio2">Radio option 2</label>
     </div>
     <div class="col-3">
-      <input type="radio" name="RadioOptions" id="Radio1" value="option1" >
-      <label for="Radio1">Radio option 1</label>
-      <input type="radio" name="RadioOptions" id="Radio2" value="option2">
-      <label for="Radio2">Radio option 2</label>
-      <input type="checkbox" id="checkExample1" checked>
-      <label for="checkExample1">Checkbox option 1</label>
-      <input type="checkbox" id="checkExample2">
-      <label for="checkExample2">Checkbox option 2</label>
-    </div>
-    <div class="col-3">
-      <p>Paragraph</p>
-      <button>Button</button>
+      <input type="radio" name="RadioOptions" id="Radio3" value="option3" >
+      <label for="Radio3">Radio option 3</label>
+      <input type="radio" name="RadioOptions" id="Radio4" value="option4">
+      <label for="Radio4">Radio option 4</label>
+      <input type="checkbox" id="checkExample3" checked>
+      <label for="checkExample3">Checkbox option 3</label>
+      <input type="checkbox" id="checkExample4">
+      <label for="checkExample4">Checkbox option 4</label>
     </div>
   </div>
 </div>
@@ -47,8 +43,8 @@ category: _templates
         <tr>
           <th>
             <form>
-              <input type="checkbox" id="checkExample1" checked="">
-              <label for="checkExample1" class="is-inline-label">lbl</label>
+              <input type="checkbox" id="checkExample99" checked="">
+              <label for="checkExample99" class="is-inline-label">label</label>
             </form>
           </th>
           <th>Power</th>
@@ -65,7 +61,7 @@ category: _templates
           <th aria-label="FQDN | MAC">
             <form>
               <input type="checkbox" id="checkExample1" checked="">
-              <label for="checkExample1" class="is-inline-label">lbl</label>
+              <label for="checkExample1" class="is-inline-label">label</label>
             </form>
           </th>
           <td aria-label="Power">Off</td>
@@ -79,8 +75,8 @@ category: _templates
         <tr>
           <th aria-label="FQDN | MAC">
             <form>
-              <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
-              <label for="Radio1" class="is-inline-label">lbl</label>
+              <input type="radio" name="RadioOptions" id="Radio10" value="option1" checked>
+              <label for="Radio10" class="is-inline-label">label</label>
             </form>
           </th>
           <td aria-label="Power">Off</td>

--- a/examples/templates/tick-element-comparison.html
+++ b/examples/templates/tick-element-comparison.html
@@ -43,8 +43,8 @@ category: _templates
         <tr>
           <th>
             <form>
-              <input type="checkbox" id="checkExample99" checked="">
-              <label for="checkExample99" class="is-inline-label">label</label>
+              <input type="checkbox" id="checkExample5" checked="">
+              <label for="checkExample5" class="is-inline-label">label</label>
             </form>
           </th>
           <th>Power</th>
@@ -60,8 +60,8 @@ category: _templates
         <tr>
           <th aria-label="FQDN | MAC">
             <form>
-              <input type="checkbox" id="checkExample1" checked="">
-              <label for="checkExample1" class="is-inline-label">label</label>
+              <input type="checkbox" id="checkExample6" checked="">
+              <label for="checkExample6" class="is-inline-label">label</label>
             </form>
           </th>
           <td aria-label="Power">Off</td>
@@ -75,8 +75,8 @@ category: _templates
         <tr>
           <th aria-label="FQDN | MAC">
             <form>
-              <input type="radio" name="RadioOptions" id="Radio10" value="option1" checked>
-              <label for="Radio10" class="is-inline-label">label</label>
+              <input type="radio" name="RadioOptions" id="Radio5" value="option1" checked>
+              <label for="Radio5" class="is-inline-label">label</label>
             </form>
           </th>
           <td aria-label="Power">Off</td>

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -89,7 +89,6 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     & + label {
       margin-bottom: $spv-outer--small-scaleable;
       padding-left: $label-offset--left;
-      padding-top: 0;
       position: relative;
 
       // container
@@ -111,6 +110,17 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
       &::before,
       &::after {
         position: absolute;
+      }
+
+      &.is-inline {
+        // removing padding-top is only needed when the label needs to align
+        // to inline elements like text inside a td
+        display: inline;
+        padding-top: 0;
+
+        &::before {
+          top: 0;
+        }
       }
     }
 
@@ -241,6 +251,10 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     &:checked + label::before {
       background-color: $color-information;
       border-color: $color-information;
+    }
+
+    &:checked + label.is-inline::after {
+      top: $sp-unit * 0.5;
     }
   }
 

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -3,6 +3,10 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
 
 // Form element styles
 @mixin vf-b-forms {
+  //tick element variables
+  $box-size: 1rem;
+  $box-offset-top: $spv-nudge + $spv-inner--x-small; // center to x-height of adjacent text
+
   // Used in buttons, inputs
   %bordered-text-vertical-padding {
     margin-bottom: $input-margin-bottom;
@@ -79,17 +83,18 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
 
   // Default form checkbox and radio styles
   %vf-tick-elements {
-    $box-size: 1rem;
-    $box-offset-top: $spv-inner--x-small;
-    $label-offset--left: $sph-inner + $box-size;
-    $tick-offset-top: calc(#{$box-offset-top} + 0.1875rem);
     opacity: 0;
     position: absolute;
 
     & + label {
-      margin-bottom: $spv-outer--small-scaleable;
-      padding-left: $label-offset--left;
+      margin-bottom: $spv-outer--small-scaleable + $spv-nudge-compensation;
+      padding-left: $sph-inner + $box-size;
       position: relative;
+
+      &::before,
+      &::after {
+        position: absolute;
+      }
 
       // container
       &::before {
@@ -107,12 +112,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
         opacity: 0;
       }
 
-      &::before,
-      &::after {
-        position: absolute;
-      }
-
-      &.is-inline {
+      &.is-inline-label {
         // removing padding-top is only needed when the label needs to align
         // to inline elements like text inside a td
         display: inline;
@@ -222,7 +222,6 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     // sass-lint:enable no-vendor-prefixes
   }
 
-  // Checkbox and radio inputs
   [type='checkbox'] {
     @extend %vf-tick-elements;
 
@@ -237,12 +236,14 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
       }
 
       &::after {
+        $tick-height: 0.375rem;
+        $tick-offset-top: $box-offset-top + 0.1875rem;
         border-bottom: 2px solid;
         border-left: 2px solid;
         color: $color-x-light;
-        height: 0.375rem;
-        left: 0.1875rem;
-        top: $sp-unit;
+        height: $tick-height;
+        left: $tick-height * 0.5;
+        top: $tick-offset-top;
         transform: rotate(-45deg);
         width: 0.625rem;
       }
@@ -253,13 +254,14 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
       border-color: $color-information;
     }
 
-    &:checked + label.is-inline::after {
+    &:checked + .is-inline-label::after {
       top: $sp-unit * 0.5;
     }
   }
 
   [type='radio'] {
     @extend %vf-tick-elements;
+    $inner-circle-diameter: 0.65rem;
 
     & + label {
       &::before {
@@ -269,11 +271,15 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
       &::after {
         background-color: $color-information;
         border-radius: 50%;
-        height: 0.65rem;
-        left: 0.1875rem;
-        top: 0.4375rem;
-        width: 0.65rem;
+        height: $inner-circle-diameter;
+        left: ($box-size - $inner-circle-diameter) * 0.5;
+        top: calc(#{$box-offset-top + ($box-size - $inner-circle-diameter) * 0.5} - 1px * 0.5);
+        width: $inner-circle-diameter;
       }
+    }
+
+    &:checked + .is-inline-label::after {
+      top: calc(#{($box-size - $inner-circle-diameter) * 0.5});
     }
   }
 

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -87,12 +87,12 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     position: absolute;
 
     & + label {
-      margin-bottom: $spv-outer--small-scaleable + $spv-nudge-compensation;
       padding-left: $sph-inner + $box-size;
       position: relative;
 
       &::before,
       &::after {
+        @include vf-animation(all, brisk);
         position: absolute;
       }
 
@@ -159,10 +159,11 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
   }
 
   label {
-    @extend %default-text;
     cursor: pointer;
     display: block;
+    margin-top: 0;
     margin-bottom: $spv-outer--small + $spv-nudge-compensation;
+    padding-top: map-get($nudges, nudge--p);
     width: fit-content;
 
     &.is-required::after {
@@ -226,11 +227,6 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     @extend %vf-tick-elements;
 
     & + label {
-      &::before,
-      &::after {
-        transition: background-color 0.1s;
-      }
-
       &::before {
         border-radius: $border-radius;
       }
@@ -261,25 +257,33 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
 
   [type='radio'] {
     @extend %vf-tick-elements;
-    $inner-circle-diameter: 0.65rem;
+    $inner-circle-diameter: 6px;
 
     & + label {
-      &::before {
+      &::before,
+      &::after {
         border-radius: 50%;
       }
 
       &::after {
-        background-color: $color-information;
+        background-color: $color-x-light;
         border-radius: 50%;
         height: $inner-circle-diameter;
-        left: ($box-size - $inner-circle-diameter) * 0.5;
-        top: calc(#{$box-offset-top + ($box-size - $inner-circle-diameter) * 0.5} - 1px * 0.5);
+        left: calc(#{$box-size * 0.5} - #{$inner-circle-diameter * 0.5});
+        top: calc(#{$box-offset-top + $box-size * 0.5} - #{$inner-circle-diameter * 0.5});
         width: $inner-circle-diameter;
       }
     }
 
-    &:checked + .is-inline-label::after {
-      top: calc(#{($box-size - $inner-circle-diameter) * 0.5});
+    &:checked {
+      & + label::before {
+        background-color: $color-information;
+        border-color: $color-information;
+      }
+
+      & + .is-inline-label::after {
+        top: calc(#{$box-size * 0.5} - #{$inner-circle-diameter * 0.5});
+      }
     }
   }
 

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -91,7 +91,6 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
       padding-left: $label-offset--left;
       padding-top: 0;
       position: relative;
-      vertical-align: middle;
 
       // container
       &::before {

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -159,6 +159,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
   }
 
   label {
+    @include p-max-width;
     cursor: pointer;
     display: block;
     margin-top: 0;

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -171,8 +171,4 @@
     cursor: help;
     text-decoration: none;
   }
-
-  label {
-    @include p-max-width;
-  }
 }


### PR DESCRIPTION
## Done

Checkboxes, radio buttons and their labels are not aligned to the baseline grid. This PR corrects that.

It also adds a class called ```.is-inline-label```, which removes the padding top (nudge that aligns text to the baseline grid). This is useful when you want to align the label to text that is not wrapped in a tag, e.g. ```<td>text here</td>```

In addition, it fixes #2186 

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/templates/tick-element-comparison/
- Turn baseline grid on
- Verify all text sticks to the baseline grid

The example above also shows that the vertical space between checkboxes / radios matches the space between paragraph and button.

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
