### PR TITLE
Update docs/heading icon page content

### DIFF
--- a/docs/en/patterns/heading-icon.md
+++ b/docs/en/patterns/heading-icon.md
@@ -5,27 +5,33 @@ title: Heading icon
 
 ## Heading icon
 
+<hr>
+
+A header can be formatted to emphasize an icon and supplementary text.
+
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon/"
   class="js-example">
 View example of the pattern heading icons
 </a>
 
-## Heading icon stacked
+### Stacked
+
+Available as a vertical variant allowing for an alternate layout.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon-stacked/"
   class="js-example">
 View example of the pattern heading icon stacked
 </a>
 
-## Heading icon small
+### Small
+
+Available at a smaller size of 32x32 pixels rather than our default size of 60x60 pixels.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon-small/"
   class="js-example">
 View example of the pattern heading icon small
 </a>
 
-<hr />
-
 ### Design
 
-- [Heading icon design](https://github.com/ubuntudesign/vanilla-design/tree/master/Heading%20icon)
+For more information view the [heading icon design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Heading%20icon) which includes the specification in markdown format and a PNG image.

--- a/docs/en/patterns/heading-icon.md
+++ b/docs/en/patterns/heading-icon.md
@@ -25,7 +25,7 @@ View example of the pattern heading icon stacked
 
 ### Small
 
-Available at a smaller size of 32x32 pixels rather than our default size of 60x60 pixels.
+Available at a smaller size of 32 x 32 pixels rather than our default size of 60 x 60 pixels.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon-small/"
   class="js-example">

--- a/docs/en/patterns/heading-icon.md
+++ b/docs/en/patterns/heading-icon.md
@@ -7,7 +7,7 @@ title: Heading icon
 
 <hr>
 
-A header can be formatted to emphasize an icon and supplementary text.
+A header can be formatted to emphasise an icon and supplementary text.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon/"
   class="js-example">

--- a/docs/en/patterns/heading-icon.md
+++ b/docs/en/patterns/heading-icon.md
@@ -7,7 +7,7 @@ title: Heading icon
 
 <hr>
 
-A header can be formatted to emphasise an icon and supplementary text.
+A header can be emphasised by adding an icon alongside the text.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon/"
   class="js-example">
@@ -16,7 +16,7 @@ View example of the pattern heading icons
 
 ### Stacked
 
-Available as a vertical variant allowing for an alternate layout.
+This variant positions the icon vertically with the text content for an alternate layout.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon-stacked/"
   class="js-example">
@@ -25,7 +25,7 @@ View example of the pattern heading icon stacked
 
 ### Small
 
-Available at a smaller size of 32 x 32 pixels rather than our default size of 60 x 60 pixels.
+The icon for this component is also available at a smaller size of 32 x 32 pixels rather than our default size of 60 x 60 pixels.
 
 <a href="https://vanilla-framework.github.io/vanilla-framework/examples/patterns/heading-icon-small/"
   class="js-example">

--- a/examples/patterns/heading-icon/heading-icon-small.html
+++ b/examples/patterns/heading-icon/heading-icon-small.html
@@ -6,8 +6,8 @@ category: _patterns
 
 <div class="p-heading-icon--small">
   <div class="p-heading-icon__header">
-    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a4d31b28-icon-quote.svg" />
-    <h4 class="p-heading-icon__title">Lorem ipsum dolor</h4>
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" />
+    <h4 class="p-heading-icon__title">LXD — system containers</h4>
   </div>
-  <p>sit amet, consectetur adipisicing elit. Enim excepturi, repudiandae blanditiis odio perferendis voluptatibus dolorum, dicta illum quae ipsa voluptatum, sunt quasi? Nulla reiciendis magnam nostrum aliquam, beatae doloribus.</p>
+  <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>
 </div>

--- a/examples/patterns/heading-icon/heading-icon-stacked.html
+++ b/examples/patterns/heading-icon/heading-icon-stacked.html
@@ -6,8 +6,8 @@ category: _patterns
 
 <div class="p-heading-icon">
   <div class="p-heading-icon__header is-stacked">
-    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a4d31b28-icon-quote.svg" />
-    <h3 class="p-heading-icon__title">Lorem ipsum dolor</h3>
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" />
+    <h3 class="p-heading-icon__title">LXD — system containers</h3>
   </div>
-  <p>sit amet, consectetur adipisicing elit. Enim excepturi, repudiandae blanditiis odio perferendis voluptatibus dolorum, dicta illum quae ipsa voluptatum, sunt quasi? Nulla reiciendis magnam nostrum aliquam, beatae doloribus.</p>
+  <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>
 </div>

--- a/examples/patterns/heading-icon/heading-icon.html
+++ b/examples/patterns/heading-icon/heading-icon.html
@@ -6,8 +6,8 @@ category: _patterns
 
 <div class="p-heading-icon">
   <div class="p-heading-icon__header">
-    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a4d31b28-icon-quote.svg" />
-    <h3 class="p-heading-icon__title">Lorem ipsum dolor</h3>
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" />
+    <h3 class="p-heading-icon__title">LXD — system containers</h3>
   </div>
-  <p>sit amet, consectetur adipisicing elit. Enim excepturi, repudiandae blanditiis odio perferendis voluptatibus dolorum, dicta illum quae ipsa voluptatum, sunt quasi? Nulla reiciendis magnam nostrum aliquam, beatae doloribus.</p>
+  <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>
 </div>


### PR DESCRIPTION
## Done
- Updated copy 👍 
- Updated demo example to showcase live example 😉 
- Check content matches copy doc [here](https://docs.google.com/document/d/1BaY3k01-6zvhC67PMxZD44IKHs4_pTpPm_ix98rHW98/edit#heading=h.m8r6djutwkm5)

## QA
- Pull code
- Run /docs > ./run
  - Check http://0.0.0.0:8104/en/patterns/heading-icon
- Pull code
- Run ./run
- Review updated examples
  - Check http://0.0.0.0:8101/vanilla-framework/examples/patterns/heading-icon/heading-icon/
  - Check http://0.0.0.0:8101/vanilla-framework/examples/patterns/heading-icon/heading-icon-stacked/
  - Check http://0.0.0.0:8101/vanilla-framework/examples/patterns/heading-icon/heading-icon-small/

## Details
- Fixes https://github.com/ubuntudesign/vanilla-design/issues/356

## Screenshots
![Screenshot 2019-03-26 at 10 18 06](https://user-images.githubusercontent.com/17748020/54989642-df421880-4fb0-11e9-893e-2cbdacb32e29.png)


