### PR TITLE
Remove strong link

### DIFF
--- a/docs/en/patterns/links.md
+++ b/docs/en/patterns/links.md
@@ -11,7 +11,7 @@ Regular links are a colour defined by `$color-link` (default: `#007aa6`) and are
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/links/"
     class="js-example">
-    View example of the default link pattern
+View example of the default link pattern
 </a>
 
 ### External link
@@ -20,11 +20,11 @@ The `.p-link--external` class should be used on hyperlinks that go to a differen
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/links/links-external/"
     class="js-example">
-    View example of the external link pattern
+View example of the external link pattern
 </a>
 
 !!! Note:
-    The `p-link--external` class makes use of the fairly new [CSS Masks](http://www.caniuse.com/#search=mask). For support in more browsers you should run your CSS through [an autoprefixer](https://www.npmjs.com/package/autoprefixer) before deploying.
+The `p-link--external` class makes use of the fairly new [CSS Masks](http://www.caniuse.com/#search=mask). For support in more browsers you should run your CSS through [an autoprefixer](https://www.npmjs.com/package/autoprefixer) before deploying.
 
 ### Soft link
 
@@ -32,16 +32,7 @@ The `.p-link--soft` class should be used on hyperlinks where many links are grou
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/links/links-soft/"
     class="js-example">
-    View example of the soft link pattern
-</a>
-
-### Strong link
-
-The `.p-link--strong` class should be used on hyperlinks that require emphasis or on a dark background.
-
-<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/links/links-strong/"
-    class="js-example">
-    View example of the strong link pattern
+View example of the soft link pattern
 </a>
 
 ### Inverted link
@@ -50,7 +41,7 @@ The `.p-link--inverted` class should be used where links are placed on a dark ba
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/links/links-inverted/"
     class="js-example">
-    View example of the inverted link pattern
+View example of the inverted link pattern
 </a>
 
 ### Back to top link
@@ -59,11 +50,11 @@ The `.p-top` link can be used to make it easier to go back to the top on long pa
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/links/links-back-to-top/"
     class="js-example">
-    View example of the back to top pattern
+View example of the back to top pattern
 </a>
 
 <hr />
 
 ### Design
 
-* [Links design](https://github.com/ubuntudesign/vanilla-design/tree/master/Links)
+- [Links design](https://github.com/ubuntudesign/vanilla-design/tree/master/Links)

--- a/examples/patterns/links/links-external.html
+++ b/examples/patterns/links/links-external.html
@@ -7,6 +7,3 @@ category: _patterns
 <p>
   <a href="#" class="p-link--external">External link</a>
 </p>
-<p>
-  <a href="#" class="p-link--external p-link--strong">External / Strong link</a>
-</p>

--- a/examples/patterns/links/links-strong.html
+++ b/examples/patterns/links/links-strong.html
@@ -1,7 +1,0 @@
----
-layout: default
-title: Links / Strong
-category: _patterns
----
-
-<a href="#" class="p-link--strong">Strong link</a>

--- a/examples/templates/external-links.html
+++ b/examples/templates/external-links.html
@@ -9,7 +9,6 @@ category: _templates
     <div class="col-12">
       <p><a href="#">Link</a></p>
       <p><a class="p-link--external">External link</a></p>
-      <p><a class="p-link--external p-link--strong">Strong external link</a></p>
       <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
       <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
       <p><a class="p-button--negative"><span class="p-link--external">External negative button</span></a></p>
@@ -24,7 +23,6 @@ category: _templates
     <div class="col-12">
       <p><a href="#">Link</a></p>
       <p><a class="p-link--external">External link</a></p>
-      <p><a class="p-link--external p-link--strong">Strong external link</a></p>
       <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
       <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
       <p><a class="p-button--negative"><span class="p-link--external">External negative button</span></a></p>
@@ -39,7 +37,6 @@ category: _templates
     <div class="col-12">
       <p><a href="#">Link</a></p>
       <p><a class="p-link--external">External link</a></p>
-      <p><a class="p-link--external p-link--strong">Strong external link</a></p>
       <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
       <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
       <p><a class="p-button--negative"><span class="p-link--external">External negative button</span></a></p>
@@ -54,7 +51,6 @@ category: _templates
     <div class="col-12">
       <p><a href="#">Link</a></p>
       <p><a class="p-link--external">External link</a></p>
-      <p><a class="p-link--external p-link--strong">Strong external link</a></p>
       <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
       <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
       <p><a class="p-button--negative"><span class="p-link--external">External negative button</span></a></p>
@@ -69,7 +65,6 @@ category: _templates
     <div class="col-12">
       <p><a href="#">Link</a></p>
       <p><a class="p-link--external">External link</a></p>
-      <p><a class="p-link--external p-link--strong">Strong external link</a></p>
       <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
       <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
       <p><a class="p-button--negative"><span class="p-link--external">External negative button</span></a></p>
@@ -84,7 +79,6 @@ category: _templates
     <div class="col-12">
       <p><a href="#">Link</a></p>
       <p><a class="p-link--external">External link</a></p>
-      <p><a class="p-link--external p-link--strong">Strong external link</a></p>
       <p><a class="p-button"><span class="p-link--external">External button</span></a></p>
       <p><a class="p-button--positive"><span class="p-link--external">External positive button</span></a></p>
       <p><a class="p-button--negative"><span class="p-link--external">External negative button</span></a></p>
@@ -93,4 +87,3 @@ category: _templates
     </div>
   </div>
 </section>
-

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -162,8 +162,8 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     @include p-max-width;
     cursor: pointer;
     display: block;
-    margin-top: 0;
     margin-bottom: $spv-outer--small + $spv-nudge-compensation;
+    margin-top: 0;
     padding-top: map-get($nudges, nudge--p);
     width: fit-content;
 

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -19,20 +19,6 @@
       }
     }
 
-    &--strong {
-      color: currentColor;
-      font-weight: 400;
-
-      &:visited {
-        color: currentColor;
-      }
-
-      &:hover {
-        color: $color-link;
-        text-decoration: underline;
-      }
-    }
-
     &--inverted {
       color: $color-light;
       font-weight: 400;
@@ -108,7 +94,6 @@
       margin-top: -0.25em;
       padding: 0.25em 1em 0 0;
 
-      &.p-link--strong,
       &.p-link--soft,
       &.sidebar__link {
         @include vf-external-link-icon(vf-url-friendly-color($color-dark));
@@ -167,12 +152,6 @@
     &:hover {
       @include vf-external-link-icon(vf-url-friendly-color($color-link));
     }
-  }
-
-  .p-strip--dark * .p-link--external.p-link--strong,
-  .p-strip--accent * .p-link--external.p-link--strong,
-  .p-strip--image.is-dark * .p-link--external.p-link--strong {
-    @include vf-external-link-icon(vf-url-friendly-color($color-x-light));
   }
 }
 


### PR DESCRIPTION
## Done

Completely removed the `.p-link--strong` class

Drive-by: fixed a lint issue

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- See that the strong link doesn't appear in the list
- `cd docs && ./run`
- See that there are no references to the removed style

## Details

Fixes #1996