### PR TITLE
Font size improvement

### DIFF
--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -8,14 +8,14 @@
     margin-top: -#{$sp-unit};
 
     @media (max-width: $breakpoint-heading-threshold) {
-      font-size: pow($ms-ratio, 6) * 1rem;
+      font-size: #{map-get($font-sizes, h1-mobile)}rem;
       line-height: map-get($line-heights, h1-mobile);
       margin-bottom: map-get($sp-after, h1-mobile) - map-get($nudges, nudge--h1-mobile);
       padding-top: map-get($nudges, nudge--h1-mobile);
     }
 
     @media (min-width: $breakpoint-heading-threshold) {
-      font-size: pow($ms-ratio, 8) * 1rem;
+      font-size: #{map-get($font-sizes, h1)}rem;
       line-height: map-get($line-heights, h1);
       margin-bottom: map-get($sp-after, h1) - map-get($nudges, nudge--h1);
       padding-top: map-get($nudges, nudge--h1);
@@ -36,14 +36,14 @@
     margin-top: -#{$sp-unit};
 
     @media (max-width: $breakpoint-heading-threshold) {
-      font-size: 1.83274rem; // pow($ms-ratio, 4.5) * 1rem
+      font-size: #{map-get($font-sizes, h2-mobile)}rem;
       line-height: map-get($line-heights, h2-mobile);
       margin-bottom: map-get($sp-after, h2-mobile) - map-get($nudges, nudge--h2-mobile);
       padding-top: map-get($nudges, nudge--h2-mobile);
     }
 
     @media (min-width: $breakpoint-heading-threshold) {
-      font-size: pow($ms-ratio, 6) * 1rem;
+      font-size: #{map-get($font-sizes, h2)}rem;
       line-height: map-get($line-heights, h2);
       margin-bottom: map-get($sp-after, h2) - map-get($nudges, nudge--h2);
       padding-top: map-get($nudges, nudge--h2);
@@ -52,7 +52,7 @@
 
   %vf-heading-3 {
     @include heading-max-width--long;
-    font-size: pow($ms-ratio, 4) * 1rem;
+    font-size: #{map-get($font-sizes, h3)}rem;
     font-style: normal;
     font-weight: 300;
     line-height: map-get($line-heights, h3);
@@ -61,7 +61,7 @@
     padding-top: map-get($nudges, nudge--h3);
 
     @media (max-width: $breakpoint-heading-threshold) {
-      font-size: pow($ms-ratio, 3) * 1rem;
+      font-size: #{map-get($font-sizes, h3-mobile)}rem;
       line-height: map-get($line-heights, h3-mobile);
       margin-bottom: map-get($sp-after, h3-mobile) - map-get($nudges, nudge--h3-mobile);
       padding-top: map-get($nudges, nudge--h3-mobile);
@@ -75,14 +75,14 @@
     margin-top: 0;
 
     @media (max-width: $breakpoint-heading-threshold) {
-      font-size: 1.22176rem; // pow($ms-ratio, 1.5) * 1rem
+      font-size: #{map-get($font-sizes, h4-mobile)}rem;
       line-height: map-get($line-heights, h4-mobile);
       margin-bottom: map-get($sp-after, h4-mobile) - map-get($nudges, nudge--h4-mobile);
       padding-top: map-get($nudges, nudge--h4-mobile);
     }
 
     @media (min-width: $breakpoint-heading-threshold) {
-      font-size: pow($ms-ratio, 2) * 1rem;
+      font-size: #{map-get($font-sizes, h4)}rem;
       line-height: map-get($line-heights, h4);
       margin-bottom: map-get($sp-after, h4) - map-get($nudges, nudge--h4);
       padding-top: map-get($nudges, nudge--h4);
@@ -131,7 +131,7 @@
   }
 
   %small-text {
-    font-size: pow($ms-ratio, -1) * 1rem;
+    font-size: #{map-get($font-sizes, small)}rem;
     line-height: map-get($line-heights, small);
     margin-bottom: map-get($sp-after, small) - map-get($nudges, nudge--small);
     padding-top: map-get($nudges, nudge--small);

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -8,6 +8,6 @@ $increase-fontsize-on-bigger-screens: true !default;
 $fontsize-ratio--largescreen: 1.125 !default;
 $fontsize-largescreen: 1rem * $fontsize-ratio--largescreen;
 $fontsizes: (
-  base: 16px,
+  base: 1rem,
   big: $fontsize-largescreen
 ) !default;

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -6,7 +6,7 @@ $font-import: 'http://fonts.gstatic.com/s/ubuntu/v9/' !default;
 $font-allow-cyrillic-greek-latin: false !default;
 $increase-fontsize-on-bigger-screens: true !default;
 $fontsize-ratio--largescreen: 1.125 !default;
-$fontsize-largescreen: 1rem * $fontsize-ratio--largescreen;
+$fontsize-largescreen: #{$fontsize-ratio--largescreen}rem;
 $fontsizes: (
   base: 1rem,
   big: $fontsize-largescreen

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -9,6 +9,19 @@ $sp-unit-ratio: 0.5 !default;
 // Baseline grid settings
 $sp-unit: 1rem * $sp-unit-ratio !default;
 
+$font-sizes: (
+  small: pow($ms-ratio, -1),
+  root: 1,
+  h4-mobile: 1.22176,
+  h4: pow($ms-ratio, 2),
+  h3-mobile: pow($ms-ratio, 3),
+  h3: pow($ms-ratio, 4),
+  h2-mobile: 1.83274,
+  h2: pow($ms-ratio, 6),
+  h1-mobile: pow($ms-ratio, 6),
+  h1: pow($ms-ratio, 8)
+);
+
 $line-heights: (
   h1: 7 * $sp-unit,
   h2: 6 * $sp-unit,


### PR DESCRIPTION
## Done

1) Best practices recommend allowing the browser to control font-size. In order to do that, the root font-size needs to be set to 1rem. 
2) Move the last remaining font setting (font-size) into a map in the settings_spacing file. This is for consistency with the rest, and to make it easier to survey the font-sizes all in one place.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- [in chrome](https://support.google.com/chrome/answer/96810?hl=en-GB); In firefox go to about:preferences > general > change default font-size
- observe how everything scales