### PR TITLE
Grid: Add classes to reset margin of first column on rows other than first, per breakpoint

### DIFF
--- a/docs/en/patterns/grid.md
+++ b/docs/en/patterns/grid.md
@@ -17,7 +17,7 @@ Read also: [Breakpoints](/en/settings/breakpoint-settings)
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/grid/default/"
     class="js-example">
-    View example of the default grid
+View example of the default grid
 </a>
 
 ### Empty columns
@@ -32,7 +32,7 @@ By default, prefixes and suffixes only work on top level columns.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/grid/empty-columns/"
     class="js-example">
-    View example of the empty columns within the grid
+View example of the empty columns within the grid
 </a>
 
 ### Nested columns
@@ -41,7 +41,18 @@ Columns can be nested infinitely by adding `.row` classes within columns. Basica
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/grid/nested/"
     class="js-example">
-    View example of the nested columns within the grid
+View example of the nested columns within the grid
+</a>
+
+<hr />
+
+### Clear margin on first col
+
+Columns can wrap on multiple lines within the same `.row`. This is useful in responsive layouts. To ensure proper alignment, the gutter on the first column must be set to zero. We have grid utilities classes which do that:
+
+<a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/grid/column-wrapping/"
+    class="js-example">
+View example of the wrapping columns
 </a>
 
 <hr />

--- a/examples/patterns/grid/column-wrapping.html
+++ b/examples/patterns/grid/column-wrapping.html
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Grid / Column wrapping
+category: _patterns
+---
+<div grid-demo>
+    <div class="row">
+        <div class="mobile-col-1 tablet-col-1 col-2"></div>
+        <div class="mobile-col-1 tablet-col-1 col-2"></div>
+        <div class="mobile-col-1 tablet-col-1 col-2"></div>
+        <div class="mobile-col-1 tablet-col-1 col-2"></div>
+        <div class="mobile-col-1 tablet-col-1 col-2 u-first-col--small"></div>
+        <div class="mobile-col-1 tablet-col-1 col-2"></div>
+        <div class="mobile-col-1 tablet-col-1 col-2 u-first-col--medium u-first-col--large"></div>
+        <div class="mobile-col-1 tablet-col-1 col-2"></div>
+        <div class="mobile-col-1 tablet-col-1 col-2 u-first-col--small"></div>
+        <div class="mobile-col-1 tablet-col-1 col-2"></div>
+        <div class="mobile-col-1 tablet-col-1 col-2"></div>
+        <div class="mobile-col-1 tablet-col-1 col-2"></div>
+    </div>
+</div>

--- a/examples/patterns/grid/column-wrapping.html
+++ b/examples/patterns/grid/column-wrapping.html
@@ -5,17 +5,65 @@ category: _patterns
 ---
 <div grid-demo>
     <div class="row">
-        <div class="mobile-col-1 tablet-col-1 col-2"></div>
-        <div class="mobile-col-1 tablet-col-1 col-2"></div>
-        <div class="mobile-col-1 tablet-col-1 col-2"></div>
-        <div class="mobile-col-1 tablet-col-1 col-2"></div>
-        <div class="mobile-col-1 tablet-col-1 col-2 u-first-col--small"></div>
-        <div class="mobile-col-1 tablet-col-1 col-2"></div>
-        <div class="mobile-col-1 tablet-col-1 col-2 u-first-col--medium u-first-col--large"></div>
-        <div class="mobile-col-1 tablet-col-1 col-2"></div>
-        <div class="mobile-col-1 tablet-col-1 col-2 u-first-col--small"></div>
-        <div class="mobile-col-1 tablet-col-1 col-2"></div>
-        <div class="mobile-col-1 tablet-col-1 col-2"></div>
-        <div class="mobile-col-1 tablet-col-1 col-2"></div>
+        <div class="mobile-col-2 tablet-col-2 col-2">
+            <span>
+                mobile-col-2 tablet-col-2 col-2
+            </span>
+        </div>
+        <div class="mobile-col-2 tablet-col-2 col-2">
+            <span>
+                mobile-col-2 tablet-col-2 col-2
+            </span>
+        </div>
+        <div class="mobile-col-2 tablet-col-2 col-2 u-first-col--small">
+            <span>
+                mobile-col-2 tablet-col-2 col-2 u-first-col--small
+            </span>
+        </div>
+        <div class="mobile-col-2 u-first-col--medium tablet-col-2 col-2">
+            <span>
+                mobile-col-2 tablet-col-2 col-2 u-first-col--medium
+            </span>
+        </div>
+        <div class="mobile-col-2 tablet-col-2 col-2 u-first-col--small">
+            <span>
+                mobile-col-2 tablet-col-2 col-2 u-first-col--small
+            </span>
+        </div>
+        <div class="mobile-col-2 tablet-col-2 col-2">
+            <span>
+                mobile-col-2 tablet-col-2 col-2
+            </span>
+        </div>
+        <div class="mobile-col-2 tablet-col-2 col-2 u-first-col--small u-first-col--medium u-first-col--large">
+            <span>
+                mobile-col-2 tablet-col-2 col-2 u-first-col--small u-first-col--medium u-first-col--large
+            </span>
+        </div>
+        <div class="mobile-col-2 tablet-col-2 col-2">
+            <span>
+                mobile-col-2 tablet-col-2 col-2
+            </span>
+        </div>
+        <div class="mobile-col-2 u-first-col--small tablet-col-2 col-2">
+            <span>
+                mobile-col-2 tablet-col-2 col-2 u-first-col--small
+            </span>
+        </div>
+        <div class="mobile-col-2 tablet-col-2 col-2 u-first-col--medium">
+            <span>
+                mobile-col-2 tablet-col-2 col-2 u-first-col--medium
+            </span>
+        </div>
+        <div class="mobile-col-2 u-first-col--small tablet-col-2 col-2">
+            <span>
+                mobile-col-2 tablet-col-2 col-2 u-first-col--small
+            </span>
+        </div>
+        <div class="mobile-col-2 tablet-col-2 col-2">
+            <span>
+                mobile-col-2 tablet-col-2 col-2
+            </span>
+        </div>
     </div>
 </div>

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -29,3 +29,21 @@ $shelves-column-name: $grid-col-name;
     padding: $spv-inner--small $sph-inner--small;
   }
 }
+
+.col-first--desktop {
+  @media (min-width: $breakpoint-medium) {
+    margin-left: 0;
+  }
+}
+
+.col-first--tablet {
+  @media (min-width: $breakpoint-small) and (max-width: $breakpoint-medium) {
+    margin-left: 0;
+  }
+}
+
+.col-first--mobile {
+  @media (max-width: $breakpoint-small) {
+    margin-left: 0;
+  }
+}

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -29,21 +29,3 @@ $shelves-column-name: $grid-col-name;
     padding: $spv-inner--small $sph-inner--small;
   }
 }
-
-.u-first-col--mobile {
-  @media (max-width: $breakpoint-small) {
-    margin-left: 0;
-  }
-}
-
-.u-first-col--tablet {
-  @media (min-width: $breakpoint-small) and (max-width: $breakpoint-medium) {
-    margin-left: 0;
-  }
-}
-
-.u-first-col--desktop {
-  @media (min-width: $breakpoint-medium) {
-    margin-left: 0;
-  }
-}

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -30,20 +30,20 @@ $shelves-column-name: $grid-col-name;
   }
 }
 
-.col-first--desktop {
-  @media (min-width: $breakpoint-medium) {
+.u-first-col--mobile {
+  @media (max-width: $breakpoint-small) {
     margin-left: 0;
   }
 }
 
-.col-first--tablet {
+.u-first-col--tablet {
   @media (min-width: $breakpoint-small) and (max-width: $breakpoint-medium) {
     margin-left: 0;
   }
 }
 
-.col-first--mobile {
-  @media (max-width: $breakpoint-small) {
+.u-first-col--desktop {
+  @media (min-width: $breakpoint-medium) {
     margin-left: 0;
   }
 }

--- a/scss/_utilities_grid.scss
+++ b/scss/_utilities_grid.scss
@@ -1,17 +1,17 @@
 @mixin grid-first-col {
-  .u-first-col--mobile {
+  .u-first-col--small {
     @media (max-width: $breakpoint-small) {
       margin-left: 0;
     }
   }
 
-  .u-first-col--tablet {
+  .u-first-col--medium {
     @media (min-width: $breakpoint-small) and (max-width: $breakpoint-medium) {
       margin-left: 0;
     }
   }
 
-  .u-first-col--desktop {
+  .u-first-col--large {
     @media (min-width: $breakpoint-medium) {
       margin-left: 0;
     }

--- a/scss/_utilities_grid.scss
+++ b/scss/_utilities_grid.scss
@@ -1,18 +1,21 @@
 @mixin grid-first-col {
   .u-first-col--small {
     @media (max-width: $breakpoint-small) {
+      clear: left;
       margin-left: 0;
     }
   }
 
   .u-first-col--medium {
     @media (min-width: $breakpoint-small) and (max-width: $breakpoint-medium) {
+      clear: left;
       margin-left: 0;
     }
   }
 
   .u-first-col--large {
     @media (min-width: $breakpoint-medium) {
+      clear: left;
       margin-left: 0;
     }
   }

--- a/scss/_utilities_grid.scss
+++ b/scss/_utilities_grid.scss
@@ -1,0 +1,19 @@
+@mixin grid-first-col {
+  .u-first-col--mobile {
+    @media (max-width: $breakpoint-small) {
+      margin-left: 0;
+    }
+  }
+
+  .u-first-col--tablet {
+    @media (min-width: $breakpoint-small) and (max-width: $breakpoint-medium) {
+      margin-left: 0;
+    }
+  }
+
+  .u-first-col--desktop {
+    @media (min-width: $breakpoint-medium) {
+      margin-left: 0;
+    }
+  }
+}

--- a/scss/grid/shelves-grid.scss
+++ b/scss/grid/shelves-grid.scss
@@ -1,7 +1,7 @@
 @import './shelves/functions';
 @import './shelves/variables';
 @import './shelves/mixins';
-@import '../utilities_grid';
+@import 'utilities_grid';
 
 @mixin vf-p-grid {
   @include shelves-base;

--- a/scss/grid/shelves-grid.scss
+++ b/scss/grid/shelves-grid.scss
@@ -1,7 +1,7 @@
 @import './shelves/functions';
 @import './shelves/variables';
 @import './shelves/mixins';
-@import 'utilities_grid';
+@import '../utilities_grid';
 
 @mixin vf-p-grid {
   @include shelves-base;

--- a/scss/grid/shelves-grid.scss
+++ b/scss/grid/shelves-grid.scss
@@ -1,6 +1,7 @@
-@import "./shelves/functions";
-@import "./shelves/variables";
-@import "./shelves/mixins";
+@import './shelves/functions';
+@import './shelves/variables';
+@import './shelves/mixins';
+@import 'utilities_grid';
 
 @mixin vf-p-grid {
   @include shelves-base;
@@ -28,7 +29,7 @@
       }
 
       @include shelves-columns(
-        $extend: "shelves-mobile-column-base",
+        $extend: 'shelves-mobile-column-base',
         $prefixes: $shelves-mobile-prefixes,
         $suffixes: $shelves-mobile-suffixes,
         $pushes: $shelves-mobile-pushes,
@@ -65,7 +66,7 @@
       }
 
       @include shelves-columns(
-        $extend: "shelves-tablet-column-base",
+        $extend: 'shelves-tablet-column-base',
         $prefixes: $shelves-tablet-prefixes,
         $suffixes: $shelves-tablet-suffixes,
         $pushes: $shelves-tablet-pushes,
@@ -102,7 +103,7 @@
       }
 
       @include shelves-columns(
-        $extend: "shelves-desktop-column-base",
+        $extend: 'shelves-desktop-column-base',
         $prefixes: $shelves-prefixes,
         $suffixes: $shelves-suffixes,
         $pushes: $shelves-pushes,
@@ -123,7 +124,7 @@
             }
 
             @include shelves-columns(
-              $extend: "shelves-nested-column-#{$i}-base",
+              $extend: 'shelves-nested-column-#{$i}-base',
               $context: $i,
               $prefixes: $shelves-nested-prefixes,
               $suffixes: $shelves-nested-suffixes,
@@ -148,4 +149,6 @@
   @if $shelves-visibility {
     @include shelves-visibility-helpers;
   }
+
+  @include grid-first-col;
 }


### PR DESCRIPTION
## Done

Shelves grid lacks the ability to specify first-column per breakpoint. 
This gets in the way of making responsive layouts. For example:

Say you want to create a logo strip containing 12 logos, 2 rows x 6 logos on desktop, 3 rows x 4 logos on mobile.

If you put 12 logos in one row, you have the following problem:
on desktop: the first logo on the second row is offset by a margin-left, because the grid is not aware you're in column 1.

If you apply u-no-margin--left on that logo to fix the alignment, you're breaking the mobile view, because the utility removes margins across all breakpoints.

To solve this, we need what is commonly implemented as a first-col class - a reset of the margin that only affects mobile/tablet/desktop.

This pr provides those classes.

Example of this working can e found on the maas homepage in this pr: 
https://maas-io-canonical-websites-pr-316.run.demo.haus/




## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- [Add additional steps]

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
