### PR TITLE
Add image option to pull quotes

### DIFF
--- a/docs/en/patterns/pull-quote.md
+++ b/docs/en/patterns/pull-quote.md
@@ -31,6 +31,15 @@ To give more prominence to a quote, there is also a large variant.
 View example of the small pull quote pattern
 </a>
 
+### Image header
+
+To add an image header to any size of pull-quote, add the class `has-image` and use the following markup for the image.
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/pull-quotes/default-image/"
+    class="js-example">
+View example of the small pull quote pattern with an image
+</a>
+
 <hr />
 
 ### Design

--- a/examples/patterns/pull-quotes/default-image.html
+++ b/examples/patterns/pull-quotes/default-image.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Pull quote / Default
+title: Pull quote / Image
 category: _patterns
 ---
 

--- a/examples/patterns/pull-quotes/default-image.html
+++ b/examples/patterns/pull-quotes/default-image.html
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Pull quote / Default
+category: _patterns
+---
+
+<blockquote class="p-pull-quote has-image">
+  <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="" />
+  <p class="p-pull-quote__quote">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
+  <cite class="p-pull-quote__citation">A. N. Author</cite>
+</blockquote>

--- a/scss/_base_blockquotes.scss
+++ b/scss/_base_blockquotes.scss
@@ -19,9 +19,5 @@
       display: block;
       font-style: normal;
     }
-
-    > p {
-      font-style: italic;
-    }
   }
 }

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -18,6 +18,13 @@
 @mixin vf-p-pull-quotes {
   .p-pull-quote {
     padding: 0 $sph-outer * 2;
+    position: relative;
+
+    .p-pull-quote__image {
+      height: $sp-x-large;
+      position: absolute;
+      top: -$spv-inner--x-large;
+    }
 
     .p-pull-quote__quote {
       @extend %vf-heading-4;
@@ -93,9 +100,23 @@
   .p-pull-quote--large {
     @include vf-pull-quote;
 
+    .p-pull-quote__image {
+      height: $sp-x-large;
+      position: absolute;
+      top: -$spv-inner--x-large;
+    }
+
     .p-pull-quote__citation {
       font-style: italic;
       margin-top: $spv-inner--x-small--scaleable;
+    }
+  }
+
+  .p-pull-quote,
+  .p-pull-quote--small,
+  .p-pull-quote--large {
+    &.has-image {
+      margin-top: calc(#{$spv-inner--x-large} + #{$spv-outer--scaleable});
     }
   }
 

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -3,7 +3,6 @@
 @mixin vf-quote-mark {
   color: $color-mid-dark;
   display: inline-block;
-  font-weight: bold;
   position: absolute;
 }
 

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -57,6 +57,7 @@ $spv-inner--small: $sp-unit !default;
 $spv-inner--scaleable: $sp-unit * $multi !default;
 $spv-inner--medium: $sp-unit * 1.5 !default; //vertical padding in: navigation, tabs
 $spv-inner--large: $sp-unit * 2;
+$spv-inner--x-large: $sp-unit * 5.5;
 
 // 1.2 Vertical spacing between components
 $spv-outer--small: $sp-unit * 1 !default; //labels


### PR DESCRIPTION
## Done

Add image heading option for pull-quotes

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/pull-quotes/default-image/
- To see other sizes change the `p-pull-quote` class to `p-pull-quote--small` or `p-pull-quote--large`

## Details

Fixes #1961 