### PR TITLE
Un-nest elements in utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - '6.6.0'
 before_install:
-  - rvm install 2.3.0
+  - rvm install 2.4.0
 install:
   - gem install jekyll
   - gem install percy-cli

--- a/scss/_utilities_baseline-grid.scss
+++ b/scss/_utilities_baseline-grid.scss
@@ -21,12 +21,12 @@
       top: $baseline-offset;
       z-index: 100;
     }
+  }
 
-    &__toggle {
-      bottom: $spv-outer--scaleable;
-      position: fixed;
-      right: $sph-outer--large;
-      z-index: 101;
-    }
+  .u-baseline-grid__toggle {
+    bottom: $spv-outer--scaleable;
+    position: fixed;
+    right: $sph-outer--large;
+    z-index: 101;
   }
 }

--- a/scss/_utilities_embedded-media.scss
+++ b/scss/_utilities_embedded-media.scss
@@ -9,13 +9,13 @@
     overflow: hidden;
     padding-bottom: 56.25%;
     position: relative;
+  }
 
-    &__element {
-      height: 100%;
-      left: 0;
-      position: absolute;
-      top: 0;
-      width: 100%;
-    }
+  .u-embedded-media__element {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Done

Un-nest class names in utils. 
Keep classes in full unless absolutely necessary.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- No visual changes

## Details

Fixes #2089 