### PR TITLE
Baseline fixes

### DIFF
--- a/examples/templates/typographic-spacing.html
+++ b/examples/templates/typographic-spacing.html
@@ -3,1385 +3,163 @@ layout: default
 title: Typographic spacing
 category: _templates
 ---
+
+<div class="p-strip is-shallow">
+</div>
 <style>
-  .flex-container {
-    display: flex;
-    justify-content: space-between;
+  body {
+    position: relative;
+  }
+
+  .controls-pseudo {
+    bottom: .5rem;
+    padding: .75rem;
+    position: fixed;
+    left: .5rem;
+    z-index: 101;
+  }
+
+  .u-pseudo-baseline-container {
+    bottom: 0;
+    height: 100%;
+    left: 0;
+    overflow: hidden;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 100%;
+    z-index: 100;
+  }
+
+  .u-pseudo-baseline {
+    font-size: 0;
+    height: 8px;
+    margin: 0;
+    pointer-events: none;
+    position: relative;
+    width: 100%;
+  }
+
+  @media (min-width: 1680px) {
+    .u-pseudo-baseline {
+      height: 9px;
+    }
+  }
+
+  .u-pseudo-baseline::after {
+    border-bottom: 1px solid rgba(0, 0, 0, .1);
+    bottom: 0;
+    content: '';
+    height: 1px;
+    left: 0;
+    position: absolute;
+    right: 0;
   }
 </style>
+    <script>
+        var VF_ENV = "DEV";
+        if (VF_ENV === "DEV") {
+            fragmentFromString = function fragmentFromString(strHTML) {
+                var temp = document.createElement('template');
+                temp.innerHTML = strHTML;
+                return temp.content;
+            }
 
-<!-- h1+others -->
-<div class="flex-container">
-  <div class="flex-col">
-    <h1>Canonical’s AI and ML solutions feature…</h1>
-    <h1>Architectural freedom. Fully automated operations.</h1>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-  </div>
-  <div class="flex-col">
-    <h1>Canonical’s AI and ML solutions feature…</h1>
-    <h2>Architectural freedom. Fully automated operations.</h2>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <a href="#" class="p-button">Get started</a>
-  </div>
-  <div class="flex-col">
-    <h1>Canonical’s AI and ML solutions feature…</h1>
-    <h3>Architectural freedom. Fully automated operations.</h3>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h1>Canonical’s AI and ML solutions feature…</h1>
-    <h4>Architectural freedom. Fully automated operations.</h4>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h1>Canonical’s AI and ML solutions feature…</h1>
-    <h5>Architectural freedom. Fully automated operations.</h5>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h1>Canonical’s AI and ML solutions feature…</h1>
-    <h6>Architectural freedom. Fully automated operations.</h6>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-</div>
+            class baselineGrid {
+                constructor() {
+                    this.target = document.body;
+                    this.baselineHeight = 8;
+                    this.baselineContainerClassName = "u-pseudo-baseline-container";
+                    this.baselineRowClassName = "u-pseudo-baseline";
+                    this.toggleGridClass = "u-hide";
+                }
+                addBaselineGridToggle() {
+                    var controls = fragmentFromString('<div class="controls-pseudo"><label><input type="checkbox" class="p-switch js-pseudo-baseline-toggle" /><div class="p-switch__slider"></div></label></div>');
+                    this.target.appendChild(controls);
+                }
+                appendBaselineRow(parent) {
+                    var baseline = document.createElement('div');
+                    baseline.classList.add(this.baselineRowClassName);
+                    parent.appendChild(baseline);
+                }
+                baselineCount() {
+                    return Math.floor(document.documentElement.scrollHeight / this.baselineHeight);
+                }
+                create() {
+                    var baselineContainer = document.createElement('div'),
+                        fragment = document.createDocumentFragment(),
+                        documentHeight = document.documentElement.scrollHeight,
+                        baselineCount = this.baselineCount(documentHeight);
 
-<!-- h2+others -->
-<div class="flex-container">
-  <div class="flex-col">
-    <h2>Canonical’s AI and ML solutions feature…</h2>
-    <h1>Architectural freedom. Fully automated operations.</h1>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-  </div>
-  <div class="flex-col">
-    <h2>Canonical’s AI and ML solutions feature…</h2>
-    <h2>Architectural freedom. Fully automated operations.</h2>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <a href="#" class="p-button">Get started</a>
-  </div>
-  <div class="flex-col">
-    <h2>Canonical’s AI and ML solutions feature…</h2>
-    <h3>Architectural freedom. Fully automated operations.</h3>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h2>Canonical’s AI and ML solutions feature…</h2>
-    <h4>Architectural freedom. Fully automated operations.</h4>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h2>Canonical’s AI and ML solutions feature…</h2>
-    <h5>Architectural freedom. Fully automated operations.</h5>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h2>Canonical’s AI and ML solutions feature…</h2>
-    <h6>Architectural freedom. Fully automated operations.</h6>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-</div>
+                    baselineContainer.classList.add(this.baselineContainerClassName);
 
-<!-- h3 + others -->
-<div class="flex-container">
-  <div class="flex-col">
-    <h3>Canonical’s AI and ML solutions feature…</h3>
-    <h1>Architectural freedom. Fully automated operations.</h1>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-  </div>
-  <div class="flex-col">
-    <h3>Canonical’s AI and ML solutions feature…</h3>
-    <h2>Architectural freedom. Fully automated operations.</h2>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <a href="#" class="p-button">Get started</a>
-  </div>
-  <div class="flex-col">
-    <h3>Canonical’s AI and ML solutions feature…</h3>
-    <h3>Architectural freedom. Fully automated operations.</h3>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h3>Canonical’s AI and ML solutions feature…</h3>
-    <h4>Architectural freedom. Fully automated operations.</h4>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h3>Canonical’s AI and ML solutions feature…</h3>
-    <h5>Architectural freedom. Fully automated operations.</h5>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h3>Canonical’s AI and ML solutions feature…</h3>
-    <h6>Architectural freedom. Fully automated operations.</h6>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-</div>
+                    if (!this.showGrid) {
+                        baselineContainer.classList.add(this.toggleGridClass);
+                    }
+                    for (var i = 0; i < baselineCount; i++) {
+                        this.appendBaselineRow(baselineContainer);
+                    }
+                    fragment.appendChild(baselineContainer);
+                    this.target.appendChild(fragment);
+                    this.baselineContainer = document.querySelector('.u-pseudo-baseline-container');
+                }
+                initGridToggle(switchBtn) {
+                    var toggle = document.querySelector(switchBtn);
 
-<!-- h4 + others -->
-<div class="flex-container">
-  <div class="flex-col">
-    <h4>Canonical’s AI and ML solutions feature…</h4>
-    <h1>Architectural freedom. Fully automated operations.</h1>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-  </div>
-  <div class="flex-col">
-    <h4>Canonical’s AI and ML solutions feature…</h4>
-    <h2>Architectural freedom. Fully automated operations.</h2>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <a href="#" class="p-button">Get started</a>
-  </div>
-  <div class="flex-col">
-    <h4>Canonical’s AI and ML solutions feature…</h4>
-    <h3>Architectural freedom. Fully automated operations.</h3>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h4>Canonical’s AI and ML solutions feature…</h4>
-    <h4>Architectural freedom. Fully automated operations.</h4>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h4>Canonical’s AI and ML solutions feature…</h4>
-    <h5>Architectural freedom. Fully automated operations.</h5>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h4>Canonical’s AI and ML solutions feature…</h4>
-    <h6>Architectural freedom. Fully automated operations.</h6>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-</div>
+                    toggle.addEventListener('click', function (event) {
+                        this.baselineContainer.classList.toggle(this.toggleGridClass);
+                    }.bind(this));
+                }
+                update() {
+                    this.baselineContainer.remove();
+                    this.create();
+                }
+            }
 
-<!-- h5 + others -->
-<div class="flex-container">
-  <div class="flex-col">
-    <h5>Canonical’s AI and ML solutions feature…</h5>
-    <h1>Architectural freedom. Fully automated operations.</h1>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-  </div>
-  <div class="flex-col">
-    <h5>Canonical’s AI and ML solutions feature…</h5>
-    <h2>Architectural freedom. Fully automated operations.</h2>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <a href="#" class="p-button">Get started</a>
-  </div>
-  <div class="flex-col">
-    <h5>Canonical’s AI and ML solutions feature…</h5>
-    <h3>Architectural freedom. Fully automated operations.</h3>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h5>Canonical’s AI and ML solutions feature…</h5>
-    <h4>Architectural freedom. Fully automated operations.</h4>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h5>Canonical’s AI and ML solutions feature…</h5>
-    <h5>Architectural freedom. Fully automated operations.</h5>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h5>Canonical’s AI and ML solutions feature…</h5>
-    <h6>Architectural freedom. Fully automated operations.</h6>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-</div>
+            class makePragraphs {
+                constructor() {
+                    this.target = document.body;
+                    this.numParagraphs = 1000;
+                }
+                appendP(parent, i) {
+                    var para = document.createElement('p'),
+                        rowNum = "<strong># " + arguments[1] + "</strong>",
+                        lorem = " Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";
 
-<!-- h6 + others -->
-<div class="flex-container">
-  <div class="flex-col">
-    <h6>Canonical’s AI and ML solutions feature…</h6>
-    <h1>Architectural freedom. Fully automated operations.</h1>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-  </div>
-  <div class="flex-col">
-    <h6>Canonical’s AI and ML solutions feature…</h6>
-    <h2>Architectural freedom. Fully automated operations.</h2>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <a href="#" class="p-button">Get started</a>
-  </div>
-  <div class="flex-col">
-    <h6>Canonical’s AI and ML solutions feature…</h6>
-    <h3>Architectural freedom. Fully automated operations.</h3>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h6>Canonical’s AI and ML solutions feature…</h6>
-    <h4>Architectural freedom. Fully automated operations.</h4>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h6>Canonical’s AI and ML solutions feature…</h6>
-    <h5>Architectural freedom. Fully automated operations.</h5>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-  <div class="flex-col">
-    <h6>Canonical’s AI and ML solutions feature…</h6>
-    <h6>Architectural freedom. Fully automated operations.</h6>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
-    <button>Contact us</button>
-  </div>
-</div>
+                    para.innerHTML = rowNum;
+                    for (var i = 0; i < 3; i++) {
+                      para.innerHTML += lorem;
+                    }
 
-<!-- / -->
-<div class="flex-container">
-  <div class="flex-col">
-    <input type="radio" name="" id="Radio1">
-    <label for="Radio1">radio</label>
-  </div>
-  <div class="flex-col">
-    <select name="exampleSelect" id="exampleSelect">
-      <option value="" disabled="disabled" selected="">Select</option>
-      <option value="1">Option 1</option>
-      <option value="2">Option 2</option>
-      <option value="3">Option 3</option>
-    </select>
-  </div>
-  <div class="flex-col">
-    <textarea id="textarea" rows="3">Textarea</textarea>
-  </div>
-  <div class="flex-col">
-    <label for="exampleInputEmail1">Email address</label>
-  </div>
-  <div class="flex-col">
-    <input type="text" id="exampleInputEmail1" placeholder="Email">
-  </div>
-  <div class="flex-col">
-    <button>Button</button>
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">muted</p>
-  </div>
-  <div class="flex-col">
-    <p>para</p>
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-  </div>
-  <div class="flex-col">
-    <h6>h6</h6>
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-  </div>
-</div>
-<hr>
-<!-- h1 -->
-<div class="flex-container">
-  <div class="flex-col">
-    <h1>h1</h1>
-    <input type="radio" name="" id="Radio1">
-    <label for="Radio1">radio</label>
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-    <select name="exampleSelect" id="exampleSelect">
-      <option value="" disabled="disabled" selected="">Select</option>
-      <option value="1">Option 1</option>
-      <option value="2">Option 2</option>
-      <option value="3">Option 3</option>
-    </select>
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-    <textarea id="textarea" rows="3">Textarea</textarea>
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-    <label for="exampleInputEmail1">Email address</label>
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-    <input type="text" id="exampleInputEmail1" placeholder="Email">
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-    <button>Button</button>
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-    <p class="p-muted-heading">muted</p>
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-    <p>para</p>
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-    <h5>h5</h5>
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-    <h6>h6</h6>
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-    <h4>h4</h4>
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-    <h3>h3</h3>
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-    <h2>h2</h2>
-  </div>
-  <div class="flex-col">
-    <h1>h1</h1>
-    <h1>h1</h1>
-  </div>
-</div>
-<hr>
-<!-- h2 -->
-<div class="flex-container">
-  <div class="flex-col">
-    <h2>h2</h2>
-    <input type="radio" name="" id="Radio1">
-    <label for="Radio1">radio</label>
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-    <select name="exampleSelect" id="exampleSelect">
-      <option value="" disabled="disabled" selected="">Select</option>
-      <option value="1">Option 1</option>
-      <option value="2">Option 2</option>
-      <option value="3">Option 3</option>
-    </select>
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-    <textarea id="textarea" rows="3">Textarea</textarea>
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-    <label for="exampleInputEmail1">Email address</label>
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-    <input type="text" id="exampleInputEmail1" placeholder="Email">
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-    <button>Button</button>
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-    <p class="p-muted-heading">muted</p>
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-    <p>para</p>
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-    <h5>h5</h5>
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-    <h6>h6</h6>
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-    <h4>h4</h4>
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-    <h3>h3</h3>
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-    <h2>h2</h2>
-  </div>
-  <div class="flex-col">
-    <h2>h2</h2>
-    <h1>h1</h1>
-  </div>
-</div>
-<hr>
-<!-- h3 -->
-<div class="flex-container">
-  <div class="flex-col">
-    <h3>h3</h3>
-    <input type="radio" name="" id="Radio1">
-    <label for="Radio1">radio</label>
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-    <select name="exampleSelect" id="exampleSelect">
-      <option value="" disabled="disabled" selected="">Select</option>
-      <option value="1">Option 1</option>
-      <option value="2">Option 2</option>
-      <option value="3">Option 3</option>
-    </select>
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-    <textarea id="textarea" rows="3">Textarea</textarea>
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-    <label for="exampleInputEmail1">Email address</label>
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-    <input type="text" id="exampleInputEmail1" placeholder="Email">
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-    <button>Button</button>
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-    <p class="p-muted-heading">muted</p>
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-    <p>para</p>
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-    <h5>h5</h5>
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-    <h6>h6</h6>
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-    <h4>h4</h4>
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-    <h3>h3</h3>
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-    <h2>h2</h2>
-  </div>
-  <div class="flex-col">
-    <h3>h3</h3>
-    <h1>h1</h1>
-  </div>
-</div>
-<hr>
+                    para.classList.add(this.baselineRowClassName);
+                    parent.appendChild(para);
+                }
+                create() {
+                    var pContainer = document.createElement('div'),
+                        fragment = document.createDocumentFragment();
 
-<!-- h4 -->
-<div class="flex-container">
-  <div class="flex-col">
-    <h4>h4</h4>
-    <input type="radio" name="" id="Radio1">
-    <label for="Radio1">radio</label>
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-    <select name="exampleSelect" id="exampleSelect">
-      <option value="" disabled="disabled" selected="">Select</option>
-      <option value="1">Option 1</option>
-      <option value="2">Option 2</option>
-      <option value="3">Option 3</option>
-    </select>
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-    <textarea id="textarea" rows="3">Textarea</textarea>
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-    <label for="exampleInputEmail1">Email address</label>
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-    <input type="text" id="exampleInputEmail1" placeholder="Email">
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-    <button>Button</button>
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-    <p class="p-muted-heading">muted</p>
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-    <p>para</p>
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-    <h5>h5</h5>
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-    <h6>h6</h6>
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-    <h4>h4</h4>
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-    <h3>h3</h3>
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-    <h2>h2</h2>
-  </div>
-  <div class="flex-col">
-    <h4>h4</h4>
-    <h1>h1</h1>
-  </div>
-</div>
-<hr>
+                    pContainer.classList.add("p-container");
+                    pContainer.classList.add("row");
 
-<!-- h5 -->
-<div class="flex-container">
-  <div class="flex-col">
-    <h5>h5</h5>
-    <input type="radio" name="" id="Radio1">
-    <label for="Radio1">radio</label>
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-    <select name="exampleSelect" id="exampleSelect">
-      <option value="" disabled="disabled" selected="">Select</option>
-      <option value="1">Option 1</option>
-      <option value="2">Option 2</option>
-      <option value="3">Option 3</option>
-    </select>
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-    <textarea id="textarea" rows="3">Textarea</textarea>
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-    <label for="exampleInputEmail1">Email address</label>
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-    <input type="text" id="exampleInputEmail1" placeholder="Email">
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-    <button>Button</button>
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-    <p class="p-muted-heading">muted</p>
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-    <p>para</p>
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-    <h5>h5</h5>
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-    <h6>h6</h6>
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-    <h4>h4</h4>
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-    <h3>h3</h3>
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-    <h2>h2</h2>
-  </div>
-  <div class="flex-col">
-    <h5>h5</h5>
-    <h1>h1</h1>
-  </div>
-</div>
-<hr>
+                    for (var i = 0; i < this.numParagraphs; i++) {
+                        this.appendP(pContainer, i);
+                    }
 
-<!-- muted -->
-<div class="flex-container">
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <input type="radio" name="" id="Radio1">
-    <label for="Radio1">radio</label>
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <select name="exampleSelect" id="exampleSelect">
-      <option value="" disabled="disabled" selected="">Select</option>
-      <option value="1">Option 1</option>
-      <option value="2">Option 2</option>
-      <option value="3">Option 3</option>
-    </select>
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <textarea id="textarea" rows="3">Textarea</textarea>
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <label for="exampleInputEmail1">Email address</label>
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <input type="text" id="exampleInputEmail1" placeholder="Email">
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <button>Button</button>
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <p class="p-muted-heading">muted</p>
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <p>para</p>
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <h5>h5</h5>
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <h6>h6</h6>
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <h4>h4</h4>
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <h3>h3</h3>
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <h2>h2</h2>
-  </div>
-  <div class="flex-col">
-    <p class="p-muted-heading">Muted</p>
-    <h1>h1</h1>
-  </div>
-</div>
-<hr>
+                    fragment.appendChild(pContainer);
+                    this.target.appendChild(fragment);
+                    this.pContainer = document.querySelector('.p-container');
+                }
+            }
 
-<!--
-<div class="p-strip is-shallow">
-  <div class="row p-divider">
-    <div class="col-6 p-divider__block">
-      <h1>h1</h1>
-      <div class="col-1 u-no-margin--left">
-        <h1>h1</h1>
-        <h1>h1</h1>
-      </div>
-      <div class="col-1">
-        <h1>h1</h1>
-        <h2>h2</h2>
-      </div>
-      <div class="col-1">
-        <h1>h1</h1>
-        <h3>h3</h3>
-      </div>
-      <div class="col-1">
-        <h1>h1</h1>
-        <h4>h4</h4>
-      </div>
-      <div class="col-1">
-        <h1>h1</h1>
-        <h5>h5</h5>
-      </div>
-      <div class="col-1">
-        <div class="col-6">
-          <h1>h1</h1>
-          <h6>h6</h6>
-        </div>
-        <div class="col-6">
-          <h1>&nbsp;</h1>
-          <p>p</p>
-        </div>
-      </div>
-    </div>
-    <div class="col-6 p-divider__block">
-      <p class="p-heading--one">p-heading--one</p>
-      <div class="col-1 u-no-margin--left">
-        <p class="p-heading--one">h1</p>
-        <p class="p-heading--one">h1</p>
-      </div>
-      <div class="col-1">
-        <p class="p-heading--one">h1</p>
-        <p class="p-heading--two">h2</p>
-      </div>
-      <div class="col-1">
-        <p class="p-heading--one">h1</p>
-        <p class="p-heading--three">h3</p>
-      </div>
-      <div class="col-1">
-        <p class="p-heading--one">h1</p>
-        <p class="p-heading--four">h4</p>
-      </div>
-      <div class="col-1">
-        <p class="p-heading--one">h1</p>
-        <p class="p-heading--five">h5</p>
-      </div>
-      <div class="col-1">
-        <div class="col-6">
-          <p class="p-heading--one">h1</p>
-          <p class="p-heading--six">h6</p>
-        </div>
-        <div class="col-6">
-          <p class="p-heading--one">&nbsp;</p>
-          <p>p</p>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <hr>
-  </div>
-  <div class="row p-divider">
-    <div class="col-6 p-divider__block">
-      <h2>h2</h2>
-      <div class="col-1 u-no-margin--left">
-        <h2>h2</h2>
-        <h1>h1</h1>
-      </div>
-      <div class="col-1">
-        <h2>h2</h2>
-        <h2>h2</h2>
-      </div>
-      <div class="col-1">
-        <h2>h2</h2>
-        <h3>h3</h3>
-      </div>
-      <div class="col-1">
-        <h2>h2</h2>
-        <h4>h4</h4>
-      </div>
-      <div class="col-1">
-        <h2>h2</h2>
-        <h5>h5</h5>
-      </div>
-      <div class="col-1">
-        <div class="col-6">
-          <h2>h1</h2>
-          <h6>h6</h6>
-        </div>
-        <div class="col-6">
-          <h2>&nbsp;</h2>
-          <p>p</p>
-        </div>
-      </div>
-    </div>
-    <div class="col-6 p-divider__block">
-      <p class="p-heading--two">p-heading--two</p>
-      <div class="col-1 u-no-margin--left">
-        <p class="p-heading--two">h2</p>
-        <p class="p-heading--one">h1</p>
-      </div>
-      <div class="col-1">
-        <p class="p-heading--two">h2</p>
-        <p class="p-heading--two">h2</p>
-      </div>
-      <div class="col-1">
-        <p class="p-heading--two">h2</p>
-        <p class="p-heading--three">h3</p>
-      </div>
-      <div class="col-1">
-        <p class="p-heading--two">h2</p>
-        <p class="p-heading--four">h4</p>
-      </div>
-      <div class="col-1">
-        <p class="p-heading--two">h2</p>
-        <p class="p-heading--five">h5</p>
-      </div>
-      <div class="col-1">
-        <div class="col-6">
-          <p class="p-heading--two">h2</p>
-          <p class="p-heading--six">h6</p>
-        </div>
-        <div class="col-6">
-          <p class="p-heading--two">&nbsp;</p>
-          <p>p</p>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <hr>
-  </div>
-    <div class="row p-divider">
-      <div class="col-6 p-divider__block">
-        <h3>h3</h3>
-        <div class="col-1 u-no-margin--left">
-          <h3>h3</h3>
-          <h1>h1</h1>
-        </div>
-        <div class="col-1">
-          <h3>h3</h3>
-          <h2>h2</h2>
-        </div>
-        <div class="col-1">
-          <h3>h3</h3>
-          <h3>h3</h3>
-        </div>
-        <div class="col-1">
-          <h3>h3</h3>
-          <h4>h4</h4>
-        </div>
-        <div class="col-1">
-          <h3>h3</h3>
-          <h5>h5</h5>
-        </div>
-        <div class="col-1">
-          <div class="col-6">
-            <h3>h3</h3>
-            <h6>h6</h6>
-          </div>
-          <div class="col-6">
-            <h3>&nbsp;</h3>
-            <p>p</p>
-          </div>
-        </div>
-      </div>
-      <div class="col-6 p-divider__block">
-        <p class="p-heading--three">p-heading--three</p>
-        <div class="col-1 u-no-margin--left">
-          <p class="p-heading--three">h3</p>
-          <p class="p-heading--one">h1</p>
-        </div>
-        <div class="col-1">
-          <p class="p-heading--three">h3</p>
-          <p class="p-heading--two">h2</p>
-        </div>
-        <div class="col-1">
-          <p class="p-heading--three">h3</p>
-          <p class="p-heading--three">h3</p>
-        </div>
-        <div class="col-1">
-          <p class="p-heading--three">h3</p>
-          <p class="p-heading--four">h4</p>
-        </div>
-        <div class="col-1">
-          <p class="p-heading--three">h3</p>
-          <p class="p-heading--five">h5</p>
-        </div>
-        <div class="col-1">
-          <div class="col-6">
-            <p class="p-heading--three">h3</p>
-            <p class="p-heading--six">h6</p>
-          </div>
-          <div class="col-6">
-            <p class="p-heading--three">&nbsp;</p>
-            <p>p</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  <div class="row">
-  <hr>
-</div>
-    <div class="row p-divider">
-      <div class="col-6 p-divider__block">
-        <h4>h4</h4>
-        <div class="col-1 u-no-margin--left">
-          <h4>h4</h4>
-          <h1>h1</h1>
-        </div>
-        <div class="col-1">
-          <h4>h4</h4>
-          <h2>h2</h2>
-        </div>
-        <div class="col-1">
-          <h4>h4</h4>
-          <h3>h3</h3>
-        </div>
-        <div class="col-1">
-          <h4>h4</h4>
-          <h4>h4</h4>
-        </div>
-        <div class="col-1">
-          <h4>h4</h4>
-          <h5>h5</h5>
-        </div>
-        <div class="col-1">
-          <div class="col-6">
-            <h4>h4</h4>
-            <h6>h6</h6>
-          </div>
-          <div class="col-6">
-            <h4>&nbsp;</h4>
-            <p>p</p>
-          </div>
-        </div>
-      </div>
-      <div class="col-6 p-divider__block">
-        <p class="p-heading--four">p-heading--four</p>
-        <div class="col-1 u-no-margin--left">
-          <p class="p-heading--four">h4</p>
-          <p class="p-heading--one">h1</p>
-        </div>
-        <div class="col-1">
-          <p class="p-heading--four">h4</p>
-          <p class="p-heading--two">h2</p>
-        </div>
-        <div class="col-1">
-          <p class="p-heading--four">h4</p>
-          <p class="p-heading--three">h3</p>
-        </div>
-        <div class="col-1">
-          <p class="p-heading--four">h4</p>
-          <p class="p-heading--four">h4</p>
-        </div>
-        <div class="col-1">
-          <p class="p-heading--four">h4</p>
-          <p class="p-heading--five">h5</p>
-        </div>
-        <div class="col-1">
-          <div class="col-6">
-            <p class="p-heading--four">h4</p>
-            <p class="p-heading--six">h6</p>
-          </div>
-          <div class="col-6">
-            <p class="p-heading--four">&nbsp;</p>
-            <p>p</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  <div class="row">
-  <hr>
-</div>
-    <div class="row p-divider">
-      <div class="col-6 p-divider__block">
-        <h5>h5</h5>
-        <div class="col-1 u-no-margin--left">
-          <h5>h5</h5>
-          <h1>h1</h1>
-        </div>
-        <div class="col-1">
-          <h5>h5</h5>
-          <h2>h2</h2>
-        </div>
-        <div class="col-1">
-          <h5>h5</h5>
-          <h3>h3</h3>
-        </div>
-        <div class="col-1">
-          <h5>h5</h5>
-          <h4>h4</h4>
-        </div>
-        <div class="col-1">
-          <h5>h5</h5>
-          <h5>h5</h5>
-        </div>
-        <div class="col-1">
-          <div class="col-6">
-            <h5>h5</h5>
-            <h6>h6</h6>
-          </div>
-        <div class="col-2">
-          <h5>&nbsp;</h5>
-          <p>p</p>
-        </div>
-        </div>
-      </div>
-      <div class="col-6 p-divider__block">
-        <p class="p-heading--five">p-heading--five</p>
-        <div class="col-1 u-no-margin--left">
-          <p class="p-heading--five">h5</p>
-          <p class="p-heading--one">h1</p>
-        </div>
-        <div class="col-1">
-          <p class="p-heading--five">h5</p>
-          <p class="p-heading--two">h2</p>
-        </div>
-        <div class="col-1">
-          <p class="p-heading--five">h5</p>
-          <p class="p-heading--three">h3</p>
-        </div>
-        <div class="col-1">
-          <p class="p-heading--five">h5</p>
-          <p class="p-heading--four">h4</p>
-        </div>
-        <div class="col-1">
-          <p class="p-heading--five">h5</p>
-          <p class="p-heading--five">h5</p>
-        </div>
-        <div class="col-1">
-          <div class="col-6">
-            <p class="p-heading--five">h5</p>
-            <p class="p-heading--six">h6</p>
-          </div>
-          <div class="col-6">
-            <p class="p-heading--five">&nbsp;</p>
-            <p>p</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  <div class="row">
-  <hr>
-</div>
-  <div class="row p-divider">
-    <div class="col-6 p-divider__block">
-      <h6>h6</h6>
-      <div class="col-1 u-no-margin--left">
-        <h6>h6</h6>
-        <h1>h1</h1>
-      </div>
-      <div class="col-1">
-        <h6>h6</h6>
-        <h2>h2</h2>
-      </div>
-      <div class="col-1">
-        <h6>h6</h6>
-        <h3>h3</h3>
-      </div>
-      <div class="col-1">
-        <h6>h6</h6>
-        <h4>h4</h4>
-      </div>
-      <div class="col-1">
-        <h6>h6</h6>
-        <h5>h5</h5>
-      </div>
-      <div class="col-1">
-        <div class="col-6">
-          <h6>h6</h6>
-          <h6>h6</h6>
-        </div>
-        <div class="col-6">
-          <h6>&nbsp;</h6>
-          <p>p</p>
-        </div>
-      </div>
-    </div>
-    <div class="col-6 p-divider__block">
-      <p class="p-heading--six">p-heading--six</p>
-      <div class="col-1 u-no-margin--left">
-        <p class="p-heading--six">h6</p>
-        <p class="p-heading--one">h1</p>
-      </div>
-      <div class="col-1">
-        <p class="p-heading--six">h6</p>
-        <p class="p-heading--two">h2</p>
-      </div>
-      <div class="col-1">
-        <p class="p-heading--six">h6</p>
-        <p class="p-heading--three">h3</p>
-      </div>
-      <div class="col-1">
-        <p class="p-heading--six">h6</p>
-        <p class="p-heading--four">h4</p>
-      </div>
-      <div class="col-1">
-        <p class="p-heading--six">h6</p>
-        <p class="p-heading--five">h5</p>
-      </div>
-      <div class="col-1">
-        <div class="col-6">
-          <p class="p-heading--six">h6</p>
-          <p class="p-heading--six">h6</p>
-        </div>
-        <div class="col-6">
-          <p class="p-heading--six">&nbsp</p>
-          <p>p</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
--->
-
-<!-- <p>Headings preceding block level element</p> -->
-<div class="p-strip--light is-shallow">
-  <div class="row" style="max-width: 100%">
-    <p>Headings preceding block level element</p>
-  </div>
-  <div class="row" style="max-width: 100%">
-    <hr>
-  </div>
-  <div class="row" style="max-width: 100%">
-    <div class="col-2">
-      <h1>H1</h1>
-      <div class="p-card">
-        <h1 class="p-card__title">Title</h1>
-        <p class="p-card__content">Use data triggers to schedule content.</p>
-      </div>
-    </div>
-    <div class="col-2">
-      <h2>H2</h2>
-      <div class="p-card">
-        <h2 class="p-card__title">Title</h2>
-        <p class="p-card__content">Use data triggers to schedule content.</p>
-      </div>
-    </div>
-    <div class="col-2">
-      <h3>H3</h3>
-      <div class="p-card">
-        <h3 class="p-card__title">Title</h3>
-        <p class="p-card__content">Use data triggers to schedule content.</p>
-      </div>
-    </div>
-    <div class="col-2">
-      <h4>H4 </h4>
-      <div class="p-card">
-        <h4 class="p-card__title">Title</h4>
-        <p class="p-card__content">Use data triggers to schedule content.</p>
-      </div>
-    </div>
-    <div class="col-2">
-      <h5>H5</h5>
-      <div class="p-card">
-        <h5 class="p-card__title">Title</h5>
-        <p class="p-card__content">Use data triggers to schedule content.</p>
-      </div>
-    </div>
-    <div class="col-1">
-      <h6>H6</h6>
-      <div class="p-card">
-        <h6 class="p-card__title">Title</h6>
-      </div>
-    </div>
-    <div class="col-1">
-      <p>P</p>
-      <div class="p-card">
-        <p class="p-card__title">Title</p>
-      </div>
-    </div>
-
-  </div>
-</div>
-
-<!-- <p>Single heading or paragraph inside card</p> -->
-<!-- <div class="p-strip--light is-shallow">
-  <div class="row" style="max-width: 100%">
-    <p>Single heading or paragraph inside card</p>
-  </div>
-  <div class="row" style="max-width: 100%">
-    <hr>
-  </div>
-  <div class="row" style="max-width: 100%">
-    <div class="col-2">
-      <h1>H1</h1>
-      <div class="p-card">
-        <h1 class="p-card__title">Title</h1>
-      </div>
-    </div>
-    <div class="col-2">
-      <h2>H2</h2>
-      <div class="p-card">
-        <h2 class="p-card__title">Title</h2>
-      </div>
-    </div>
-    <div class="col-2">
-      <h3>H3</h3>
-      <div class="p-card">
-        <h3 class="p-card__title">Title</h3>
-      </div>
-    </div>
-    <div class="col-2">
-      <h4>H4 </h4>
-      <div class="p-card">
-        <h4 class="p-card__title">Title</h4>
-      </div>
-    </div>
-    <div class="col-2">
-      <h5>H5</h5>
-      <div class="p-card">
-        <h5 class="p-card__title">Title</h5>
-      </div>
-    </div>
-    <div class="col-1">
-      <h6>H6</h6>
-      <div class="p-card">
-        <h6 class="p-card__title">Title</h6>
-      </div>
-    </div>
-    <div class="col-1">
-      <p>p</p>
-      <div class="p-card">
-        <p class="p-card__title">Title</p>
-      </div>
-    </div>
-
-  </div>
-</div> -->
-
-<!-- <p>Headings sandwitched between paragraphs</p> -->
-<!-- <div class="p-strip is-shallow">
-  <div class="row" style="max-width: 100%">
-    <p>Headings sandwitched between paragraphs</p>
-  </div>
-  <div class="row" style="max-width: 100%">
-    <hr>
-  </div>
-  <div class="row" style="max-width: 100%">
-    <div class="col-2">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
-      <h1>H1</h1>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
-    </div>
-    <div class="col-2">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
-      <h2>H two</h2>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
-    </div>
-    <div class="col-2">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
-      <h3>H three</h3>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
-    </div>
-    <div class="col-2">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
-      <h4>Heading four</h4>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
-    </div>
-    <div class="col-2">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
-      <h5>Heading five</h5>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-    </div>
-    <div class="col-2">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
-      <h6>Heading six</h6>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-      <button href="#">Long button name</button>
-      <button href="#">Confirm</button>
-    </div>
-  </div>
-</div> -->
-
-<!-- blog text -->
-<div class="p-strip is-shallow">
-  <div class="row" style="max-width: 100%">
-    <hr>
-  </div>
-  <div class="row">
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
-    <h1>Heading one</h1>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
-    <h2>Heading two</h2>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
-    <h3>Heading three</h3>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
-    <h4>Heading four</h4>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
-    <h5>Heading five</h5>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
-    <h6>Heading six</h6>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
-
-    <p class="p-muted-heading">Muted heading</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
-  </div>
-</div>
-
-<section class="p-strip is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-9">
-      <h1>Canonical’s AI and ML solutions feature…</h1>
-      <p class="p-heading--two">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
-      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
-      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
-      <button>Contact us</button>
-      <p><a href="/ai/contact-us?product=ai-features">Contact us for machine learning, deep learning and AI consulting&nbsp;›</a></p>
-    </div>
-    <div class="col-3 prefix-1 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
-    </div>
-  </div>
-</section>
-<section class="p-strip is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-9">
-      <h1>Canonical’s AI and ML solutions feature…</h1>
-      <p class="p-heading--three">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
-      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
-      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
-      <button>Contact us</button>
-    </div>
-    <div class="col-3 prefix-1 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-9">
-      <h1>Canonical’s AI and ML solutions feature…</h1>
-      <p class="p-heading--four">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
-      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
-      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
-      <button>Contact us</button>
-    </div>
-    <div class="col-3 prefix-1 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-9">
-      <h2>Canonical’s AI and ML solutions feature…</h2>
-      <p class="p-heading--three">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
-      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
-      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
-      <button>Contact us</button>
-    </div>
-    <div class="col-3 prefix-1 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-9">
-      <h2>Canonical’s AI and ML solutions feature…</h2>
-      <p class="p-heading--four">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
-      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
-      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
-      <button>Contact us</button>
-    </div>
-    <div class="col-3 prefix-1 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
-    </div>
-  </div>
-</section>
+            var bg = new baselineGrid();
+            var paras = new makePragraphs();
+            document.addEventListener('DOMContentLoaded', () => {
+                paras.create();
+                bg.create();
+                bg.addBaselineGridToggle();
+                bg.initGridToggle('.p-switch.js-pseudo-baseline-toggle');
+            });
+            window.addEventListener('resize', () => { bg.update(); });
+        }
+    </script>

--- a/examples/templates/typographic-spacing.html
+++ b/examples/templates/typographic-spacing.html
@@ -3,163 +3,1385 @@ layout: default
 title: Typographic spacing
 category: _templates
 ---
-
-<div class="p-strip is-shallow">
-</div>
 <style>
-  body {
-    position: relative;
-  }
-
-  .controls-pseudo {
-    bottom: .5rem;
-    padding: .75rem;
-    position: fixed;
-    left: .5rem;
-    z-index: 101;
-  }
-
-  .u-pseudo-baseline-container {
-    bottom: 0;
-    height: 100%;
-    left: 0;
-    overflow: hidden;
-    pointer-events: none;
-    position: absolute;
-    right: 0;
-    top: 0;
-    width: 100%;
-    z-index: 100;
-  }
-
-  .u-pseudo-baseline {
-    font-size: 0;
-    height: 8px;
-    margin: 0;
-    pointer-events: none;
-    position: relative;
-    width: 100%;
-  }
-
-  @media (min-width: 1680px) {
-    .u-pseudo-baseline {
-      height: 9px;
-    }
-  }
-
-  .u-pseudo-baseline::after {
-    border-bottom: 1px solid rgba(0, 0, 0, .1);
-    bottom: 0;
-    content: '';
-    height: 1px;
-    left: 0;
-    position: absolute;
-    right: 0;
+  .flex-container {
+    display: flex;
+    justify-content: space-between;
   }
 </style>
-    <script>
-        var VF_ENV = "DEV";
-        if (VF_ENV === "DEV") {
-            fragmentFromString = function fragmentFromString(strHTML) {
-                var temp = document.createElement('template');
-                temp.innerHTML = strHTML;
-                return temp.content;
-            }
 
-            class baselineGrid {
-                constructor() {
-                    this.target = document.body;
-                    this.baselineHeight = 8;
-                    this.baselineContainerClassName = "u-pseudo-baseline-container";
-                    this.baselineRowClassName = "u-pseudo-baseline";
-                    this.toggleGridClass = "u-hide";
-                }
-                addBaselineGridToggle() {
-                    var controls = fragmentFromString('<div class="controls-pseudo"><label><input type="checkbox" class="p-switch js-pseudo-baseline-toggle" /><div class="p-switch__slider"></div></label></div>');
-                    this.target.appendChild(controls);
-                }
-                appendBaselineRow(parent) {
-                    var baseline = document.createElement('div');
-                    baseline.classList.add(this.baselineRowClassName);
-                    parent.appendChild(baseline);
-                }
-                baselineCount() {
-                    return Math.floor(document.documentElement.scrollHeight / this.baselineHeight);
-                }
-                create() {
-                    var baselineContainer = document.createElement('div'),
-                        fragment = document.createDocumentFragment(),
-                        documentHeight = document.documentElement.scrollHeight,
-                        baselineCount = this.baselineCount(documentHeight);
+<!-- h1+others -->
+<div class="flex-container">
+  <div class="flex-col">
+    <h1>Canonical’s AI and ML solutions feature…</h1>
+    <h1>Architectural freedom. Fully automated operations.</h1>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+  </div>
+  <div class="flex-col">
+    <h1>Canonical’s AI and ML solutions feature…</h1>
+    <h2>Architectural freedom. Fully automated operations.</h2>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <a href="#" class="p-button">Get started</a>
+  </div>
+  <div class="flex-col">
+    <h1>Canonical’s AI and ML solutions feature…</h1>
+    <h3>Architectural freedom. Fully automated operations.</h3>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h1>Canonical’s AI and ML solutions feature…</h1>
+    <h4>Architectural freedom. Fully automated operations.</h4>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h1>Canonical’s AI and ML solutions feature…</h1>
+    <h5>Architectural freedom. Fully automated operations.</h5>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h1>Canonical’s AI and ML solutions feature…</h1>
+    <h6>Architectural freedom. Fully automated operations.</h6>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+</div>
 
-                    baselineContainer.classList.add(this.baselineContainerClassName);
+<!-- h2+others -->
+<div class="flex-container">
+  <div class="flex-col">
+    <h2>Canonical’s AI and ML solutions feature…</h2>
+    <h1>Architectural freedom. Fully automated operations.</h1>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+  </div>
+  <div class="flex-col">
+    <h2>Canonical’s AI and ML solutions feature…</h2>
+    <h2>Architectural freedom. Fully automated operations.</h2>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <a href="#" class="p-button">Get started</a>
+  </div>
+  <div class="flex-col">
+    <h2>Canonical’s AI and ML solutions feature…</h2>
+    <h3>Architectural freedom. Fully automated operations.</h3>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h2>Canonical’s AI and ML solutions feature…</h2>
+    <h4>Architectural freedom. Fully automated operations.</h4>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h2>Canonical’s AI and ML solutions feature…</h2>
+    <h5>Architectural freedom. Fully automated operations.</h5>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h2>Canonical’s AI and ML solutions feature…</h2>
+    <h6>Architectural freedom. Fully automated operations.</h6>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+</div>
 
-                    if (!this.showGrid) {
-                        baselineContainer.classList.add(this.toggleGridClass);
-                    }
-                    for (var i = 0; i < baselineCount; i++) {
-                        this.appendBaselineRow(baselineContainer);
-                    }
-                    fragment.appendChild(baselineContainer);
-                    this.target.appendChild(fragment);
-                    this.baselineContainer = document.querySelector('.u-pseudo-baseline-container');
-                }
-                initGridToggle(switchBtn) {
-                    var toggle = document.querySelector(switchBtn);
+<!-- h3 + others -->
+<div class="flex-container">
+  <div class="flex-col">
+    <h3>Canonical’s AI and ML solutions feature…</h3>
+    <h1>Architectural freedom. Fully automated operations.</h1>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+  </div>
+  <div class="flex-col">
+    <h3>Canonical’s AI and ML solutions feature…</h3>
+    <h2>Architectural freedom. Fully automated operations.</h2>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <a href="#" class="p-button">Get started</a>
+  </div>
+  <div class="flex-col">
+    <h3>Canonical’s AI and ML solutions feature…</h3>
+    <h3>Architectural freedom. Fully automated operations.</h3>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h3>Canonical’s AI and ML solutions feature…</h3>
+    <h4>Architectural freedom. Fully automated operations.</h4>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h3>Canonical’s AI and ML solutions feature…</h3>
+    <h5>Architectural freedom. Fully automated operations.</h5>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h3>Canonical’s AI and ML solutions feature…</h3>
+    <h6>Architectural freedom. Fully automated operations.</h6>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+</div>
 
-                    toggle.addEventListener('click', function (event) {
-                        this.baselineContainer.classList.toggle(this.toggleGridClass);
-                    }.bind(this));
-                }
-                update() {
-                    this.baselineContainer.remove();
-                    this.create();
-                }
-            }
+<!-- h4 + others -->
+<div class="flex-container">
+  <div class="flex-col">
+    <h4>Canonical’s AI and ML solutions feature…</h4>
+    <h1>Architectural freedom. Fully automated operations.</h1>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+  </div>
+  <div class="flex-col">
+    <h4>Canonical’s AI and ML solutions feature…</h4>
+    <h2>Architectural freedom. Fully automated operations.</h2>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <a href="#" class="p-button">Get started</a>
+  </div>
+  <div class="flex-col">
+    <h4>Canonical’s AI and ML solutions feature…</h4>
+    <h3>Architectural freedom. Fully automated operations.</h3>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h4>Canonical’s AI and ML solutions feature…</h4>
+    <h4>Architectural freedom. Fully automated operations.</h4>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h4>Canonical’s AI and ML solutions feature…</h4>
+    <h5>Architectural freedom. Fully automated operations.</h5>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h4>Canonical’s AI and ML solutions feature…</h4>
+    <h6>Architectural freedom. Fully automated operations.</h6>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+</div>
 
-            class makePragraphs {
-                constructor() {
-                    this.target = document.body;
-                    this.numParagraphs = 1000;
-                }
-                appendP(parent, i) {
-                    var para = document.createElement('p'),
-                        rowNum = "<strong># " + arguments[1] + "</strong>",
-                        lorem = " Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";
+<!-- h5 + others -->
+<div class="flex-container">
+  <div class="flex-col">
+    <h5>Canonical’s AI and ML solutions feature…</h5>
+    <h1>Architectural freedom. Fully automated operations.</h1>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+  </div>
+  <div class="flex-col">
+    <h5>Canonical’s AI and ML solutions feature…</h5>
+    <h2>Architectural freedom. Fully automated operations.</h2>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <a href="#" class="p-button">Get started</a>
+  </div>
+  <div class="flex-col">
+    <h5>Canonical’s AI and ML solutions feature…</h5>
+    <h3>Architectural freedom. Fully automated operations.</h3>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h5>Canonical’s AI and ML solutions feature…</h5>
+    <h4>Architectural freedom. Fully automated operations.</h4>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h5>Canonical’s AI and ML solutions feature…</h5>
+    <h5>Architectural freedom. Fully automated operations.</h5>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h5>Canonical’s AI and ML solutions feature…</h5>
+    <h6>Architectural freedom. Fully automated operations.</h6>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+</div>
 
-                    para.innerHTML = rowNum;
-                    for (var i = 0; i < 3; i++) {
-                      para.innerHTML += lorem;
-                    }
+<!-- h6 + others -->
+<div class="flex-container">
+  <div class="flex-col">
+    <h6>Canonical’s AI and ML solutions feature…</h6>
+    <h1>Architectural freedom. Fully automated operations.</h1>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+  </div>
+  <div class="flex-col">
+    <h6>Canonical’s AI and ML solutions feature…</h6>
+    <h2>Architectural freedom. Fully automated operations.</h2>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <a href="#" class="p-button">Get started</a>
+  </div>
+  <div class="flex-col">
+    <h6>Canonical’s AI and ML solutions feature…</h6>
+    <h3>Architectural freedom. Fully automated operations.</h3>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h6>Canonical’s AI and ML solutions feature…</h6>
+    <h4>Architectural freedom. Fully automated operations.</h4>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h6>Canonical’s AI and ML solutions feature…</h6>
+    <h5>Architectural freedom. Fully automated operations.</h5>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+  <div class="flex-col">
+    <h6>Canonical’s AI and ML solutions feature…</h6>
+    <h6>Architectural freedom. Fully automated operations.</h6>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <button>Contact us</button>
+  </div>
+</div>
 
-                    para.classList.add(this.baselineRowClassName);
-                    parent.appendChild(para);
-                }
-                create() {
-                    var pContainer = document.createElement('div'),
-                        fragment = document.createDocumentFragment();
+<!-- / -->
+<div class="flex-container">
+  <div class="flex-col">
+    <input type="radio" name="" id="Radio1">
+    <label for="Radio1">radio</label>
+  </div>
+  <div class="flex-col">
+    <select name="exampleSelect" id="exampleSelect">
+      <option value="" disabled="disabled" selected="">Select</option>
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+      <option value="3">Option 3</option>
+    </select>
+  </div>
+  <div class="flex-col">
+    <textarea id="textarea" rows="3">Textarea</textarea>
+  </div>
+  <div class="flex-col">
+    <label for="exampleInputEmail1">Email address</label>
+  </div>
+  <div class="flex-col">
+    <input type="text" id="exampleInputEmail1" placeholder="Email">
+  </div>
+  <div class="flex-col">
+    <button>Button</button>
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">muted</p>
+  </div>
+  <div class="flex-col">
+    <p>para</p>
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+  </div>
+  <div class="flex-col">
+    <h6>h6</h6>
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+  </div>
+</div>
+<hr>
+<!-- h1 -->
+<div class="flex-container">
+  <div class="flex-col">
+    <h1>h1</h1>
+    <input type="radio" name="" id="Radio1">
+    <label for="Radio1">radio</label>
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+    <select name="exampleSelect" id="exampleSelect">
+      <option value="" disabled="disabled" selected="">Select</option>
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+      <option value="3">Option 3</option>
+    </select>
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+    <textarea id="textarea" rows="3">Textarea</textarea>
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+    <label for="exampleInputEmail1">Email address</label>
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+    <input type="text" id="exampleInputEmail1" placeholder="Email">
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+    <button>Button</button>
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+    <p class="p-muted-heading">muted</p>
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+    <p>para</p>
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+    <h5>h5</h5>
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+    <h6>h6</h6>
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+    <h4>h4</h4>
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+    <h3>h3</h3>
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+    <h2>h2</h2>
+  </div>
+  <div class="flex-col">
+    <h1>h1</h1>
+    <h1>h1</h1>
+  </div>
+</div>
+<hr>
+<!-- h2 -->
+<div class="flex-container">
+  <div class="flex-col">
+    <h2>h2</h2>
+    <input type="radio" name="" id="Radio1">
+    <label for="Radio1">radio</label>
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+    <select name="exampleSelect" id="exampleSelect">
+      <option value="" disabled="disabled" selected="">Select</option>
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+      <option value="3">Option 3</option>
+    </select>
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+    <textarea id="textarea" rows="3">Textarea</textarea>
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+    <label for="exampleInputEmail1">Email address</label>
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+    <input type="text" id="exampleInputEmail1" placeholder="Email">
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+    <button>Button</button>
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+    <p class="p-muted-heading">muted</p>
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+    <p>para</p>
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+    <h5>h5</h5>
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+    <h6>h6</h6>
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+    <h4>h4</h4>
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+    <h3>h3</h3>
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+    <h2>h2</h2>
+  </div>
+  <div class="flex-col">
+    <h2>h2</h2>
+    <h1>h1</h1>
+  </div>
+</div>
+<hr>
+<!-- h3 -->
+<div class="flex-container">
+  <div class="flex-col">
+    <h3>h3</h3>
+    <input type="radio" name="" id="Radio1">
+    <label for="Radio1">radio</label>
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+    <select name="exampleSelect" id="exampleSelect">
+      <option value="" disabled="disabled" selected="">Select</option>
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+      <option value="3">Option 3</option>
+    </select>
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+    <textarea id="textarea" rows="3">Textarea</textarea>
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+    <label for="exampleInputEmail1">Email address</label>
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+    <input type="text" id="exampleInputEmail1" placeholder="Email">
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+    <button>Button</button>
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+    <p class="p-muted-heading">muted</p>
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+    <p>para</p>
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+    <h5>h5</h5>
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+    <h6>h6</h6>
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+    <h4>h4</h4>
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+    <h3>h3</h3>
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+    <h2>h2</h2>
+  </div>
+  <div class="flex-col">
+    <h3>h3</h3>
+    <h1>h1</h1>
+  </div>
+</div>
+<hr>
 
-                    pContainer.classList.add("p-container");
-                    pContainer.classList.add("row");
+<!-- h4 -->
+<div class="flex-container">
+  <div class="flex-col">
+    <h4>h4</h4>
+    <input type="radio" name="" id="Radio1">
+    <label for="Radio1">radio</label>
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+    <select name="exampleSelect" id="exampleSelect">
+      <option value="" disabled="disabled" selected="">Select</option>
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+      <option value="3">Option 3</option>
+    </select>
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+    <textarea id="textarea" rows="3">Textarea</textarea>
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+    <label for="exampleInputEmail1">Email address</label>
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+    <input type="text" id="exampleInputEmail1" placeholder="Email">
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+    <button>Button</button>
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+    <p class="p-muted-heading">muted</p>
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+    <p>para</p>
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+    <h5>h5</h5>
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+    <h6>h6</h6>
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+    <h4>h4</h4>
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+    <h3>h3</h3>
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+    <h2>h2</h2>
+  </div>
+  <div class="flex-col">
+    <h4>h4</h4>
+    <h1>h1</h1>
+  </div>
+</div>
+<hr>
 
-                    for (var i = 0; i < this.numParagraphs; i++) {
-                        this.appendP(pContainer, i);
-                    }
+<!-- h5 -->
+<div class="flex-container">
+  <div class="flex-col">
+    <h5>h5</h5>
+    <input type="radio" name="" id="Radio1">
+    <label for="Radio1">radio</label>
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+    <select name="exampleSelect" id="exampleSelect">
+      <option value="" disabled="disabled" selected="">Select</option>
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+      <option value="3">Option 3</option>
+    </select>
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+    <textarea id="textarea" rows="3">Textarea</textarea>
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+    <label for="exampleInputEmail1">Email address</label>
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+    <input type="text" id="exampleInputEmail1" placeholder="Email">
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+    <button>Button</button>
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+    <p class="p-muted-heading">muted</p>
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+    <p>para</p>
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+    <h5>h5</h5>
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+    <h6>h6</h6>
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+    <h4>h4</h4>
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+    <h3>h3</h3>
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+    <h2>h2</h2>
+  </div>
+  <div class="flex-col">
+    <h5>h5</h5>
+    <h1>h1</h1>
+  </div>
+</div>
+<hr>
 
-                    fragment.appendChild(pContainer);
-                    this.target.appendChild(fragment);
-                    this.pContainer = document.querySelector('.p-container');
-                }
-            }
+<!-- muted -->
+<div class="flex-container">
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <input type="radio" name="" id="Radio1">
+    <label for="Radio1">radio</label>
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <select name="exampleSelect" id="exampleSelect">
+      <option value="" disabled="disabled" selected="">Select</option>
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+      <option value="3">Option 3</option>
+    </select>
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <textarea id="textarea" rows="3">Textarea</textarea>
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <label for="exampleInputEmail1">Email address</label>
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <input type="text" id="exampleInputEmail1" placeholder="Email">
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <button>Button</button>
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <p class="p-muted-heading">muted</p>
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <p>para</p>
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <h5>h5</h5>
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <h6>h6</h6>
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <h4>h4</h4>
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <h3>h3</h3>
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <h2>h2</h2>
+  </div>
+  <div class="flex-col">
+    <p class="p-muted-heading">Muted</p>
+    <h1>h1</h1>
+  </div>
+</div>
+<hr>
 
-            var bg = new baselineGrid();
-            var paras = new makePragraphs();
-            document.addEventListener('DOMContentLoaded', () => {
-                paras.create();
-                bg.create();
-                bg.addBaselineGridToggle();
-                bg.initGridToggle('.p-switch.js-pseudo-baseline-toggle');
-            });
-            window.addEventListener('resize', () => { bg.update(); });
-        }
-    </script>
+<!--
+<div class="p-strip is-shallow">
+  <div class="row p-divider">
+    <div class="col-6 p-divider__block">
+      <h1>h1</h1>
+      <div class="col-1 u-no-margin--left">
+        <h1>h1</h1>
+        <h1>h1</h1>
+      </div>
+      <div class="col-1">
+        <h1>h1</h1>
+        <h2>h2</h2>
+      </div>
+      <div class="col-1">
+        <h1>h1</h1>
+        <h3>h3</h3>
+      </div>
+      <div class="col-1">
+        <h1>h1</h1>
+        <h4>h4</h4>
+      </div>
+      <div class="col-1">
+        <h1>h1</h1>
+        <h5>h5</h5>
+      </div>
+      <div class="col-1">
+        <div class="col-6">
+          <h1>h1</h1>
+          <h6>h6</h6>
+        </div>
+        <div class="col-6">
+          <h1>&nbsp;</h1>
+          <p>p</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-6 p-divider__block">
+      <p class="p-heading--one">p-heading--one</p>
+      <div class="col-1 u-no-margin--left">
+        <p class="p-heading--one">h1</p>
+        <p class="p-heading--one">h1</p>
+      </div>
+      <div class="col-1">
+        <p class="p-heading--one">h1</p>
+        <p class="p-heading--two">h2</p>
+      </div>
+      <div class="col-1">
+        <p class="p-heading--one">h1</p>
+        <p class="p-heading--three">h3</p>
+      </div>
+      <div class="col-1">
+        <p class="p-heading--one">h1</p>
+        <p class="p-heading--four">h4</p>
+      </div>
+      <div class="col-1">
+        <p class="p-heading--one">h1</p>
+        <p class="p-heading--five">h5</p>
+      </div>
+      <div class="col-1">
+        <div class="col-6">
+          <p class="p-heading--one">h1</p>
+          <p class="p-heading--six">h6</p>
+        </div>
+        <div class="col-6">
+          <p class="p-heading--one">&nbsp;</p>
+          <p>p</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <hr>
+  </div>
+  <div class="row p-divider">
+    <div class="col-6 p-divider__block">
+      <h2>h2</h2>
+      <div class="col-1 u-no-margin--left">
+        <h2>h2</h2>
+        <h1>h1</h1>
+      </div>
+      <div class="col-1">
+        <h2>h2</h2>
+        <h2>h2</h2>
+      </div>
+      <div class="col-1">
+        <h2>h2</h2>
+        <h3>h3</h3>
+      </div>
+      <div class="col-1">
+        <h2>h2</h2>
+        <h4>h4</h4>
+      </div>
+      <div class="col-1">
+        <h2>h2</h2>
+        <h5>h5</h5>
+      </div>
+      <div class="col-1">
+        <div class="col-6">
+          <h2>h1</h2>
+          <h6>h6</h6>
+        </div>
+        <div class="col-6">
+          <h2>&nbsp;</h2>
+          <p>p</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-6 p-divider__block">
+      <p class="p-heading--two">p-heading--two</p>
+      <div class="col-1 u-no-margin--left">
+        <p class="p-heading--two">h2</p>
+        <p class="p-heading--one">h1</p>
+      </div>
+      <div class="col-1">
+        <p class="p-heading--two">h2</p>
+        <p class="p-heading--two">h2</p>
+      </div>
+      <div class="col-1">
+        <p class="p-heading--two">h2</p>
+        <p class="p-heading--three">h3</p>
+      </div>
+      <div class="col-1">
+        <p class="p-heading--two">h2</p>
+        <p class="p-heading--four">h4</p>
+      </div>
+      <div class="col-1">
+        <p class="p-heading--two">h2</p>
+        <p class="p-heading--five">h5</p>
+      </div>
+      <div class="col-1">
+        <div class="col-6">
+          <p class="p-heading--two">h2</p>
+          <p class="p-heading--six">h6</p>
+        </div>
+        <div class="col-6">
+          <p class="p-heading--two">&nbsp;</p>
+          <p>p</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <hr>
+  </div>
+    <div class="row p-divider">
+      <div class="col-6 p-divider__block">
+        <h3>h3</h3>
+        <div class="col-1 u-no-margin--left">
+          <h3>h3</h3>
+          <h1>h1</h1>
+        </div>
+        <div class="col-1">
+          <h3>h3</h3>
+          <h2>h2</h2>
+        </div>
+        <div class="col-1">
+          <h3>h3</h3>
+          <h3>h3</h3>
+        </div>
+        <div class="col-1">
+          <h3>h3</h3>
+          <h4>h4</h4>
+        </div>
+        <div class="col-1">
+          <h3>h3</h3>
+          <h5>h5</h5>
+        </div>
+        <div class="col-1">
+          <div class="col-6">
+            <h3>h3</h3>
+            <h6>h6</h6>
+          </div>
+          <div class="col-6">
+            <h3>&nbsp;</h3>
+            <p>p</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-6 p-divider__block">
+        <p class="p-heading--three">p-heading--three</p>
+        <div class="col-1 u-no-margin--left">
+          <p class="p-heading--three">h3</p>
+          <p class="p-heading--one">h1</p>
+        </div>
+        <div class="col-1">
+          <p class="p-heading--three">h3</p>
+          <p class="p-heading--two">h2</p>
+        </div>
+        <div class="col-1">
+          <p class="p-heading--three">h3</p>
+          <p class="p-heading--three">h3</p>
+        </div>
+        <div class="col-1">
+          <p class="p-heading--three">h3</p>
+          <p class="p-heading--four">h4</p>
+        </div>
+        <div class="col-1">
+          <p class="p-heading--three">h3</p>
+          <p class="p-heading--five">h5</p>
+        </div>
+        <div class="col-1">
+          <div class="col-6">
+            <p class="p-heading--three">h3</p>
+            <p class="p-heading--six">h6</p>
+          </div>
+          <div class="col-6">
+            <p class="p-heading--three">&nbsp;</p>
+            <p>p</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  <div class="row">
+  <hr>
+</div>
+    <div class="row p-divider">
+      <div class="col-6 p-divider__block">
+        <h4>h4</h4>
+        <div class="col-1 u-no-margin--left">
+          <h4>h4</h4>
+          <h1>h1</h1>
+        </div>
+        <div class="col-1">
+          <h4>h4</h4>
+          <h2>h2</h2>
+        </div>
+        <div class="col-1">
+          <h4>h4</h4>
+          <h3>h3</h3>
+        </div>
+        <div class="col-1">
+          <h4>h4</h4>
+          <h4>h4</h4>
+        </div>
+        <div class="col-1">
+          <h4>h4</h4>
+          <h5>h5</h5>
+        </div>
+        <div class="col-1">
+          <div class="col-6">
+            <h4>h4</h4>
+            <h6>h6</h6>
+          </div>
+          <div class="col-6">
+            <h4>&nbsp;</h4>
+            <p>p</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-6 p-divider__block">
+        <p class="p-heading--four">p-heading--four</p>
+        <div class="col-1 u-no-margin--left">
+          <p class="p-heading--four">h4</p>
+          <p class="p-heading--one">h1</p>
+        </div>
+        <div class="col-1">
+          <p class="p-heading--four">h4</p>
+          <p class="p-heading--two">h2</p>
+        </div>
+        <div class="col-1">
+          <p class="p-heading--four">h4</p>
+          <p class="p-heading--three">h3</p>
+        </div>
+        <div class="col-1">
+          <p class="p-heading--four">h4</p>
+          <p class="p-heading--four">h4</p>
+        </div>
+        <div class="col-1">
+          <p class="p-heading--four">h4</p>
+          <p class="p-heading--five">h5</p>
+        </div>
+        <div class="col-1">
+          <div class="col-6">
+            <p class="p-heading--four">h4</p>
+            <p class="p-heading--six">h6</p>
+          </div>
+          <div class="col-6">
+            <p class="p-heading--four">&nbsp;</p>
+            <p>p</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  <div class="row">
+  <hr>
+</div>
+    <div class="row p-divider">
+      <div class="col-6 p-divider__block">
+        <h5>h5</h5>
+        <div class="col-1 u-no-margin--left">
+          <h5>h5</h5>
+          <h1>h1</h1>
+        </div>
+        <div class="col-1">
+          <h5>h5</h5>
+          <h2>h2</h2>
+        </div>
+        <div class="col-1">
+          <h5>h5</h5>
+          <h3>h3</h3>
+        </div>
+        <div class="col-1">
+          <h5>h5</h5>
+          <h4>h4</h4>
+        </div>
+        <div class="col-1">
+          <h5>h5</h5>
+          <h5>h5</h5>
+        </div>
+        <div class="col-1">
+          <div class="col-6">
+            <h5>h5</h5>
+            <h6>h6</h6>
+          </div>
+        <div class="col-2">
+          <h5>&nbsp;</h5>
+          <p>p</p>
+        </div>
+        </div>
+      </div>
+      <div class="col-6 p-divider__block">
+        <p class="p-heading--five">p-heading--five</p>
+        <div class="col-1 u-no-margin--left">
+          <p class="p-heading--five">h5</p>
+          <p class="p-heading--one">h1</p>
+        </div>
+        <div class="col-1">
+          <p class="p-heading--five">h5</p>
+          <p class="p-heading--two">h2</p>
+        </div>
+        <div class="col-1">
+          <p class="p-heading--five">h5</p>
+          <p class="p-heading--three">h3</p>
+        </div>
+        <div class="col-1">
+          <p class="p-heading--five">h5</p>
+          <p class="p-heading--four">h4</p>
+        </div>
+        <div class="col-1">
+          <p class="p-heading--five">h5</p>
+          <p class="p-heading--five">h5</p>
+        </div>
+        <div class="col-1">
+          <div class="col-6">
+            <p class="p-heading--five">h5</p>
+            <p class="p-heading--six">h6</p>
+          </div>
+          <div class="col-6">
+            <p class="p-heading--five">&nbsp;</p>
+            <p>p</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  <div class="row">
+  <hr>
+</div>
+  <div class="row p-divider">
+    <div class="col-6 p-divider__block">
+      <h6>h6</h6>
+      <div class="col-1 u-no-margin--left">
+        <h6>h6</h6>
+        <h1>h1</h1>
+      </div>
+      <div class="col-1">
+        <h6>h6</h6>
+        <h2>h2</h2>
+      </div>
+      <div class="col-1">
+        <h6>h6</h6>
+        <h3>h3</h3>
+      </div>
+      <div class="col-1">
+        <h6>h6</h6>
+        <h4>h4</h4>
+      </div>
+      <div class="col-1">
+        <h6>h6</h6>
+        <h5>h5</h5>
+      </div>
+      <div class="col-1">
+        <div class="col-6">
+          <h6>h6</h6>
+          <h6>h6</h6>
+        </div>
+        <div class="col-6">
+          <h6>&nbsp;</h6>
+          <p>p</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-6 p-divider__block">
+      <p class="p-heading--six">p-heading--six</p>
+      <div class="col-1 u-no-margin--left">
+        <p class="p-heading--six">h6</p>
+        <p class="p-heading--one">h1</p>
+      </div>
+      <div class="col-1">
+        <p class="p-heading--six">h6</p>
+        <p class="p-heading--two">h2</p>
+      </div>
+      <div class="col-1">
+        <p class="p-heading--six">h6</p>
+        <p class="p-heading--three">h3</p>
+      </div>
+      <div class="col-1">
+        <p class="p-heading--six">h6</p>
+        <p class="p-heading--four">h4</p>
+      </div>
+      <div class="col-1">
+        <p class="p-heading--six">h6</p>
+        <p class="p-heading--five">h5</p>
+      </div>
+      <div class="col-1">
+        <div class="col-6">
+          <p class="p-heading--six">h6</p>
+          <p class="p-heading--six">h6</p>
+        </div>
+        <div class="col-6">
+          <p class="p-heading--six">&nbsp</p>
+          <p>p</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+-->
+
+<!-- <p>Headings preceding block level element</p> -->
+<div class="p-strip--light is-shallow">
+  <div class="row" style="max-width: 100%">
+    <p>Headings preceding block level element</p>
+  </div>
+  <div class="row" style="max-width: 100%">
+    <hr>
+  </div>
+  <div class="row" style="max-width: 100%">
+    <div class="col-2">
+      <h1>H1</h1>
+      <div class="p-card">
+        <h1 class="p-card__title">Title</h1>
+        <p class="p-card__content">Use data triggers to schedule content.</p>
+      </div>
+    </div>
+    <div class="col-2">
+      <h2>H2</h2>
+      <div class="p-card">
+        <h2 class="p-card__title">Title</h2>
+        <p class="p-card__content">Use data triggers to schedule content.</p>
+      </div>
+    </div>
+    <div class="col-2">
+      <h3>H3</h3>
+      <div class="p-card">
+        <h3 class="p-card__title">Title</h3>
+        <p class="p-card__content">Use data triggers to schedule content.</p>
+      </div>
+    </div>
+    <div class="col-2">
+      <h4>H4 </h4>
+      <div class="p-card">
+        <h4 class="p-card__title">Title</h4>
+        <p class="p-card__content">Use data triggers to schedule content.</p>
+      </div>
+    </div>
+    <div class="col-2">
+      <h5>H5</h5>
+      <div class="p-card">
+        <h5 class="p-card__title">Title</h5>
+        <p class="p-card__content">Use data triggers to schedule content.</p>
+      </div>
+    </div>
+    <div class="col-1">
+      <h6>H6</h6>
+      <div class="p-card">
+        <h6 class="p-card__title">Title</h6>
+      </div>
+    </div>
+    <div class="col-1">
+      <p>P</p>
+      <div class="p-card">
+        <p class="p-card__title">Title</p>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<!-- <p>Single heading or paragraph inside card</p> -->
+<!-- <div class="p-strip--light is-shallow">
+  <div class="row" style="max-width: 100%">
+    <p>Single heading or paragraph inside card</p>
+  </div>
+  <div class="row" style="max-width: 100%">
+    <hr>
+  </div>
+  <div class="row" style="max-width: 100%">
+    <div class="col-2">
+      <h1>H1</h1>
+      <div class="p-card">
+        <h1 class="p-card__title">Title</h1>
+      </div>
+    </div>
+    <div class="col-2">
+      <h2>H2</h2>
+      <div class="p-card">
+        <h2 class="p-card__title">Title</h2>
+      </div>
+    </div>
+    <div class="col-2">
+      <h3>H3</h3>
+      <div class="p-card">
+        <h3 class="p-card__title">Title</h3>
+      </div>
+    </div>
+    <div class="col-2">
+      <h4>H4 </h4>
+      <div class="p-card">
+        <h4 class="p-card__title">Title</h4>
+      </div>
+    </div>
+    <div class="col-2">
+      <h5>H5</h5>
+      <div class="p-card">
+        <h5 class="p-card__title">Title</h5>
+      </div>
+    </div>
+    <div class="col-1">
+      <h6>H6</h6>
+      <div class="p-card">
+        <h6 class="p-card__title">Title</h6>
+      </div>
+    </div>
+    <div class="col-1">
+      <p>p</p>
+      <div class="p-card">
+        <p class="p-card__title">Title</p>
+      </div>
+    </div>
+
+  </div>
+</div> -->
+
+<!-- <p>Headings sandwitched between paragraphs</p> -->
+<!-- <div class="p-strip is-shallow">
+  <div class="row" style="max-width: 100%">
+    <p>Headings sandwitched between paragraphs</p>
+  </div>
+  <div class="row" style="max-width: 100%">
+    <hr>
+  </div>
+  <div class="row" style="max-width: 100%">
+    <div class="col-2">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
+      <h1>H1</h1>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
+    </div>
+    <div class="col-2">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
+      <h2>H two</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
+    </div>
+    <div class="col-2">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
+      <h3>H three</h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
+    </div>
+    <div class="col-2">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
+      <h4>Heading four</h4>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
+    </div>
+    <div class="col-2">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
+      <h5>Heading five</h5>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </div>
+    <div class="col-2">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.</p>
+      <h6>Heading six</h6>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      <button href="#">Long button name</button>
+      <button href="#">Confirm</button>
+    </div>
+  </div>
+</div> -->
+
+<!-- blog text -->
+<div class="p-strip is-shallow">
+  <div class="row" style="max-width: 100%">
+    <hr>
+  </div>
+  <div class="row">
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <h1>Heading one</h1>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <h2>Heading two</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <h3>Heading three</h3>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <h4>Heading four</h4>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <h5>Heading five</h5>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <h6>Heading six</h6>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+
+    <p class="p-muted-heading">Muted heading</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+  </div>
+</div>
+
+<section class="p-strip is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-9">
+      <h1>Canonical’s AI and ML solutions feature…</h1>
+      <p class="p-heading--two">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
+      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
+      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
+      <button>Contact us</button>
+      <p><a href="/ai/contact-us?product=ai-features">Contact us for machine learning, deep learning and AI consulting&nbsp;›</a></p>
+    </div>
+    <div class="col-3 prefix-1 u-vertically-center u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
+    </div>
+  </div>
+</section>
+<section class="p-strip is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-9">
+      <h1>Canonical’s AI and ML solutions feature…</h1>
+      <p class="p-heading--three">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
+      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
+      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
+      <button>Contact us</button>
+    </div>
+    <div class="col-3 prefix-1 u-vertically-center u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-9">
+      <h1>Canonical’s AI and ML solutions feature…</h1>
+      <p class="p-heading--four">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
+      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
+      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
+      <button>Contact us</button>
+    </div>
+    <div class="col-3 prefix-1 u-vertically-center u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-9">
+      <h2>Canonical’s AI and ML solutions feature…</h2>
+      <p class="p-heading--three">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
+      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
+      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
+      <button>Contact us</button>
+    </div>
+    <div class="col-3 prefix-1 u-vertically-center u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-9">
+      <h2>Canonical’s AI and ML solutions feature…</h2>
+      <p class="p-heading--four">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
+      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
+      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
+      <button>Contact us</button>
+    </div>
+    <div class="col-3 prefix-1 u-vertically-center u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
+    </div>
+  </div>
+</section>

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -11,20 +11,20 @@
       font-size: #{map-get($font-sizes, h1-mobile)}rem;
       line-height: map-get($line-heights, h1-mobile);
       margin-bottom: map-get($sp-after, h1-mobile) - map-get($nudges, nudge--h1-mobile);
-      padding-top: map-get($nudges, nudge--h1-mobile);
+      padding-top: map-get($nudges, nudge--h1-mobile) + map-get($browser-rounding-compensations, h1);
     }
 
     @media (min-width: $breakpoint-heading-threshold) {
       font-size: #{map-get($font-sizes, h1)}rem;
       line-height: map-get($line-heights, h1);
       margin-bottom: map-get($sp-after, h1) - map-get($nudges, nudge--h1);
-      padding-top: map-get($nudges, nudge--h1);
+      padding-top: map-get($nudges, nudge--h1) + map-get($browser-rounding-compensations, h1);
     }
 
     @if ($increase-fontsize-on-bigger-screens) {
       @media (min-width: $breakpoint-x-large) {
         margin-bottom: map-get($sp-after, h1) - map-get($nudges, nudge--h1-large);
-        padding-top: map-get($nudges, nudge--h1-large);
+        padding-top: map-get($nudges, nudge--h1-large) + map-get($browser-rounding-compensations, h1);
       }
     }
   }
@@ -39,14 +39,14 @@
       font-size: #{map-get($font-sizes, h2-mobile)}rem;
       line-height: map-get($line-heights, h2-mobile);
       margin-bottom: map-get($sp-after, h2-mobile) - map-get($nudges, nudge--h2-mobile);
-      padding-top: map-get($nudges, nudge--h2-mobile);
+      padding-top: map-get($nudges, nudge--h2-mobile) + map-get($browser-rounding-compensations, h2);
     }
 
     @media (min-width: $breakpoint-heading-threshold) {
       font-size: #{map-get($font-sizes, h2)}rem;
       line-height: map-get($line-heights, h2);
       margin-bottom: map-get($sp-after, h2) - map-get($nudges, nudge--h2);
-      padding-top: map-get($nudges, nudge--h2);
+      padding-top: map-get($nudges, nudge--h2) + map-get($browser-rounding-compensations, h2);
     }
   }
 
@@ -58,7 +58,7 @@
     line-height: map-get($line-heights, h3);
     margin-bottom: map-get($sp-after, h3) - map-get($nudges, nudge--h3);
     margin-top: -#{$sp-unit};
-    padding-top: map-get($nudges, nudge--h3);
+    padding-top: map-get($nudges, nudge--h3) + map-get($browser-rounding-compensations, h3);
 
     @media (max-width: $breakpoint-heading-threshold) {
       font-size: #{map-get($font-sizes, h3-mobile)}rem;
@@ -78,20 +78,20 @@
       font-size: #{map-get($font-sizes, h4-mobile)}rem;
       line-height: map-get($line-heights, h4-mobile);
       margin-bottom: map-get($sp-after, h4-mobile) - map-get($nudges, nudge--h4-mobile);
-      padding-top: map-get($nudges, nudge--h4-mobile);
+      padding-top: map-get($nudges, nudge--h4-mobile) + map-get($browser-rounding-compensations, h4);
     }
 
     @media (min-width: $breakpoint-heading-threshold) {
       font-size: #{map-get($font-sizes, h4)}rem;
       line-height: map-get($line-heights, h4);
       margin-bottom: map-get($sp-after, h4) - map-get($nudges, nudge--h4);
-      padding-top: map-get($nudges, nudge--h4);
+      padding-top: map-get($nudges, nudge--h4) + map-get($browser-rounding-compensations, h4);
     }
 
     @if ($increase-fontsize-on-bigger-screens) {
       @media (min-width: $breakpoint-x-large) {
         margin-bottom: map-get($sp-after, h4) - map-get($nudges, nudge--h4-large);
-        padding-top: map-get($nudges, nudge--h4-large);
+        padding-top: map-get($nudges, nudge--h4-large) + map-get($browser-rounding-compensations, h4);
       }
     }
   }
@@ -104,7 +104,7 @@
     line-height: map-get($line-heights, default-text);
     margin-bottom: map-get($sp-after, p) - map-get($nudges, nudge--p);
     margin-top: 0;
-    padding-top: map-get($nudges, nudge--p);
+    padding-top: map-get($nudges, nudge--p) + map-get($browser-rounding-compensations, h5);
   }
 
   %vf-heading-6 {
@@ -115,14 +115,20 @@
     line-height: map-get($line-heights, default-text);
     margin-bottom: map-get($sp-after, p) - map-get($nudges, nudge--p);
     margin-top: 0;
-    padding-top: map-get($nudges, nudge--p) + 0.0015;
+    padding-top: map-get($nudges, nudge--h6) + map-get($browser-rounding-compensations, h6);
+
+    @if ($increase-fontsize-on-bigger-screens) {
+      @media (min-width: $breakpoint-x-large) {
+        padding-top: map-get($nudges, nudge--h6-large) + map-get($browser-rounding-compensations, h6);
+      }
+    }
   }
 
   %default-text {
     line-height: map-get($line-heights, default-text);
     margin-bottom: map-get($sp-after, default-text) - map-get($nudges, nudge--p);
     margin-top: 0;
-    padding-top: map-get($nudges, nudge--p) + 0;
+    padding-top: map-get($nudges, nudge--p) + map-get($browser-rounding-compensations, p);
   }
 
   %paragraph {
@@ -134,7 +140,13 @@
     font-size: #{map-get($font-sizes, small)}rem;
     line-height: map-get($line-heights, small);
     margin-bottom: map-get($sp-after, small) - map-get($nudges, nudge--small);
-    padding-top: map-get($nudges, nudge--small);
+    padding-top: map-get($nudges, nudge--small) + map-get($browser-rounding-compensations, small);
+
+    @if ($increase-fontsize-on-bigger-screens) {
+      @media (min-width: $breakpoint-x-large) {
+        padding-top: map-get($nudges, nudge--small) + map-get($browser-rounding-compensations, small-largescreen);
+      }
+    }
   }
 
   %muted-heading {

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -115,14 +115,14 @@
     line-height: map-get($line-heights, default-text);
     margin-bottom: map-get($sp-after, p) - map-get($nudges, nudge--p);
     margin-top: 0;
-    padding-top: map-get($nudges, nudge--p);
+    padding-top: map-get($nudges, nudge--p) + 0.0015;
   }
 
   %default-text {
     line-height: map-get($line-heights, default-text);
     margin-bottom: map-get($sp-after, default-text) - map-get($nudges, nudge--p);
     margin-top: 0;
-    padding-top: map-get($nudges, nudge--p);
+    padding-top: map-get($nudges, nudge--p) + 0;
   }
 
   %paragraph {

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -35,7 +35,7 @@ $line-heights: (
   small: $sp-unit * 2
 ) !default;
 
-// baseline nudges for type scale ratio of (16/14) squared
+// baseline nudges for type scale ratio of (16/14)^2
 $nudges: (
   nudge--h1-large: 0.15rem,
   nudge--h4-large: 0,
@@ -43,6 +43,8 @@ $nudges: (
   nudge--h2: 0.2rem,
   nudge--h3: 0.1rem,
   nudge--h4: 0.05rem,
+  nudge--h6: 0.338rem,
+  nudge--h6-large: 0.345rem,
   nudge--h1-mobile: 0.165rem,
   nudge--h2-mobile: 0.1rem,
   nudge--h3-mobile: 0.5rem,
@@ -50,6 +52,20 @@ $nudges: (
   nudge--p: 0.4rem,
   nudge--p-ubuntumono: 0.45rem,
   nudge--small: 0.2rem
+) !default;
+
+// Correct baseline drift due to browser rounding. (Visible in text > 1000 lines)
+// It is applied only to padding-top.
+$browser-rounding-compensations: (
+  small: 0.0005rem,
+  small-largescreen: 0.0006rem,
+  p: 0.0005rem,
+  h6: 0,
+  h5: 0.001rem,
+  h4: 0.001rem,
+  h3: 0.001rem,
+  h2: 0.001rem,
+  h1: 0.001rem
 ) !default;
 
 //scaling factor


### PR DESCRIPTION
## Done

Due to browser rounding, text elements start to drift from the baseline grid after a few hundred lines.
To minimise this, I'm adding a small constant that forces the rounding to happen so that text stays on the baseline. 

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Paste 1000 lines of text in any heading style (or checkout this [file ](https://github.com/lyubomir-popov/vanilla-framework/blob/thousand-line-test/examples/templates/typographic-spacing.html) that includes a script to generate text)
- Observe no drift from baseline

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
