### PR TITLE
Update docs/navigation page content

### DIFF
--- a/docs/en/patterns/navigation.md
+++ b/docs/en/patterns/navigation.md
@@ -5,38 +5,29 @@ table_of_contents: true
 
 ## Navigation
 
+<hr>
+
 Vanilla includes a simple navigation bar that you can add to the top of your
 sites.
 
 The navigation items are collapsed behind a "Menu" link in small screens and
 displayed horizontally on larger screens.
 
-Note: You can constrain the width of the navigation to match the
-`$grid-max-width` by placing everything inside the header element within a
-`.row` wrapper.
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Note:</span>You can constrain the width of the navigation to match the `$grid-max-width` by placing everything inside the header element within a `.row` wrapper.
+  </p>
+</div>
 
 The background color of a navigation pattern can be set via the
 `$color-navigation-background` variable.
 
+You can change the breakpoint at which the menu changes to a small screen menu
+by adjusting the `$breakpoint-navigation-threshold` in `_settings_breakpoints.scss`.
+
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/navigation/default/"
     class="js-example">
 View example of the navigation pattern
-</a>
-
-Tip: You can change the breakpoint at which the menu changes to a small screen
-menu by adjusting the `$breakpoint-navigation-threshold` in
-`_settings_breakpoints.scss`.
-
-### Sidebar Navigation
-
-Vanilla also allows you to use a sidebar navigation, with menu items collapsing
-under section titles in an accordion. This example code will expand to fill the
-space available to it so it needs to be used in conjunction with the grid to
-set the layout. This pattern includes a tagline which sits next to the logo.
-
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/navigation/sidebar/"
-    class="js-example">
-View example of the sidebar navigation pattern
 </a>
 
 ### Sub-navigation
@@ -55,9 +46,6 @@ or more `p-subnav` components.
 View example of the sub-navigation pattern
 </a>
 
-<hr />
-
 ### Design
 
-- [Navigation design](https://github.com/ubuntudesign/vanilla-design/tree/master/Navigation)
-- [Sidebar navigation design](https://github.com/ubuntudesign/vanilla-design/tree/master/Sidebar%20navigation)
+For more information [view the navigation and sub-navigation design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Navigation), which includes the specification in markdown format and a PNG image.

--- a/docs/en/patterns/navigation.md
+++ b/docs/en/patterns/navigation.md
@@ -15,7 +15,7 @@ displayed horizontally on larger screens.
 
 <div class="p-notification--information">
   <p class="p-notification__response">
-    <span class="p-notification__status">Note:</span>You can constrain the width of the navigation to match the `$grid-max-width` by placing everything inside the header element within a `.row` wrapper.
+    <span class="p-notification__status">Note:</span>You can constrain the width of the navigation to match the <code>$grid-max-width</code> by placing everything inside the header element within a `.row` wrapper.
   </p>
 </div>
 

--- a/examples/patterns/navigation/default.html
+++ b/examples/patterns/navigation/default.html
@@ -7,7 +7,7 @@ category: _patterns
   <div class="p-navigation__banner">
     <div class="p-navigation__logo">
       <a class="p-navigation__link" href="#">
-        <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="" width="95" />
+        <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="" width="95" />
       </a>
     </div>
     <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
@@ -24,13 +24,19 @@ category: _patterns
     </span>
     <ul class="p-navigation__links" role="menu">
       <li class="p-navigation__link is-selected" role="menuitem">
-        <a href="#">Link1</a>
+        <a href="#">Products</a>
       </li>
       <li class="p-navigation__link" role="menuitem">
-        <a href="#">Link2</a>
+        <a href="#">Services</a>
       </li>
       <li class="p-navigation__link" role="menuitem">
-        <a href="#">Link3</a>
+        <a href="#">Partners</a>
+      </li>
+      <li class="p-navigation__link" role="menuitem">
+        <a href="#">About</a>
+      </li>
+      <li class="p-navigation__link" role="menuitem">
+        <a href="#">Careers</a>
       </li>
     </ul>
   </nav>

--- a/examples/patterns/navigation/subnav.html
+++ b/examples/patterns/navigation/subnav.html
@@ -7,7 +7,7 @@ category: _patterns
   <div class="p-navigation__banner">
     <div class="p-navigation__logo">
       <a class="p-navigation__link" href="#">
-        <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="" width="95" />
+        <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg" alt="" width="95" />
       </a>
     </div>
     <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
@@ -24,52 +24,52 @@ category: _patterns
     </span>
     <ul class="p-navigation__links" role="menu">
       <li class="p-navigation__link p-subnav" role="menuitem" id="link-1">
-        <a href="#link-1-menu" class="p-subnav__toggle">Link 1</i>
+        <a href="#link-1-menu" class="p-subnav__toggle">LXC</i>
         </a>
         <ul class="p-subnav__items" id="link-1-menu" aria-hidden="true">
           <li>
-            <a href="#" class="p-subnav__item">Sub item 1</a>
+            <a href="#" class="p-subnav__item">Introduction</a>
           </li>
           <li>
-            <a href="#" class="p-subnav__item">Sub item 2</a>
+            <a href="#" class="p-subnav__item">News</a>
           </li>
           <li>
-            <a href="#" class="p-subnav__item">Sub item 3</a>
+            <a href="#" class="p-subnav__item">Getting started</a>
           </li>
         </ul>
       </li>
       <li class="p-navigation__link p-subnav" role="menuitem" id="link-2">
-        <a href="#link-2-menu" class="p-subnav__toggle">Link 2</i>
+        <a href="#link-2-menu" class="p-subnav__toggle">LXD</i>
         </a>
         <ul class="p-subnav__items" id="link-2-menu" aria-hidden="true">
           <li>
-            <a href="#" class="p-subnav__item">Sub item 1</a>
+            <a href="#" class="p-subnav__item">Introduction</a>
           </li>
           <li>
-            <a href="#" class="p-subnav__item">Sub item 2</a>
+            <a href="#" class="p-subnav__item">News</a>
           </li>
           <li>
-            <a href="#" class="p-subnav__item">Sub item 3</a>
+            <a href="#" class="p-subnav__item">Getting started - Command line</a>
           </li>
           <li>
-            <a href="#" class="p-subnav__item">Sub item 4</a>
+            <a href="#" class="p-subnav__item">Getting started - OpenStack</a>
           </li>
           <li>
-            <a href="#" class="p-subnav__item">Sub item 5</a>
+            <a href="#" class="p-subnav__item">Getting started - OpenNebula</a>
           </li>
         </ul>
       </li>
       <li class="p-navigation__link p-subnav" role="menuitem" id="link-3">
-        <a href="#link-3-menu" class="p-subnav__toggle">Link 3</a>
+        <a href="#link-3-menu" class="p-subnav__toggle">LXCFS</a>
         <ul class="p-subnav__items" id="link-3-menu" aria-hidden="true">
           <li>
-            <a href="#" class="p-subnav__item">Sub item 1</a>
+            <a href="#" class="p-subnav__item">Introduction</a>
           </li>
           <li>
-            <a href="#" class="p-subnav__item">Sub item 2</a>
+            <a href="#" class="p-subnav__item">News</a>
           </li>
           <li>
-            <a href="#" class="p-subnav__item">Sub item 3</a>
+            <a href="#" class="p-subnav__item">Getting started</a>
           </li>
         </ul>
       </li>


### PR DESCRIPTION
## Done
- Updated copy and remove sidebar navigation (as it will be deprecated)
- Updated demo example to showcase live example 😉 
- Check content matches copy doc [here](https://docs.google.com/document/d/1FK485n4m21iCU_yt3DrsAcBPeiukpWUUQZLX4_PGXSM/edit#heading=h.b0krna2wthn0)

## QA
- Pull code
- Run /docs > ./run 
  - Check http://0.0.0.0:8104/en/patterns/navigation/
- Pull code
- Run ./run
  - Check http://0.0.0.0:8101/vanilla-framework/examples/patterns/navigation/default/
  - Check http://0.0.0.0:8101/vanilla-framework/examples/patterns/subnav/
- Review updated examples

## Details
- Fixes https://github.com/ubuntudesign/vanilla-design/issues/345

## Screenshots
![Screenshot 2019-03-12 at 11 39 22](https://user-images.githubusercontent.com/17748020/54197316-82783580-44bb-11e9-9e69-e6edf79720d9.png)

![Screenshot 2019-03-12 at 11 38 52](https://user-images.githubusercontent.com/17748020/54197322-873ce980-44bb-11e9-839f-942d3e46e8cd.png)

