### PR TITLE
Fix margin in Safari

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -18,7 +18,7 @@
     font-size: 1rem;
     font-weight: 300;
     line-height: map-get($line-heights, default-text);
-    margin-bottom: $spv-outer--scaleable + 2 * $spv-nudge-compensation;
+    margin: 0 0 $spv-outer--scaleable + 2 * $spv-nudge-compensation 0;
     padding: calc(#{$spv-nudge} - 1px) $sph-inner--small * 1.5;
     text-align: center;
     text-decoration: none;


### PR DESCRIPTION
## Done

Set top, left, and right margin to 0 explicitly to override the 2px margin added by safari on mac.
## QA

- Pull code
- Run `./run serve --watch`
- Open any button example in safari
- Observe buttons have all but bottom margin set to 0

## Details

Fixes #2191
