### PR TITLE
Update docs/breadcrumbs page content

### DIFF
--- a/docs/en/patterns/breadcrumbs.md
+++ b/docs/en/patterns/breadcrumbs.md
@@ -5,14 +5,17 @@ table_of_contents: true
 
 ## Breadcrumbs
 
-You can use the breadcrumbs component to indicate where the current page sits in the site's navigation, and to help the user navigate back to the parent.
-
-The separators between each item are added via CSS, so you don't have to include them manually.
+<hr>
+You can use the breadcrumbs pattern to indicate where the current page sits in
+the site's navigation. The separators between each item are added via CSS, so
+you don't have to include them manually.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/breadcrumbs/"
     class="js-example">
 View example of the breadcrumbs pattern
 </a>
+
+<hr />
 
 ### Design
 

--- a/docs/en/patterns/breadcrumbs.md
+++ b/docs/en/patterns/breadcrumbs.md
@@ -5,17 +5,15 @@ table_of_contents: true
 
 ## Breadcrumbs
 
-You can use the breadcrumbs pattern to indicate where the current page sits in
-the site's navigation. The separators between each item are added via CSS, so
-you don't have to include them manually.
+You can use the breadcrumbs component to indicate where the current page sits in the site's navigation, and to help the user navigate back to the parent.
+
+The separators between each item are added via CSS, so you don't have to include them manually.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/breadcrumbs/"
     class="js-example">
-    View example of the breadcrumbs pattern
+View example of the breadcrumbs pattern
 </a>
-
-<hr />
 
 ### Design
 
-* [Breadcrumbs design](https://github.com/ubuntudesign/vanilla-design/tree/master/Breadcrumbs)
+For more information [view the breadcrumbs design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Breadcrumbs), which includes the specification in markdown format and a PNG image.

--- a/examples/patterns/breadcrumbs.html
+++ b/examples/patterns/breadcrumbs.html
@@ -5,8 +5,10 @@ category: _patterns
 ---
 
 <ul class="p-breadcrumbs">
-  <li class="p-breadcrumbs__item"><a href="#">Breadcrumb One</a></li>
-  <li class="p-breadcrumbs__item"><a href="#">Breadcrumb Two</a></li>
-  <li class="p-breadcrumbs__item"><a href="#">Breadcrumb Three</a></li>
-  <li class="p-breadcrumbs__item">Breadcrumb Four</li>
+  <li class="p-breadcrumbs__item">Overview</li>
+  <li class="p-breadcrumbs__item"><a href="#">Features</a></li>
+  <li class="p-breadcrumbs__item"><a href="#">Managed</a></li>
+  <li class="p-breadcrumbs__item"><a href="#">Install</a></li>
+  <li class="p-breadcrumbs__item"><a href="#">Partners</a></li>
+  <li class="p-breadcrumbs__item"><a href="#">Docs</a></li>
 </ul>


### PR DESCRIPTION
## Done
- Updated parts of the copy
- Updated demo example to showcase live example 😉 
- Check content matches copy doc [here](https://docs.google.com/document/d/1FK485n4m21iCU_yt3DrsAcBPeiukpWUUQZLX4_PGXSM/edit#heading=h.ifh1f0ulklnm)

## QA
- Pull code
- Run /docs > ./run 
- Check http://0.0.0.0:8104/en/patterns/breadcrumbs
- Check http://0.0.0.0:8101/vanilla-framework/examples/patterns/breadcrumbs
- Review updated example

## Details
- Fixes https://github.com/ubuntudesign/vanilla-design/issues/379