### PR TITLE
Pattern nesting

### DIFF
--- a/examples/patterns/code-numbered.html
+++ b/examples/patterns/code-numbered.html
@@ -4,11 +4,11 @@ title: Code numbered
 category: _patterns
 ---
 
-<pre class="p-code-numbered"><code><span class="code-line">#!/bin/bash</span>
-<span class="code-line">set -eu</span>
-<span class="code-line">. $CONJURE_UP_SPELLSDIR/sdk/common.sh</span>
-<span class="code-line">if [[ "$JUJU_PROVIDERTYPE" == "lxd" ]]; then
+<pre class="p-code-numbered"><code><span class="p-code-numbered__line">#!/bin/bash</span>
+<span class="p-code-numbered__line">set -eu</span>
+<span class="p-code-numbered__line">. $CONJURE_UP_SPELLSDIR/sdk/common.sh</span>
+<span class="p-code-numbered__line">if [[ "$JUJU_PROVIDERTYPE" == "lxd" ]]; then
     debug "Running pre-deploy for $CONJURE_UP_SPELL"
     sed "s/##MODEL##/$JUJU_MODEL/" $(scriptPath)/lxd-profile.yaml | lxc profile edit "juju-$JUJU_MODEL" || exposeResult "Failed to set profile" $? "false"
 fi</span>
-<span class="code-line">exposeResult "Successful pre-deploy." 0 "true"</span></code></pre>
+<span class="p-code-numbered__line">exposeResult "Successful pre-deploy." 0 "true"</span></code></pre>

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -6,65 +6,63 @@
 @mixin vf-p-accordion {
   $icon-size: map-get($icon-sizes, accordion);
 
-  .p-accordion {
-    &__list {
-      list-style-type: none;
-      margin: 0 0 $spv-outer--scaleable 0;
-      padding: 0;
-    }
+  .p-accordion__list {
+    list-style-type: none;
+    margin: 0 0 $spv-outer--scaleable 0;
+    padding: 0;
+  }
 
-    &__group {
-      &:not(:last-child) .p-accordion__tab {
-        border-bottom: 1px solid $color-mid-light;
-      }
-    }
-
-    &__tab {
-      @extend %single-border-text-vpadding--scaling;
-      @include vf-focus;
-
-      $calculated-height: $multi * $spv-inner--x-small * 2 + map-get($line-heights, default-text);
-      background: {
-        position: top 50% right $sph-inner;
-        repeat: no-repeat;
-      }
-      background-color: inherit;
-      border: 0;
-      border-radius: 0;
-      margin-bottom: 0;
-      padding-left: $sph-inner;
-      padding-right: $sph-inner;
-      text-align: left;
-      transition-duration: 0s;
-      width: 100%;
-      z-index: 2;
-
-      // aria-selected controls the open and closed state for the accordion tab
-      &[aria-expanded='true'] {
-        @include vf-icon-minus($color-mid-dark);
-        background-size: $icon-size;
-      }
-
-      &[aria-expanded='false'] {
-        @include vf-icon-plus($color-mid-dark);
-        background-size: $icon-size;
-      }
-    }
-
-    &__panel {
+  .p-accordion__group {
+    &:not(:last-child) .p-accordion__tab {
       border-bottom: 1px solid $color-mid-light;
-      margin: 0;
-      overflow: auto; // include child margins into its height
-      padding-left: $sph-inner * 2;
+    }
+  }
 
-      // Hides panel content
-      &[aria-hidden='true'] {
-        display: none;
-      }
+  .p-accordion__tab {
+    @extend %single-border-text-vpadding--scaling;
+    @include vf-focus;
+
+    $calculated-height: $multi * $spv-inner--x-small * 2 + map-get($line-heights, default-text);
+    background: {
+      position: top 50% right $sph-inner;
+      repeat: no-repeat;
+    }
+    background-color: inherit;
+    border: 0;
+    border-radius: 0;
+    margin-bottom: 0;
+    padding-left: $sph-inner;
+    padding-right: $sph-inner;
+    text-align: left;
+    transition-duration: 0s;
+    width: 100%;
+    z-index: 2;
+
+    // aria-selected controls the open and closed state for the accordion tab
+    &[aria-expanded='true'] {
+      @include vf-icon-minus($color-mid-dark);
+      background-size: $icon-size;
     }
 
-    p {
-      margin-bottom: map-get($sp-after, p) - $sp-unit - map-get($nudges, nudge--p);
+    &[aria-expanded='false'] {
+      @include vf-icon-plus($color-mid-dark);
+      background-size: $icon-size;
     }
+  }
+
+  .p-accordion__panel {
+    border-bottom: 1px solid $color-mid-light;
+    margin: 0;
+    overflow: auto; // include child margins into its height
+    padding-left: $sph-inner * 2;
+
+    // Hides panel content
+    &[aria-hidden='true'] {
+      display: none;
+    }
+  }
+
+  .p-accordion p {
+    margin-bottom: map-get($sp-after, p) - $sp-unit - map-get($nudges, nudge--p);
   }
 }

--- a/scss/_patterns_article-pagination.scss
+++ b/scss/_patterns_article-pagination.scss
@@ -12,82 +12,82 @@
   .p-article-pagination {
     display: flex;
     width: 100%;
+  }
 
-    &__link {
-      margin-top: 0;
-      padding: $sp-medium;
-      position: relative;
-      width: 50%;
+  .p-article-pagination__label,
+  .p-article-pagination__title {
+    color: $color-dark;
+    display: block;
+    margin-top: 0;
+    width: 100%;
+  }
 
-      &:hover {
-        background: $color-light;
-        text-decoration: none;
+  .p-article-pagination__label {
+    margin-bottom: $sp-x-small;
+  }
+
+  .p-article-pagination__title {
+    font-size: 1.125em;
+
+    @media (min-width: $breakpoint-small) {
+      font-size: 1.25em;
+    }
+  }
+
+  .p-article-pagination__link {
+    margin-top: 0;
+    padding: $sp-medium;
+    position: relative;
+    width: 50%;
+
+    &:hover {
+      background: $color-light;
+      text-decoration: none;
+    }
+  }
+
+  .p-article-pagination__link--previous {
+    @extend .p-article-pagination__link; // sass-lint:disable-line placeholder-in-extend
+    padding-left: $sp-xx-large;
+    text-align: left;
+
+    @media (max-width: $breakpoint-x-small) {
+      width: auto;
+
+      &:only-child {
+        width: 100%;
       }
 
-      &--previous {
-        @extend .p-article-pagination__link; // sass-lint:disable-line placeholder-in-extend
-        padding-left: $sp-xx-large;
-        text-align: left;
-
-        @media (max-width: $breakpoint-x-small) {
-          width: auto;
-
-          &:only-child {
-            width: 100%;
-          }
-
-          &:not(:only-child) * {
-            display: none;
-            max-width: $sp-x-small;
-            padding-left: $sp-large;
-          }
-        }
-
-        &::before {
-          @extend %chevron-icon;
-          left: $sp-small;
-          transform: scaleX(-1);
-        }
-      }
-
-      &--next {
-        @extend .p-article-pagination__link; // sass-lint:disable-line placeholder-in-extend
-        padding-right: $sp-xx-large;
-        text-align: right;
-
-        @media (max-width: $breakpoint-x-small) {
-          width: 100%;
-        }
-
-        &:only-child {
-          margin-left: auto;
-        }
-
-        &::after {
-          @extend %chevron-icon;
-          right: $sp-small;
-        }
+      &:not(:only-child) * {
+        display: none;
+        max-width: $sp-x-small;
+        padding-left: $sp-large;
       }
     }
 
-    &__label,
-    &__title {
-      color: $color-dark;
-      display: block;
-      margin-top: 0;
+    &::before {
+      @extend %chevron-icon;
+      left: $sp-small;
+      transform: scaleX(-1);
+    }
+  }
+
+  .p-article-pagination__link--next {
+    @extend .p-article-pagination__link; // sass-lint:disable-line placeholder-in-extend
+    padding-right: $sp-xx-large;
+    text-align: right;
+
+    @media (max-width: $breakpoint-x-small) {
       width: 100%;
     }
 
-    &__label {
-      margin-bottom: $sp-x-small;
+    &:only-child {
+      margin-left: auto;
     }
 
-    &__title {
-      font-size: 1.125em;
-
-      @media (min-width: $breakpoint-small) {
-        font-size: 1.25em;
-      }
+    &::after {
+      @extend %chevron-icon;
+      right: $sp-small;
     }
   }
 }

--- a/scss/_patterns_aside.scss
+++ b/scss/_patterns_aside.scss
@@ -11,45 +11,45 @@
       border-top: 0;
       padding: 0 $sp-medium;
     }
+  }
 
-    &__header {
-      color: $color-mid-dark;
-      font-size: $sp-medium;
-      line-height: 1.5;
-      margin-bottom: $sp-medium;
-      text-transform: uppercase;
+  .p-aside__header {
+    color: $color-mid-dark;
+    font-size: $sp-medium;
+    line-height: 1.5;
+    margin-bottom: $sp-medium;
+    text-transform: uppercase;
+  }
+
+  .p-aside__section {
+    padding: $sp-medium 0;
+
+    &:not(:last-child) {
+      border-bottom: 1px dotted $color-mid-light;
     }
+  }
 
-    &__section {
-      padding: $sp-medium 0;
+  .p-aside__nav {
+    list-style: none;
+    margin: 0;
+    padding: 0;
 
-      &:not(:last-child) {
-        border-bottom: 1px dotted $color-mid-light;
-      }
-    }
+    .p-aside__link {
+      border-bottom: 0;
+      color: $color-dark;
+      margin-bottom: $sp-x-small;
 
-    &__nav {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-
-      .p-aside__link {
-        border-bottom: 0;
+      &:visited {
         color: $color-dark;
-        margin-bottom: $sp-x-small;
+      }
 
-        &:visited {
-          color: $color-dark;
-        }
+      &:hover {
+        color: $color-link;
+      }
 
-        &:hover {
-          color: $color-link;
-        }
-
-        &.is-active {
-          font-weight: 400;
-          padding-left: $sp-x-small;
-        }
+      &.is-active {
+        font-weight: 400;
+        padding-left: $sp-x-small;
       }
     }
   }

--- a/scss/_patterns_breadcrumbs.scss
+++ b/scss/_patterns_breadcrumbs.scss
@@ -7,22 +7,22 @@
     margin: 0;
     padding: 0;
     width: 100%;
+  }
 
-    &__item {
-      @extend %default-text;
+  .p-breadcrumbs__item {
+    @extend %default-text;
 
-      display: inline-block;
-      margin-bottom: $spv-outer--small-scaleable - $spv-nudge;
+    display: inline-block;
+    margin-bottom: $spv-outer--small-scaleable - $spv-nudge;
 
-      &:not(:first-of-type) {
-        text-indent: $sph-outer;
-      }
+    &:not(:first-of-type) {
+      text-indent: $sph-outer;
+    }
 
-      &:not(:first-of-type)::before {
-        content: '\203A';
-        margin-left: -0.75rem;
-        margin-right: 0.5rem;
-      }
+    &:not(:first-of-type)::before {
+      content: '\203A';
+      margin-left: -0.75rem;
+      margin-right: 0.5rem;
     }
   }
 }

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -17,15 +17,6 @@ $cc-button-size: 36px;
       margin-top: 0; // overrides p + p
     }
 
-    &__input {
-      border: 0;
-      color: $color-mid-dark;
-      font-family: unquote($font-monospace);
-      line-height: map-get($line-heights, default-text);
-      padding: 0 calc(#{$cc-button-size} + #{$sph-inner--small}) 0 $sph-inner * 1.5;
-      width: 100%;
-    }
-
     &::before {
       color: $color-mid;
       content: '$';
@@ -37,23 +28,32 @@ $cc-button-size: 36px;
       top: $spv-inner--x-small;
       width: 1rem;
     }
+  }
 
-    &__action {
-      @extend %vf-hide-text;
-      @extend %bordered-text-vertical-padding;
-      @include vf-icon-copy($color-mid-dark);
-      @include vf-button-pattern($button-background-color: $color-light, $button-hover-background-color: darken($color-light, 10%));
-      background-position: center;
-      background-repeat: no-repeat;
-      border: 0;
-      border-left: $border;
-      border-radius: 0;
-      line-height: map-get($line-heights, default-text);
-      margin: 0;
-      position: absolute;
-      right: 0;
-      top: 0;
-      width: $cc-button-size;
-    }
+  .p-code-copyable__input {
+    border: 0;
+    color: $color-mid-dark;
+    font-family: unquote($font-monospace);
+    line-height: map-get($line-heights, default-text);
+    padding: 0 calc(#{$cc-button-size} + #{$sph-inner--small}) 0 $sph-inner * 1.5;
+    width: 100%;
+  }
+
+  .p-code-copyable__action {
+    @extend %vf-hide-text;
+    @extend %bordered-text-vertical-padding;
+    @include vf-icon-copy($color-mid-dark);
+    @include vf-button-pattern($button-background-color: $color-light, $button-hover-background-color: darken($color-light, 10%));
+    background-position: center;
+    background-repeat: no-repeat;
+    border: 0;
+    border-left: $border;
+    border-radius: 0;
+    line-height: map-get($line-heights, default-text);
+    margin: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: $cc-button-size;
   }
 }

--- a/scss/_patterns_code-numbered.scss
+++ b/scss/_patterns_code-numbered.scss
@@ -5,45 +5,45 @@ $sidebar-width: 4.5rem !default;
   .p-code-numbered {
     counter-reset: line-numbering;
     padding: 0;
+  }
 
-    .code-line {
+  .p-code-numbered__line {
+    display: inline-block;
+    padding: $spv-inner--small $sph-inner 0 ($sidebar-width + $sph-inner);
+    position: relative;
+    width: 100%;
+
+    &:empty {
+      display: block;
+      min-height: $sp-xx-large;
+    }
+
+    &:last-of-type,
+    &:last-of-type::before {
+      padding-bottom: $spv-inner--small;
+    }
+
+    &::before {
+      // sass-lint:disable no-vendor-prefixes property-sort-order
+      background: $color-x-light;
+      border-right: 1px solid $color-mid-light;
+      color: $color-mid-dark;
+      content: counter(line-numbering);
+      counter-increment: line-numbering;
       display: inline-block;
-      padding: $spv-inner--small $sph-inner 0 ($sidebar-width + $sph-inner);
-      position: relative;
-      width: 100%;
-
-      &:empty {
-        display: block;
-        min-height: $sp-xx-large;
-      }
-
-      &:last-of-type,
-      &:last-of-type::before {
-        padding-bottom: $spv-inner--small;
-      }
-
-      &::before {
-        // sass-lint:disable no-vendor-prefixes property-sort-order
-        background: $color-x-light;
-        border-right: 1px solid $color-mid-light;
-        color: $color-mid-dark;
-        content: counter(line-numbering);
-        counter-increment: line-numbering;
-        display: inline-block;
-        height: 100%;
-        left: 0;
-        padding: $spv-inner--small $sph-inner 0 $sph-inner;
-        pointer-events: none;
-        position: absolute;
-        text-align: right;
-        top: 0;
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        user-select: none;
-        // sass-lint:enable no-vendor-prefixes property-sort-order
-        width: $sidebar-width;
-      }
+      height: 100%;
+      left: 0;
+      padding: $spv-inner--small $sph-inner 0 $sph-inner;
+      pointer-events: none;
+      position: absolute;
+      text-align: right;
+      top: 0;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      // sass-lint:enable no-vendor-prefixes property-sort-order
+      width: $sidebar-width;
     }
   }
 }

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -5,44 +5,44 @@
     display: inline-block;
     margin: 0;
     position: relative;
+  }
 
-    // Alignment extension to align the menu to the left
-    &--left {
-      @extend .p-contextual-menu; // sass-lint:disable-line placeholder-in-extend
+  // Alignment extension to align the menu to the left
+  .p-contextual-menu--left {
+    @extend .p-contextual-menu; // sass-lint:disable-line placeholder-in-extend
 
-      .p-contextual-menu__dropdown {
-        left: 0;
+    .p-contextual-menu__dropdown {
+      left: 0;
 
-        &::before,
-        &::after {
-          left: $sp-small;
-          right: initial;
-        }
+      &::before,
+      &::after {
+        left: $sp-small;
+        right: initial;
+      }
 
-        &::after {
-          left: $sp-small + 0.1rem;
-        }
+      &::after {
+        left: $sp-small + 0.1rem;
       }
     }
+  }
 
-    // Alignment extension to align the menu to the center of the parent
-    &--center {
-      @extend .p-contextual-menu; // sass-lint:disable-line placeholder-in-extend
+  // Alignment extension to align the menu to the center of the parent
+  .p-contextual-menu--center {
+    @extend .p-contextual-menu; // sass-lint:disable-line placeholder-in-extend
 
-      .p-contextual-menu__dropdown {
-        // sass-lint:disable no-vendor-prefixes property-sort-order
+    .p-contextual-menu__dropdown {
+      // sass-lint:disable no-vendor-prefixes property-sort-order
+      left: 50%;
+      -webkit-transform: translateX(-50%);
+      transform: translateX(-50%);
+
+      &::before,
+      &::after {
         left: 50%;
+        right: initial;
         -webkit-transform: translateX(-50%);
         transform: translateX(-50%);
-
-        &::before,
-        &::after {
-          left: 50%;
-          right: initial;
-          -webkit-transform: translateX(-50%);
-          transform: translateX(-50%);
-          // sass-lint:enable no-vendor-prefixes property-sort-order
-        }
+        // sass-lint:enable no-vendor-prefixes property-sort-order
       }
     }
   }

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -6,86 +6,6 @@
     margin: 0;
     position: relative;
 
-    // Dropdown element for contextual menu
-    &__dropdown {
-      @extend %vf-card;
-      @extend %vf-has-box-shadow;
-      @extend %vf-has-round-corners;
-      display: none;
-      margin: 0;
-      max-width: 21rem;
-      min-width: 10rem;
-      padding: 0;
-      position: absolute;
-      right: 0;
-      top: calc(100% + #{$sp-x-small});
-      z-index: 1;
-
-      &::before,
-      &::after {
-        border: {
-          bottom: 8px solid transparentize($color-dark, 0.95);
-          left: 8px solid transparent;
-          right: 8px solid transparent;
-        }
-        bottom: 100%;
-        content: '';
-        height: 0;
-        pointer-events: none;
-        position: absolute;
-        right: $sp-small;
-        width: 0;
-      }
-
-      &::after {
-        border: {
-          bottom: 6px solid $color-x-light;
-          left: 6px solid transparent;
-          right: 6px solid transparent;
-        }
-        right: $sp-small + 0.1rem;
-      }
-
-      // When set to false will show the contextual menu
-      &[aria-hidden='false'] {
-        display: block;
-      }
-    }
-
-    &__group {
-      display: block;
-      padding: $sp-xx-small 0;
-
-      + .p-contextual-menu__group {
-        border-top: 1px solid $color-mid-light;
-        margin: 0;
-      }
-    }
-
-    &__toggle {
-      margin-bottom: $spv-inner--small + ($spv-nudge-compensation * 2);
-    }
-
-    &__link {
-      border: 0;
-      clear: both;
-      color: $color-dark;
-      display: block;
-      line-height: 1.5rem;
-      margin: 0;
-      overflow: hidden;
-      padding: $sp-xx-small $sp-small;
-      text-align: left;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      width: 100%;
-
-      &:hover {
-        background-color: $color-light;
-        text-decoration: none;
-      }
-    }
-
     // Alignment extension to align the menu to the left
     &--left {
       @extend .p-contextual-menu; // sass-lint:disable-line placeholder-in-extend
@@ -124,6 +44,86 @@
           // sass-lint:enable no-vendor-prefixes property-sort-order
         }
       }
+    }
+  }
+
+  // Dropdown element for contextual menu
+  .p-contextual-menu__dropdown {
+    @extend %vf-card;
+    @extend %vf-has-box-shadow;
+    @extend %vf-has-round-corners;
+    display: none;
+    margin: 0;
+    max-width: 21rem;
+    min-width: 10rem;
+    padding: 0;
+    position: absolute;
+    right: 0;
+    top: calc(100% + #{$sp-x-small});
+    z-index: 1;
+
+    &::before,
+    &::after {
+      border: {
+        bottom: 8px solid transparentize($color-dark, 0.95);
+        left: 8px solid transparent;
+        right: 8px solid transparent;
+      }
+      bottom: 100%;
+      content: '';
+      height: 0;
+      pointer-events: none;
+      position: absolute;
+      right: $sp-small;
+      width: 0;
+    }
+
+    &::after {
+      border: {
+        bottom: 6px solid $color-x-light;
+        left: 6px solid transparent;
+        right: 6px solid transparent;
+      }
+      right: $sp-small + 0.1rem;
+    }
+
+    // When set to false will show the contextual menu
+    &[aria-hidden='false'] {
+      display: block;
+    }
+  }
+
+  .p-contextual-menu__group {
+    display: block;
+    padding: $sp-xx-small 0;
+
+    + .p-contextual-menu__group {
+      border-top: 1px solid $color-mid-light;
+      margin: 0;
+    }
+  }
+
+  .p-contextual-menu__toggle {
+    margin-bottom: $spv-inner--small + ($spv-nudge-compensation * 2);
+  }
+
+  .p-contextual-menu__link {
+    border: 0;
+    clear: both;
+    color: $color-dark;
+    display: block;
+    line-height: 1.5rem;
+    margin: 0;
+    overflow: hidden;
+    padding: $sp-xx-small $sp-small;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 100%;
+
+    &:hover {
+      background-color: $color-light;
+      text-decoration: none;
     }
   }
 }

--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -5,32 +5,32 @@
     @media (min-width: $breakpoint-medium) {
       display: flex;
     }
+  }
 
-    &__block {
-      @media (max-width: $breakpoint-medium) {
-        padding-bottom: $spv-outer--scaleable;
+  .p-divider__block {
+    @media (max-width: $breakpoint-medium) {
+      padding-bottom: $spv-outer--scaleable;
 
-        &:not(:first-child) {
-          border-top: 1px solid $color-mid-light;
-          padding-top: calc(#{$spv-inner--scaleable} - 1px); // border compensation
-        }
+      &:not(:first-child) {
+        border-top: 1px solid $color-mid-light;
+        padding-top: calc(#{$spv-inner--scaleable} - 1px); // border compensation
+      }
+    }
+
+    @media (min-width: $breakpoint-medium) {
+      padding-right: 1rem;
+
+      &:not(:nth-child(1))::before {
+        border-left: 1px solid $color-mid-light;
+        bottom: $sp-unit; // compensate for bottom margin on children
+        content: '';
+        left: -1.5rem;
+        position: absolute;
+        top: $sp-unit;
       }
 
-      @media (min-width: $breakpoint-medium) {
-        padding-right: 1rem;
-
-        &:not(:nth-child(1))::before {
-          border-left: 1px solid $color-mid-light;
-          bottom: $sp-unit; // compensate for bottom margin on children
-          content: '';
-          left: -1.5rem;
-          position: absolute;
-          top: $sp-unit;
-        }
-
-        &:last-child {
-          padding-right: 0;
-        }
+      &:last-child {
+        padding-right: 0;
       }
     }
   }

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -15,20 +15,20 @@
       background-position: calc(100% - #{$sph-inner--small}) 50%;
       background-repeat: no-repeat;
     }
+  }
 
-    .p-form-validation__icon {
-      position: relative;
+  .p-form-validation__message {
+    @extend %small-text;
+    margin-top: -$sp-unit;
+  }
 
-      &::after {
-        position: absolute;
-        right: $sp-small;
-        top: calc(50% - #{$sp-x-small});
-      }
-    }
+  .p-form-validation__icon {
+    position: relative;
 
-    &__message {
-      @extend %small-text;
-      margin-top: -$sp-unit;
+    &::after {
+      position: absolute;
+      right: $sp-small;
+      top: calc(50% - #{$sp-x-small});
     }
   }
 

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -7,34 +7,34 @@
     @media (min-width: $breakpoint-medium) {
       margin-bottom: 0;
     }
+  }
 
-    &__header {
-      display: flex;
-      // Match adjustment of margin-top on paragraphs that are following a heading.
-      // Necessary because in this pattern the heading and paragraph are not in the same parent, so h3 + p rules do not apply
-      margin-bottom: $spv-p-after-heading-adjustment;
+  .p-heading-icon__header {
+    display: flex;
+    // Match adjustment of margin-top on paragraphs that are following a heading.
+    // Necessary because in this pattern the heading and paragraph are not in the same parent, so h3 + p rules do not apply
+    margin-bottom: $spv-p-after-heading-adjustment;
 
-      &.is-stacked {
-        display: inherit;
-      }
+    &.is-stacked {
+      display: inherit;
+    }
+  }
+
+  .p-heading-icon__img {
+    flex-shrink: 0;
+    height: map-get($icon-sizes, heading-icon--small);
+    margin-bottom: $spv-inner--small;
+    margin-right: $sph-inner;
+    width: map-get($icon-sizes, heading-icon--small);
+
+    @media (max-width: $breakpoint-medium) {
+      margin-top: 0;
     }
 
-    &__img {
-      flex-shrink: 0;
-      height: map-get($icon-sizes, heading-icon--small);
-      margin-bottom: $spv-inner--small;
-      margin-right: $sph-inner;
-      width: map-get($icon-sizes, heading-icon--small);
-
-      @media (max-width: $breakpoint-medium) {
-        margin-top: 0;
-      }
-
-      @media (min-width: $breakpoint-medium) {
-        height: map-get($icon-sizes, heading-icon);
-        margin-top: -#{$spv-inner--small};
-        width: map-get($icon-sizes, heading-icon);
-      }
+    @media (min-width: $breakpoint-medium) {
+      height: map-get($icon-sizes, heading-icon);
+      margin-top: -#{$spv-inner--small};
+      width: map-get($icon-sizes, heading-icon);
     }
   }
 

--- a/scss/_patterns_headings.scss
+++ b/scss/_patterns_headings.scss
@@ -2,29 +2,27 @@
 
 // Default breadcrumbs styling
 @mixin vf-p-headings {
-  .p-heading {
-    &--one {
-      @extend %vf-heading-1;
-    }
+  .p-heading--one {
+    @extend %vf-heading-1;
+  }
 
-    &--two {
-      @extend %vf-heading-2;
-    }
+  .p-heading--two {
+    @extend %vf-heading-2;
+  }
 
-    &--three {
-      @extend %vf-heading-3;
-    }
+  .p-heading--three {
+    @extend %vf-heading-3;
+  }
 
-    &--four {
-      @extend %vf-heading-4;
-    }
+  .p-heading--four {
+    @extend %vf-heading-4;
+  }
 
-    &--five {
-      @extend %vf-heading-5;
-    }
+  .p-heading--five {
+    @extend %vf-heading-5;
+  }
 
-    &--six {
-      @extend %vf-heading-6;
-    }
+  .p-heading--six {
+    @extend %vf-heading-6;
   }
 }

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -1,17 +1,15 @@
 @import 'settings';
 
 @mixin vf-p-image {
-  .p-image {
-    &--bordered {
-      border: {
-        color: $color-mid-light;
-        style: solid;
-        width: 1px;
-      }
+  .p-image--bordered {
+    border: {
+      color: $color-mid-light;
+      style: solid;
+      width: 1px;
     }
+  }
 
-    &--shadowed {
-      box-shadow: 0 1px 5px 1px transparentize($color-mid-light, 0.8);
-    }
+  .p-image--shadowed {
+    box-shadow: 0 1px 5px 1px transparentize($color-mid-light, 0.8);
   }
 }

--- a/scss/_patterns_inline-images.scss
+++ b/scss/_patterns_inline-images.scss
@@ -9,28 +9,28 @@
     margin-left: 0;
     padding-left: 0;
     text-align: center;
+  }
 
-    &__item {
-      display: inline-block;
-      margin: 1rem;
-      overflow: hidden;
-      text-align: center;
-      vertical-align: middle;
+  .p-inline-images__item {
+    display: inline-block;
+    margin: 1rem;
+    overflow: hidden;
+    text-align: center;
+    vertical-align: middle;
 
-      @media only screen and (min-width: $breakpoint-medium) {
-        margin: 1.875rem;
-      }
+    @media only screen and (min-width: $breakpoint-medium) {
+      margin: 1.875rem;
     }
+  }
 
-    &__logo {
-      max-height: map-get($icon-sizes, thumb--small);
-      max-width: 7rem;
-      width: auto;
+  .p-inline-images__logo {
+    max-height: map-get($icon-sizes, thumb--small);
+    max-width: 7rem;
+    width: auto;
 
-      @media screen and (min-width: $breakpoint-medium) {
-        max-height: 5.5rem;
-        max-width: 9rem;
-      }
+    @media screen and (min-width: $breakpoint-medium) {
+      max-height: 5.5rem;
+      max-width: 9rem;
     }
   }
 }

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -1,35 +1,33 @@
 @import 'settings';
 
 @mixin vf-p-links {
-  .p-link {
-    &--soft {
+  .p-link--soft {
+    color: $color-dark;
+
+    &:visited {
       color: $color-dark;
-
-      &:visited {
-        color: $color-dark;
-        text-decoration: none;
-      }
-
-      &:hover {
-        color: $color-link;
-      }
-
-      &.is-selected {
-        font-weight: 400;
-      }
+      text-decoration: none;
     }
 
-    &--inverted {
-      color: $color-light;
+    &:hover {
+      color: $color-link;
+    }
+
+    &.is-selected {
       font-weight: 400;
+    }
+  }
 
-      &:hover {
-        color: $color-light;
-      }
+  .p-link--inverted {
+    color: $color-light;
+    font-weight: 400;
 
-      &:visited {
-        color: darken($color-light, 10%);
-      }
+    &:hover {
+      color: $color-light;
+    }
+
+    &:visited {
+      color: darken($color-light, 10%);
     }
   }
 
@@ -47,36 +45,35 @@
     border-bottom: 1px dotted $color-mid-light;
     clear: both;
     margin: 20px 0;
+  }
 
-    &__link {
-      background: $color-x-light;
-      color: $color-dark;
-      float: right;
-      margin-right: 5px;
-      padding: 0 5px;
-      position: relative;
-      text-decoration: none;
-      top: -0.725rem;
-    }
+  .p-top__link {
+    background: $color-x-light;
+    color: $color-dark;
+    float: right;
+    margin-right: 5px;
+    padding: 0 5px;
+    position: relative;
+    text-decoration: none;
+    top: -0.725rem;
   }
 }
 
 // For browsers that support CSS masks
 //sass-lint:disable no-vendor-prefixes
 @mixin vf-mask-supported {
-  .p-link {
+  .p-link--external {
     // Used for links point at a different domain
-    &--external {
-      &::after {
-        -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' %3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E")
-          no-repeat 0 0 / cover;
-        background-color: currentColor;
-        content: '';
-        margin: 0 0 0 0.25em;
-        mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' %3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E")
-          no-repeat 0 0 / cover;
-        padding-right: 0.75em;
-      }
+
+    &::after {
+      -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' %3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E")
+        no-repeat 0 0 / cover;
+      background-color: currentColor;
+      content: '';
+      margin: 0 0 0 0.25em;
+      mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' %3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E")
+        no-repeat 0 0 / cover;
+      padding-right: 0.75em;
     }
   }
 }
@@ -84,38 +81,36 @@
 
 // For browsers that don't support CSS masks
 @mixin vf-mask-unsupported {
-  .p-link {
+  .p-link--external {
     // Used for links that point to a different domain
-    &--external {
+    @include vf-external-link-icon(vf-url-friendly-color($color-link));
+    background-position: top right;
+    background-repeat: no-repeat;
+    background-size: 0.75em;
+    margin-top: -0.25em;
+    padding: 0.25em 1em 0 0;
+
+    &.p-link--soft,
+    &.sidebar__link {
+      @include vf-external-link-icon(vf-url-friendly-color($color-dark));
+    }
+
+    &.p-link--soft:hover,
+    &.sidebar__link:hover {
       @include vf-external-link-icon(vf-url-friendly-color($color-link));
-      background-position: top right;
-      background-repeat: no-repeat;
-      background-size: 0.75em;
-      margin-top: -0.25em;
-      padding: 0.25em 1em 0 0;
+    }
 
-      &.p-link--soft,
-      &.sidebar__link {
-        @include vf-external-link-icon(vf-url-friendly-color($color-dark));
+    &.p-link--inverted {
+      @include vf-external-link-icon(vf-url-friendly-color($color-light));
+
+      &:visited {
+        @include vf-external-link-icon(vf-url-friendly-color(darken($color-light, 10%)));
       }
+    }
 
-      &.p-link--soft:hover,
-      &.sidebar__link:hover {
-        @include vf-external-link-icon(vf-url-friendly-color($color-link));
-      }
-
-      &.p-link--inverted {
-        @include vf-external-link-icon(vf-url-friendly-color($color-light));
-
-        &:visited {
-          @include vf-external-link-icon(vf-url-friendly-color(darken($color-light, 10%)));
-        }
-      }
-
-      &.sidebar__link {
-        display: inline-block;
-        padding: 0 1em 1em 0;
-      }
+    &.sidebar__link {
+      display: inline-block;
+      padding: 0 1em 1em 0;
     }
   }
 

--- a/scss/_patterns_list-tree.scss
+++ b/scss/_patterns_list-tree.scss
@@ -23,50 +23,6 @@
     margin-left: $sp-medium;
     padding: 0 0 0 $sp-x-small;
 
-    &__item {
-      margin-top: $sp-xx-small;
-      padding-left: 0.8rem;
-      position: relative;
-
-      &::before {
-        background: $color-mid-light;
-        content: ' ';
-        display: block;
-        height: 1px;
-        left: -$sp-x-small;
-        pointer-events: none;
-        position: absolute;
-        top: 0.8rem;
-        width: 0.625rem;
-      }
-
-      &--group::after {
-        @extend %list-tree-icon;
-        background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' height='15' width='15' viewBox='0 0 15 15'%3E%3Cdefs%3E%3Cpath id='a' d='M0 0h15v15H0z'/%3E%3C/defs%3E%3Cg fill-rule='evenodd' fill='none'%3E%3Cuse xlink:href='%23a' fill='%23FFF'/%3E%3Cpath stroke='%23888' d='M.5.5h14v14H.5z'/%3E%3Cpath fill='%23888' d='M7 4h1v7H7z'/%3E%3Cpath fill='%23888' d='M4 8V7h7v1z'/%3E%3C/g%3E%3C/svg%3E");
-      }
-    }
-
-    &__toggle {
-      background: transparent;
-      border: 0;
-      font-weight: normal;
-      margin: 0 0 0 -1.75rem;
-      padding: 0 0 0 1.75rem;
-      transition-duration: 0s;
-      width: auto;
-
-      &:hover {
-        background: transparent;
-        color: $color-link;
-        text-decoration: underline;
-      }
-
-      &:focus {
-        background: transparent;
-        outline: 1px dotted $color-mid-light;
-      }
-    }
-
     .p-list-tree {
       display: none;
       margin-left: 0;
@@ -81,6 +37,50 @@
         // At this point we need to push this icon above the --group icon.
         z-index: 1;
       }
+    }
+  }
+
+  .p-list-tree__item {
+    margin-top: $sp-xx-small;
+    padding-left: 0.8rem;
+    position: relative;
+
+    &::before {
+      background: $color-mid-light;
+      content: ' ';
+      display: block;
+      height: 1px;
+      left: -$sp-x-small;
+      pointer-events: none;
+      position: absolute;
+      top: 0.8rem;
+      width: 0.625rem;
+    }
+  }
+
+  .p-list-tree__item--group::after {
+    @extend %list-tree-icon;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' height='15' width='15' viewBox='0 0 15 15'%3E%3Cdefs%3E%3Cpath id='a' d='M0 0h15v15H0z'/%3E%3C/defs%3E%3Cg fill-rule='evenodd' fill='none'%3E%3Cuse xlink:href='%23a' fill='%23FFF'/%3E%3Cpath stroke='%23888' d='M.5.5h14v14H.5z'/%3E%3Cpath fill='%23888' d='M7 4h1v7H7z'/%3E%3Cpath fill='%23888' d='M4 8V7h7v1z'/%3E%3C/g%3E%3C/svg%3E");
+  }
+
+  .p-list-tree__toggle {
+    background: transparent;
+    border: 0;
+    font-weight: normal;
+    margin: 0 0 0 -1.75rem;
+    padding: 0 0 0 1.75rem;
+    transition-duration: 0s;
+    width: auto;
+
+    &:hover {
+      background: transparent;
+      color: $color-link;
+      text-decoration: underline;
+    }
+
+    &:focus {
+      background: transparent;
+      outline: 1px dotted $color-mid-light;
     }
   }
 }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -112,10 +112,10 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
   .p-inline-list {
     margin-left: 0;
     padding-left: 0;
+  }
 
-    &__item {
-      @include vf-inline-list-item;
-    }
+  .p-inline-list__item {
+    @include vf-inline-list-item;
   }
 }
 
@@ -161,20 +161,20 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
     @extend %numbered-step-container;
 
     margin-bottom: 0; // spacing has been moved onto __item; this ensures that the heading / paragraph spacing matches that of regular headings / paragraphs
+  }
 
-    &__item {
-      // override unecessary col-8 class in markup; layout is handled with css below
-      float: none;
-      margin-left: 0;
-      overflow: visible;
-      padding-bottom: map-get($sp-before, h3);
-      position: relative;
-      width: 100%;
-    }
+  .p-stepped-list__item {
+    // override unecessary col-8 class in markup; layout is handled with css below
+    float: none;
+    margin-left: 0;
+    overflow: visible;
+    padding-bottom: map-get($sp-before, h3);
+    position: relative;
+    width: 100%;
+  }
 
-    &__bullet {
-      display: none;
-    }
+  .p-stepped-list__bullet {
+    display: none;
   }
 }
 
@@ -216,24 +216,22 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
     @extend %numbered-step-container;
 
     @media (min-width: $breakpoint-medium) {
-      .p-stepped-list {
-        &__content {
-          margin-top: 0;
+      .p-stepped-list__content {
+        margin-top: 0;
+      }
+
+      .p-stepped-list__item {
+        display: flex;
+        margin: 0;
+
+        > :nth-child(2n) {
+          @include column(6, $grid-columns);
+          position: static;
         }
 
-        &__item {
-          display: flex;
-          margin: 0;
-
-          > :nth-child(2n) {
-            @include column(6, $grid-columns);
-            position: static;
-          }
-
-          > :nth-child(2n + 1) {
-            @include column(6, $grid-columns, true);
-            position: static;
-          }
+        > :nth-child(2n + 1) {
+          @include column(6, $grid-columns, true);
+          position: static;
         }
       }
     }

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -2,10 +2,10 @@
 
 // List Grid
 @mixin vf-p-matrix {
-  .p-matrix {
-    $matrix-img-width: map-get($icon-sizes, thumb--small);
-    $matrix-img-gutter: $sph-outer;
+  $matrix-img-width: map-get($icon-sizes, thumb--small);
+  $matrix-img-gutter: $sph-outer;
 
+  .p-matrix {
     display: flex;
     flex-wrap: wrap;
     list-style: none;
@@ -13,115 +13,115 @@
     margin-left: 0;
     padding-left: 0;
 
-    &__item {
-      border-top: 1px solid $color-mid-light;
+    > p:last-child {
+      margin-bottom: $spv-nudge-compensation;
+    }
+  }
+
+  .p-matrix__item {
+    border-top: 1px solid $color-mid-light;
+    display: flex;
+    flex: 1 1 auto;
+    padding-bottom: $spv-inner--scaleable;
+    padding-top: calc(#{$spv-inner--scaleable} - 1px);
+
+    @media (min-width: $breakpoint-small) {
       display: flex;
-      flex: 1 1 auto;
-      padding-bottom: $spv-inner--scaleable;
-      padding-top: calc(#{$spv-inner--scaleable} - 1px);
-
-      @media (min-width: $breakpoint-small) {
-        display: flex;
-        flex-wrap: wrap;
-        width: 33.333%;
-      }
-
-      @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large) {
-        flex-direction: column;
-      }
-
-      @media (min-width: $breakpoint-medium) {
-        border-right: 1px solid $color-mid-light;
-        padding-left: $spv-inner--scaleable;
-        padding-right: $spv-inner--scaleable;
-        width: 33.333%;
-
-        &:empty {
-          display: block; // hide orphans
-        }
-
-        &:nth-child(3n + 1) {
-          padding-left: 0;
-        }
-
-        &:nth-child(3n + 3) {
-          border-right: 0;
-        }
-
-        &:nth-child(1),
-        &:nth-child(2),
-        &:nth-child(3) {
-          border-top: 0;
-        }
-      }
-
-      @media (min-width: $breakpoint-large) {
-        // 3 items per row
-        border-right: 1px solid $color-mid-light;
-        width: 33.333%;
-
-        &:empty {
-          display: block; // hide orphans
-        }
-
-        &:nth-child(3n + 1) {
-          padding-left: 0;
-        }
-
-        &:nth-child(3n + 3) {
-          border-right: 0;
-          padding-right: 0;
-        }
-
-        &:nth-last-child(1),
-        &:nth-last-child(2),
-        &:nth-last-child(3) {
-          border-bottom: 0;
-        }
-      }
+      flex-wrap: wrap;
+      width: 33.333%;
     }
 
-    &__img {
-      align-self: flex-start;
-      margin-bottom: $spv-inner--scaleable;
-      margin-right: $matrix-img-gutter;
-      max-height: $matrix-img-width;
-      max-width: $matrix-img-width;
-      width: auto;
-    }
-
-    &__content {
-      display: flex;
-      flex: 1 1 auto;
+    @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large) {
       flex-direction: column;
-      padding-right: $sph-inner;
+    }
 
-      @media (min-width: $breakpoint-large) {
-        width: calc(100% - #{$matrix-img-width + $matrix-img-gutter});
+    @media (min-width: $breakpoint-medium) {
+      border-right: 1px solid $color-mid-light;
+      padding-left: $spv-inner--scaleable;
+      padding-right: $spv-inner--scaleable;
+      width: 33.333%;
+
+      &:empty {
+        display: block; // hide orphans
+      }
+
+      &:nth-child(3n + 1) {
+        padding-left: 0;
+      }
+
+      &:nth-child(3n + 3) {
+        border-right: 0;
+      }
+
+      &:nth-child(1),
+      &:nth-child(2),
+      &:nth-child(3) {
+        border-top: 0;
       }
     }
 
-    &__title {
-      @extend %vf-heading-4;
+    @media (min-width: $breakpoint-large) {
+      // 3 items per row
+      border-right: 1px solid $color-mid-light;
+      width: 33.333%;
+
+      &:empty {
+        display: block; // hide orphans
+      }
+
+      &:nth-child(3n + 1) {
+        padding-left: 0;
+      }
+
+      &:nth-child(3n + 3) {
+        border-right: 0;
+        padding-right: 0;
+      }
+
+      &:nth-last-child(1),
+      &:nth-last-child(2),
+      &:nth-last-child(3) {
+        border-bottom: 0;
+      }
+    }
+  }
+
+  .p-matrix__img {
+    align-self: flex-start;
+    margin-bottom: $spv-inner--scaleable;
+    margin-right: $matrix-img-gutter;
+    max-height: $matrix-img-width;
+    max-width: $matrix-img-width;
+    width: auto;
+  }
+
+  .p-matrix__content {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    padding-right: $sph-inner;
+
+    @media (min-width: $breakpoint-large) {
+      width: calc(100% - #{$matrix-img-width + $matrix-img-gutter});
+    }
+  }
+
+  .p-matrix__title {
+    @extend %vf-heading-4;
+  }
+
+  .p-matrix__desc {
+    &:last-child {
+      @extend %sp--hp;
+      margin-bottom: $spv-nudge-compensation;
     }
 
     > p:last-child {
       margin-bottom: $spv-nudge-compensation;
     }
 
-    &__desc {
-      &:last-child {
-        @extend %sp--hp;
-        margin-bottom: $spv-nudge-compensation;
-      }
-
-      > p:last-child {
-        margin-bottom: $spv-nudge-compensation;
-      }
-
-      @media (max-width: $breakpoint-heading-threshold) {
-        margin-top: -#{$sp-unit};
-      }
+    @media (max-width: $breakpoint-heading-threshold) {
+      margin-top: -#{$sp-unit};
     }
   }
 }

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -22,72 +22,72 @@
 @mixin vf-p-media-object {
   .p-media-object {
     @extend %p-media-object;
+  }
 
-    &__image {
-      align-self: flex-start;
-      border-radius: $border-radius;
-      flex-basis: inherit;
-      flex-shrink: 0;
-      margin-right: $sph-outer;
-      max-height: map-get($icon-sizes, thumb);
-      max-width: map-get($icon-sizes, thumb);
-      vertical-align: middle;
-      width: auto;
+  .p-media-object__image {
+    align-self: flex-start;
+    border-radius: $border-radius;
+    flex-basis: inherit;
+    flex-shrink: 0;
+    margin-right: $sph-outer;
+    max-height: map-get($icon-sizes, thumb);
+    max-width: map-get($icon-sizes, thumb);
+    vertical-align: middle;
+    width: auto;
+  }
+
+  .p-media-object__content {
+    margin-bottom: $spv-nudge-compensation + $sp-unit;
+    margin-top: 0;
+  }
+
+  .p-media-object__image.is-round {
+    border-radius: 50%;
+  }
+
+  .p-media-object__title {
+    @extend %vf-heading-4;
+  }
+
+  .p-media-object__meta-list {
+    list-style: none;
+    margin: 0;
+    padding-left: 0;
+    padding-top: $spv-inner--small;
+  }
+
+  .p-media-object__meta-list-item {
+    @extend %vf-meta-list-item;
+
+    &--date {
+      @extend %vf-iconed-list-item;
+      // prettier-ignore
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="90" height="90"><g transform="translate(0 -962.362)"><path color="%23000" fill="none" stroke-width="7.5" overflow="visible" enable-background="accumulate" d="M0 962.362h90v90H0z"/><path d="M35.914 968.362v9c0 4.837-4.078 8.914-8.914 8.914-4.836 0-8.914-4.077-8.914-8.914v-8.547C7.56 969.892 6 973.59 6 986.362v42c0 18 3 18 30 18h18c27 0 30 0 30-18v-42c0-12.773-1.56-16.47-12.086-17.547v8.547c0 4.837-4.078 8.914-8.914 8.914-4.836 0-8.914-4.077-8.914-8.914v-9H35.914zm.086 24h18c24 0 24 0 24 12v24c0 12 0 12-24 12H36c-24 0-24 0-24-12v-24c0-12 0-12 24-12z" fill="' + vf-url-friendly-color($color-mid-dark) + '"/><rect width="6" height="18" x="24" y="962.362" ry="3" color="%23000" fill="' + vf-url-friendly-color($color-mid-dark) + '" stroke-width=".1" overflow="visible" enable-background="accumulate"/><rect ry="3" y="962.362" x="60" height="18" width="6" color="%23000" fill="' + vf-url-friendly-color($color-mid-dark) + '" stroke-width=".1" overflow="visible" enable-background="accumulate"/><path style="text-align:center;line-height:125%;-inkscape-font-specification:Ubuntu Medium" d="M33.336 1001.364v.01c-1.8 0-3.5.348-5.087 1.043-1.548.663-2.913 1.553-4.08 2.664l-.352.337 3.06 4.335.474-.472c.158-.158.425-.388.787-.673l.01-.013.01-.012c.342-.295.74-.582 1.194-.86.467-.27 1.002-.507 1.607-.71.577-.19 1.206-.288 1.896-.288 1.048 0 1.885.26 2.58.768.626.46.964 1.222.964 2.497 0 .56-.114 1.1-.35 1.647-.246.538-.58 1.082-1.006 1.635h-.002c-.408.535-.896 1.088-1.466 1.658-.582.582-1.192 1.176-1.827 1.785h-.004c-.827.8-1.653 1.613-2.48 2.44-.846.845-1.61 1.748-2.292 2.704h-.002c-.692.967-1.26 2.02-1.702 3.15-.426 1.134-.635 2.372-.635 3.707v.72c0 .31.015.583.046.828l.064.493h18.65v-5.197H31.386c.072-.144.057-.21.18-.392l.006-.012h.002c.33-.507.727-1.034 1.192-1.576.47-.548.966-1.096 1.488-1.645l.008-.01c.527-.553.998-1.027 1.413-1.416h.007c.8-.775 1.6-1.56 2.4-2.36h.007c.813-.844 1.534-1.7 2.163-2.576h.002c.66-.906 1.197-1.83 1.613-2.773.428-.994.645-2.02.645-3.054 0-2.528-.756-4.605-2.28-6.102-1.524-1.55-3.862-2.28-6.9-2.28zm16.626.635v.01l-.024.537c-.106 2.31-.24 4.618-.4 6.927-.158 2.277-.384 4.688-.676 7.233l-.07.628h.632c2.187 0 3.982.12 5.37.353h.004c1.42.23 2.518.58 3.283 1.01h.01c.804.44 1.316.945 1.6 1.512.302.606.46 1.297.46 2.1 0 .514-.094.994-.278 1.457-.174.414-.456.79-.876 1.14h-.016c-.375.333-.9.615-1.582.836-.677.193-1.514.298-2.51.298-1.48 0-2.72-.144-3.718-.42-1.012-.31-1.79-.596-2.3-.84l-.638-.304-1.17 5.187.394.198c.32.16.74.313 1.287.477.553.167 1.168.315 1.847.45.703.163 1.43.3 2.184.407.77.11 1.527.163 2.273.163 1.826 0 3.44-.214 4.84-.66h.008c1.386-.473 2.56-1.12 3.502-1.948.94-.827 1.647-1.823 2.105-2.967.454-1.135.68-2.365.68-3.678 0-2.868-1.023-5.22-3.034-6.892-1.888-1.617-4.76-2.472-8.434-2.75.033-.27.064-.51.097-.834.055-.535.096-1.096.123-1.68l.002-.025c.052-.575.09-1.138.117-1.688l.003-.027c.035-.38.054-.693.077-1.02h10.055V1002H49.962z" font-size="35.345" font-weight="500" letter-spacing="0" word-spacing="0" text-anchor="middle" fill="' + vf-url-friendly-color($color-mid-dark) + '" font-family="Ubuntu"/></g></svg>');
     }
 
-    &__content {
-      margin-bottom: $spv-nudge-compensation + $sp-unit;
-      margin-top: 0;
+    &--location {
+      @extend %vf-iconed-list-item;
+      // prettier-ignore
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="90" height="90"><g color="%23000"><path d="M45 0C30.088 0 18 12.088 18 27c0 .562.03 1.103.063 1.656.013.248.012.497.03.75.02.23.07.46.095.688C20.22 51.854 41.922 90 45 90c3.078 0 24.78-38.146 26.813-59.906.02-.232.076-.46.093-.688.022-.248.016-.5.03-.75.032-.56.064-1.12.064-1.656C72 12.088 59.912 0 45 0zm0 18c4.97 0 9 4.03 9 9s-4.03 9-9 9-9-4.03-9-9 4.03-9 9-9z" fill="' + vf-url-friendly-color($color-mid-dark) + '" stroke-width="3" overflow="visible" enable-background="accumulate"/><path fill="none" stroke-width="7.5" overflow="visible" enable-background="accumulate" d="M0 0h90v90H0z"/></g></svg>');
     }
 
-    &__image.is-round {
-      border-radius: 50%;
+    &--venue {
+      @extend %vf-iconed-list-item;
+      // prettier-ignore
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="90" height="90" viewBox="0 0 90 90.000001"><g transform="translate(-111.967 -929.337)" color="%23000"><path fill="none" stroke-width="4" overflow="visible" enable-background="accumulate" d="M111.967 929.336h90v90h-90z"/><circle r="6.5" cy="24.5" cx="23.5" transform="matrix(1.846 0 0 1.846 113.583 929.105)" fill="' + vf-url-friendly-color($color-mid-dark) + '" stroke-width="2" overflow="visible" enable-background="accumulate"/><circle r="21" cy="45" cx="45" transform="matrix(1.429 0 0 1.429 92.682 910.05)" fill="none" stroke="' + vf-url-friendly-color($color-mid-dark) + '" stroke-width="4.2" stroke-linejoin="round" overflow="visible" enable-background="accumulate"/><path d="M152.967 931.736l8-2.4v15h-8zM160.967 1016.336h-8v-12h8zM198.967 970.336v8h-12v-8zM114.967 978.336v-8h12v8z" overflow="visible" fill="' + vf-url-friendly-color($color-mid-dark) + '" stroke-width="6" enable-background="accumulate"/></g></svg>');
+    }
+  }
+
+  .p-media-object--large {
+    @extend %p-media-object;
+
+    .p-media-object__image {
+      max-height: map-get($icon-sizes, thumb--large);
+      max-width: map-get($icon-sizes, thumb--large);
     }
 
-    &__title {
-      @extend %vf-heading-4;
-    }
-
-    &__meta-list {
-      list-style: none;
-      margin: 0;
-      padding-left: 0;
-      padding-top: $spv-inner--small;
-    }
-
-    &__meta-list-item {
-      @extend %vf-meta-list-item;
-
-      &--date {
-        @extend %vf-iconed-list-item;
-        // prettier-ignore
-        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="90" height="90"><g transform="translate(0 -962.362)"><path color="%23000" fill="none" stroke-width="7.5" overflow="visible" enable-background="accumulate" d="M0 962.362h90v90H0z"/><path d="M35.914 968.362v9c0 4.837-4.078 8.914-8.914 8.914-4.836 0-8.914-4.077-8.914-8.914v-8.547C7.56 969.892 6 973.59 6 986.362v42c0 18 3 18 30 18h18c27 0 30 0 30-18v-42c0-12.773-1.56-16.47-12.086-17.547v8.547c0 4.837-4.078 8.914-8.914 8.914-4.836 0-8.914-4.077-8.914-8.914v-9H35.914zm.086 24h18c24 0 24 0 24 12v24c0 12 0 12-24 12H36c-24 0-24 0-24-12v-24c0-12 0-12 24-12z" fill="' + vf-url-friendly-color($color-mid-dark) + '"/><rect width="6" height="18" x="24" y="962.362" ry="3" color="%23000" fill="' + vf-url-friendly-color($color-mid-dark) + '" stroke-width=".1" overflow="visible" enable-background="accumulate"/><rect ry="3" y="962.362" x="60" height="18" width="6" color="%23000" fill="' + vf-url-friendly-color($color-mid-dark) + '" stroke-width=".1" overflow="visible" enable-background="accumulate"/><path style="text-align:center;line-height:125%;-inkscape-font-specification:Ubuntu Medium" d="M33.336 1001.364v.01c-1.8 0-3.5.348-5.087 1.043-1.548.663-2.913 1.553-4.08 2.664l-.352.337 3.06 4.335.474-.472c.158-.158.425-.388.787-.673l.01-.013.01-.012c.342-.295.74-.582 1.194-.86.467-.27 1.002-.507 1.607-.71.577-.19 1.206-.288 1.896-.288 1.048 0 1.885.26 2.58.768.626.46.964 1.222.964 2.497 0 .56-.114 1.1-.35 1.647-.246.538-.58 1.082-1.006 1.635h-.002c-.408.535-.896 1.088-1.466 1.658-.582.582-1.192 1.176-1.827 1.785h-.004c-.827.8-1.653 1.613-2.48 2.44-.846.845-1.61 1.748-2.292 2.704h-.002c-.692.967-1.26 2.02-1.702 3.15-.426 1.134-.635 2.372-.635 3.707v.72c0 .31.015.583.046.828l.064.493h18.65v-5.197H31.386c.072-.144.057-.21.18-.392l.006-.012h.002c.33-.507.727-1.034 1.192-1.576.47-.548.966-1.096 1.488-1.645l.008-.01c.527-.553.998-1.027 1.413-1.416h.007c.8-.775 1.6-1.56 2.4-2.36h.007c.813-.844 1.534-1.7 2.163-2.576h.002c.66-.906 1.197-1.83 1.613-2.773.428-.994.645-2.02.645-3.054 0-2.528-.756-4.605-2.28-6.102-1.524-1.55-3.862-2.28-6.9-2.28zm16.626.635v.01l-.024.537c-.106 2.31-.24 4.618-.4 6.927-.158 2.277-.384 4.688-.676 7.233l-.07.628h.632c2.187 0 3.982.12 5.37.353h.004c1.42.23 2.518.58 3.283 1.01h.01c.804.44 1.316.945 1.6 1.512.302.606.46 1.297.46 2.1 0 .514-.094.994-.278 1.457-.174.414-.456.79-.876 1.14h-.016c-.375.333-.9.615-1.582.836-.677.193-1.514.298-2.51.298-1.48 0-2.72-.144-3.718-.42-1.012-.31-1.79-.596-2.3-.84l-.638-.304-1.17 5.187.394.198c.32.16.74.313 1.287.477.553.167 1.168.315 1.847.45.703.163 1.43.3 2.184.407.77.11 1.527.163 2.273.163 1.826 0 3.44-.214 4.84-.66h.008c1.386-.473 2.56-1.12 3.502-1.948.94-.827 1.647-1.823 2.105-2.967.454-1.135.68-2.365.68-3.678 0-2.868-1.023-5.22-3.034-6.892-1.888-1.617-4.76-2.472-8.434-2.75.033-.27.064-.51.097-.834.055-.535.096-1.096.123-1.68l.002-.025c.052-.575.09-1.138.117-1.688l.003-.027c.035-.38.054-.693.077-1.02h10.055V1002H49.962z" font-size="35.345" font-weight="500" letter-spacing="0" word-spacing="0" text-anchor="middle" fill="' + vf-url-friendly-color($color-mid-dark) + '" font-family="Ubuntu"/></g></svg>');
-      }
-
-      &--location {
-        @extend %vf-iconed-list-item;
-        // prettier-ignore
-        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="90" height="90"><g color="%23000"><path d="M45 0C30.088 0 18 12.088 18 27c0 .562.03 1.103.063 1.656.013.248.012.497.03.75.02.23.07.46.095.688C20.22 51.854 41.922 90 45 90c3.078 0 24.78-38.146 26.813-59.906.02-.232.076-.46.093-.688.022-.248.016-.5.03-.75.032-.56.064-1.12.064-1.656C72 12.088 59.912 0 45 0zm0 18c4.97 0 9 4.03 9 9s-4.03 9-9 9-9-4.03-9-9 4.03-9 9-9z" fill="' + vf-url-friendly-color($color-mid-dark) + '" stroke-width="3" overflow="visible" enable-background="accumulate"/><path fill="none" stroke-width="7.5" overflow="visible" enable-background="accumulate" d="M0 0h90v90H0z"/></g></svg>');
-      }
-
-      &--venue {
-        @extend %vf-iconed-list-item;
-        // prettier-ignore
-        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="90" height="90" viewBox="0 0 90 90.000001"><g transform="translate(-111.967 -929.337)" color="%23000"><path fill="none" stroke-width="4" overflow="visible" enable-background="accumulate" d="M111.967 929.336h90v90h-90z"/><circle r="6.5" cy="24.5" cx="23.5" transform="matrix(1.846 0 0 1.846 113.583 929.105)" fill="' + vf-url-friendly-color($color-mid-dark) + '" stroke-width="2" overflow="visible" enable-background="accumulate"/><circle r="21" cy="45" cx="45" transform="matrix(1.429 0 0 1.429 92.682 910.05)" fill="none" stroke="' + vf-url-friendly-color($color-mid-dark) + '" stroke-width="4.2" stroke-linejoin="round" overflow="visible" enable-background="accumulate"/><path d="M152.967 931.736l8-2.4v15h-8zM160.967 1016.336h-8v-12h8zM198.967 970.336v8h-12v-8zM114.967 978.336v-8h12v8z" overflow="visible" fill="' + vf-url-friendly-color($color-mid-dark) + '" stroke-width="6" enable-background="accumulate"/></g></svg>');
-      }
-    }
-
-    &--large {
-      @extend %p-media-object;
-
-      .p-media-object__image {
-        max-height: map-get($icon-sizes, thumb--large);
-        max-width: map-get($icon-sizes, thumb--large);
-      }
-
-      .p-media-object__title {
-        @extend %vf-heading-1;
-      }
+    .p-media-object__title {
+      @extend %vf-heading-1;
     }
   }
 }

--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -15,58 +15,58 @@
     position: absolute;
     top: 0;
     width: 100%;
+  }
 
-    &__dialog {
-      @extend %vf-card;
-      @extend %vf-has-box-shadow;
-      @extend %vf-has-round-corners;
-      bottom: $sp-large;
-      left: $sp-large;
-      max-width: $grid-max-width;
-      overflow: scroll;
-      position: absolute;
-      right: $sp-large;
-      top: $sp-large;
-      width: auto;
+  .p-modal__dialog {
+    @extend %vf-card;
+    @extend %vf-has-box-shadow;
+    @extend %vf-has-round-corners;
+    bottom: $sp-large;
+    left: $sp-large;
+    max-width: $grid-max-width;
+    overflow: scroll;
+    position: absolute;
+    right: $sp-large;
+    top: $sp-large;
+    width: auto;
 
-      @media screen and (min-width: $breakpoint-medium) {
-        bottom: initial;
-        left: initial;
-        overflow: visible;
-        position: relative;
-        right: initial;
-        top: initial;
-      }
+    @media screen and (min-width: $breakpoint-medium) {
+      bottom: initial;
+      left: initial;
+      overflow: visible;
+      position: relative;
+      right: initial;
+      top: initial;
     }
+  }
 
-    &__header {
-      display: flex;
-      justify-content: space-between;
+  .p-modal__header {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .p-modal__title {
+    @extend %vf-heading-4;
+    align-self: flex-end;
+  }
+
+  .p-modal__close {
+    background: {
+      image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' height='90' width='90'%3E%3Cg color='%23000'%3E%3Cpath fill='none' d='M0 0h90v90H0z'/%3E%3Cpath d='M14.52 6L6 14.52 36.48 45 6 75.49 14.52 84 45 53.52 75.48 84 84 75.49 53.52 45 84 14.52 75.48 6 45 36.49z' fill='%23888'/%3E%3C/g%3E%3C/svg%3E");
+      position: center;
+      repeat: no-repeat;
+      size: $sp-medium;
     }
+    border: 0;
+    box-sizing: content-box;
+    height: $sp-medium;
+    margin: -#{$sp-medium} -#{$sp-medium} 0 0;
+    padding: $sp-medium;
+    text-indent: -999em;
+    width: $sp-medium;
 
-    &__title {
-      @extend %vf-heading-4;
-      align-self: flex-end;
-    }
-
-    &__close {
-      background: {
-        image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' height='90' width='90'%3E%3Cg color='%23000'%3E%3Cpath fill='none' d='M0 0h90v90H0z'/%3E%3Cpath d='M14.52 6L6 14.52 36.48 45 6 75.49 14.52 84 45 53.52 75.48 84 84 75.49 53.52 45 84 14.52 75.48 6 45 36.49z' fill='%23888'/%3E%3C/g%3E%3C/svg%3E");
-        position: center;
-        repeat: no-repeat;
-        size: $sp-medium;
-      }
-      border: 0;
-      box-sizing: content-box;
-      height: $sp-medium;
-      margin: -#{$sp-medium} -#{$sp-medium} 0 0;
-      padding: $sp-medium;
-      text-indent: -999em;
-      width: $sp-medium;
-
-      &:focus {
-        outline: 2px solid $color-focus;
-      }
+    &:focus {
+      outline: 2px solid $color-focus;
     }
   }
 }

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -36,23 +36,23 @@
     & + & {
       margin-top: $spv-outer--scaleable; // negate bottom margin
     }
+  }
 
-    &__response {
-      @extend %default-text;
-      background-position: $sph-inner $spv-inner--x-small--scaleable + $spv-nudge + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default));
-      background-repeat: no-repeat;
-      background-size: map-get($icon-sizes, default);
-      padding: $spv-inner--x-small--scaleable + $spv-nudge $sph-inner $spv-inner--x-small--scaleable;
-    }
+  .p-notification__response {
+    @extend %default-text;
+    background-position: $sph-inner $spv-inner--x-small--scaleable + $spv-nudge + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default));
+    background-repeat: no-repeat;
+    background-size: map-get($icon-sizes, default);
+    padding: $spv-inner--x-small--scaleable + $spv-nudge $sph-inner $spv-inner--x-small--scaleable;
+  }
 
-    &__status {
-      @extend %bold;
-    }
+  .p-notification__status {
+    @extend %bold;
+  }
 
-    &__status::after,
-    &__action::before {
-      content: ' ';
-    }
+  .p-notification__status::after,
+  .p-notification__action::before {
+    content: ' ';
   }
 
   .p-notification__response,

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -41,38 +41,38 @@
     list-style: none;
     margin-left: 0;
     padding-left: 0;
+  }
 
-    &__item {
-      margin-right: $sph-inner--small;
-      width: auto;
+  .p-pagination__item {
+    margin-right: $sph-inner--small;
+    width: auto;
 
-      &:first-child,
-      &:nth-last-child(2) {
-        margin-right: $sph-inner;
-      }
-
-      &--truncation {
-        margin: 0.3rem $sph-inner 0 $sph-inner--small;
-      }
+    &:first-child,
+    &:nth-last-child(2) {
+      margin-right: $sph-inner;
     }
 
-    &__link {
-      @extend %pagination-link;
+    &--truncation {
+      margin: 0.3rem $sph-inner 0 $sph-inner--small;
     }
+  }
 
-    &__link--previous,
-    &__link--next {
-      @extend %pagination-link;
-      padding-left: $sph-inner--small;
-      padding-right: $sph-inner--small;
-    }
+  .p-pagination__link {
+    @extend %pagination-link;
+  }
 
-    &__link--previous .p-icon--contextual-menu {
-      transform: rotate(0.25turn);
-    }
+  .p-pagination__link--previous,
+  .p-pagination__link--next {
+    @extend %pagination-link;
+    padding-left: $sph-inner--small;
+    padding-right: $sph-inner--small;
+  }
 
-    &__link--next .p-icon--contextual-menu {
-      transform: rotate(-0.25turn);
-    }
+  .p-pagination__link--previous .p-icon--contextual-menu {
+    transform: rotate(0.25turn);
+  }
+
+  .p-pagination__link--next .p-icon--contextual-menu {
+    transform: rotate(-0.25turn);
   }
 }

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -18,33 +18,33 @@
   .p-pull-quote {
     padding: 0 $sph-outer * 2;
     position: relative;
-  }
 
-  .p-pull-quote__image {
-    height: $sp-x-large;
-    position: absolute;
-    top: -$spv-inner--x-large;
-  }
-
-  .p-pull-quote__quote {
-    @extend %vf-heading-4;
-
-    &::before,
-    &::after {
-      font-size: 2em;
+    .p-pull-quote__image {
+      height: $sp-x-large;
+      position: absolute;
+      top: -$spv-inner--x-large;
     }
 
-    &:last-of-type::after {
-      bottom: 4rem;
+    .p-pull-quote__quote {
+      @extend %vf-heading-4;
 
-      @media (max-width: $breakpoint-heading-threshold) {
-        bottom: 3.5rem;
+      &::before,
+      &::after {
+        font-size: 2em;
+      }
+
+      &:last-of-type::after {
+        bottom: 4rem;
+
+        @media (max-width: $breakpoint-heading-threshold) {
+          bottom: 3.5rem;
+        }
       }
     }
-  }
 
-  .p-pull-quote__citation {
-    @extend %vf-heading-4;
+    .p-pull-quote__citation {
+      @extend %vf-heading-4;
+    }
   }
 
   .p-pull-quote--small {

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -18,33 +18,33 @@
   .p-pull-quote {
     padding: 0 $sph-outer * 2;
     position: relative;
+  }
 
-    .p-pull-quote__image {
-      height: $sp-x-large;
-      position: absolute;
-      top: -$spv-inner--x-large;
+  .p-pull-quote__image {
+    height: $sp-x-large;
+    position: absolute;
+    top: -$spv-inner--x-large;
+  }
+
+  .p-pull-quote__quote {
+    @extend %vf-heading-4;
+
+    &::before,
+    &::after {
+      font-size: 2em;
     }
 
-    .p-pull-quote__quote {
-      @extend %vf-heading-4;
+    &:last-of-type::after {
+      bottom: 4rem;
 
-      &::before,
-      &::after {
-        font-size: 2em;
+      @media (max-width: $breakpoint-heading-threshold) {
+        bottom: 3.5rem;
       }
-
-      &:last-of-type::after {
-        bottom: 4rem;
-
-        @media (max-width: $breakpoint-heading-threshold) {
-          bottom: 3.5rem;
-        }
-      }
     }
+  }
 
-    .p-pull-quote__citation {
-      @extend %vf-heading-4;
-    }
+  .p-pull-quote__citation {
+    @extend %vf-heading-4;
   }
 
   .p-pull-quote--small {

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -24,30 +24,30 @@
     display: flex;
     margin-bottom: $spv-outer--scaleable + $spv-nudge-compensation * 2;
     position: relative;
+  }
 
-    &__input {
-      flex-grow: 2;
-      margin-bottom: 0; // XXX patch it stretches a box shadow and the search button.
+  .p-search-box__input {
+    flex-grow: 2;
+    margin-bottom: 0; // XXX patch it stretches a box shadow and the search button.
 
-      &::-webkit-search-cancel-button {
-        -webkit-appearance: none; // sass-lint:disable-line no-vendor-prefixes
-      }
-
-      &:not(:valid) ~ .p-search-box__reset {
-        display: none;
-      }
+    &::-webkit-search-cancel-button {
+      -webkit-appearance: none; // sass-lint:disable-line no-vendor-prefixes
     }
 
-    &__button {
-      @extend %search-box-button;
-      right: 0;
+    &:not(:valid) ~ .p-search-box__reset {
+      display: none;
     }
+  }
 
-    &__reset {
-      @extend %search-box-button;
-      border-left: 0;
-      border-right: 0;
-      right: $sp-xx-large;
-    }
+  .p-search-box__button {
+    @extend %search-box-button;
+    right: 0;
+  }
+
+  .p-search-box__reset {
+    @extend %search-box-button;
+    border-left: 0;
+    border-right: 0;
+    right: $sp-xx-large;
   }
 }

--- a/scss/_patterns_slider.scss
+++ b/scss/_patterns_slider.scss
@@ -136,19 +136,19 @@
     &:disabled {
       opacity: 0.5;
     }
+  }
 
-    &__wrapper {
-      align-items: center;
-      display: inline-flex;
-      width: 100%;
-    }
+  .p-slider__wrapper {
+    align-items: center;
+    display: inline-flex;
+    width: 100%;
+  }
 
-    &__input {
-      height: 2.625rem;
-      margin: 0 0 0 $sp-medium;
-      min-width: 5rem;
-      text-align: center;
-      width: 5%;
-    }
+  .p-slider__input {
+    height: 2.625rem;
+    margin: 0 0 0 $sp-medium;
+    min-width: 5rem;
+    text-align: center;
+    width: 5%;
   }
 }

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -23,31 +23,31 @@ $knob-size: $sp-unit * 3;
         outline: 2px solid $color-focus;
       }
     }
+  }
 
-    &__slider {
+  .p-switch__slider {
+    @extend %vf-has-round-corners;
+    background: linear-gradient(to right, $color-information 50%, $color-mid-light 50%);
+    box-shadow: inset 0 2px 5px 0 transparentize($color-dark, 0.8);
+    height: $knob-size;
+    margin: $spv-nudge-compensation 0 $spv-outer--small-scaleable 0;
+    position: relative;
+    width: $knob-size * 2;
+
+    &::before {
       @extend %vf-has-round-corners;
-      background: linear-gradient(to right, $color-information 50%, $color-mid-light 50%);
-      box-shadow: inset 0 2px 5px 0 transparentize($color-dark, 0.8);
+      @extend %vf-has-box-shadow;
+      @include vf-animation($duration: slow);
+      background: $color-x-light;
+      content: '';
       height: $knob-size;
-      margin: $spv-nudge-compensation 0 $spv-outer--small-scaleable 0;
-      position: relative;
-      width: $knob-size * 2;
+      left: 0;
+      position: absolute;
+      width: $knob-size;
+    }
 
-      &::before {
-        @extend %vf-has-round-corners;
-        @extend %vf-has-box-shadow;
-        @include vf-animation($duration: slow);
-        background: $color-x-light;
-        content: '';
-        height: $knob-size;
-        left: 0;
-        position: absolute;
-        width: $knob-size;
-      }
-
-      & span {
-        @extend %vf-hide-text;
-      }
+    & span {
+      @extend %vf-hide-text;
     }
   }
 }

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -70,49 +70,49 @@
         [role='menuitem'] {
           display: none;
         }
+      }
 
-        &__dropdown {
-          box-shadow: none;
-          display: block;
-          max-width: 100%;
-          position: relative;
+      .p-contextual-menu__dropdown {
+        box-shadow: none;
+        display: block;
+        max-width: 100%;
+        position: relative;
 
-          &::before {
-            display: none;
-          }
+        &::before {
+          display: none;
         }
+      }
 
-        &__group {
-          padding: 0;
+      .p-contextual-menu__group {
+        padding: 0;
 
-          + .p-contextual-menu__group {
-            margin-top: $sp-small;
-            padding-top: $sp-small;
-          }
+        + .p-contextual-menu__group {
+          margin-top: $sp-small;
+          padding-top: $sp-small;
         }
+      }
 
-        // Any link items should be styled as a button element
-        &__link {
-          border: {
-            color: $color-mid-light;
-            radius: 0.125rem;
-            style: solid;
-            width: 1px;
-          }
-          box-sizing: border-box;
-          color: $color-x-dark;
-          cursor: pointer;
-          display: block;
-          line-height: $sp-medium;
-          outline: none;
-          padding: $sp-small $sp-large;
-          text-align: center;
-          text-decoration: none;
-          width: 100%;
+      // Any link items should be styled as a button element
+      .p-contextual-menu__link {
+        border: {
+          color: $color-mid-light;
+          radius: 0.125rem;
+          style: solid;
+          width: 1px;
+        }
+        box-sizing: border-box;
+        color: $color-x-dark;
+        cursor: pointer;
+        display: block;
+        line-height: $sp-medium;
+        outline: none;
+        padding: $sp-small $sp-large;
+        text-align: center;
+        text-decoration: none;
+        width: 100%;
 
-          + .p-contextual-menu__link {
-            margin-top: $sp-x-small;
-          }
+        + .p-contextual-menu__link {
+          margin-top: $sp-x-small;
         }
       }
     }

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -5,43 +5,6 @@ $triangle-height: $sp-unit;
   .p-tooltip {
     position: relative;
 
-    &__message {
-      // sass-lint:disable no-vendor-prefixes property-sort-order
-      @extend %small-text;
-      background-color: $color-dark;
-      border: 0;
-      border-radius: $border-radius;
-      color: $color-x-light;
-      display: none;
-      left: -#{2 * $triangle-height};
-      margin-bottom: 0;
-      padding: $spv-inner--small $sph-inner;
-      position: absolute;
-      text-align: left;
-      text-decoration: initial;
-      top: 100%;
-      -webkit-transform: translateX(0%) translateY(13px);
-      transform: translateX(0%) translateY(13px);
-      // sass-lint:enable no-vendor-prefixes property-sort-order
-      white-space: pre;
-      z-index: 1;
-
-      &::before {
-        border: {
-          bottom: $triangle-height solid $color-dark;
-          left: $triangle-height solid transparent;
-          right: $triangle-height solid transparent;
-        }
-        bottom: 100%;
-        content: '';
-        height: 0;
-        left: $sph-inner;
-        pointer-events: none;
-        position: absolute;
-        width: 0;
-      }
-    }
-
     &:focus,
     &:hover {
       .p-tooltip__message {
@@ -49,178 +12,215 @@ $triangle-height: $sp-unit;
         text-decoration: initial;
       }
     }
+  }
 
-    // Bottom center tooltip
-    &--btm-center {
-      .p-tooltip__message {
+  .p-tooltip__message {
+    // sass-lint:disable no-vendor-prefixes property-sort-order
+    @extend %small-text;
+    background-color: $color-dark;
+    border: 0;
+    border-radius: $border-radius;
+    color: $color-x-light;
+    display: none;
+    left: -#{2 * $triangle-height};
+    margin-bottom: 0;
+    padding: $spv-inner--small $sph-inner;
+    position: absolute;
+    text-align: left;
+    text-decoration: initial;
+    top: 100%;
+    -webkit-transform: translateX(0%) translateY(13px);
+    transform: translateX(0%) translateY(13px);
+    // sass-lint:enable no-vendor-prefixes property-sort-order
+    white-space: pre;
+    z-index: 1;
+
+    &::before {
+      border: {
+        bottom: $triangle-height solid $color-dark;
+        left: $triangle-height solid transparent;
+        right: $triangle-height solid transparent;
+      }
+      bottom: 100%;
+      content: '';
+      height: 0;
+      left: $sph-inner;
+      pointer-events: none;
+      position: absolute;
+      width: 0;
+    }
+  }
+
+  // Bottom center tooltip
+  .p-tooltip--btm-center {
+    .p-tooltip__message {
+      // sass-lint:disable no-vendor-prefixes property-sort-order
+      bottom: inherit;
+      left: 50%;
+      top: 100%;
+      -webkit-transform: translateX(-50%) translateY(13px);
+      transform: translateX(-50%) translateY(13px);
+      // sass-lint:enable no-vendor-prefixes property-sort-order
+
+      &::before {
         // sass-lint:disable no-vendor-prefixes property-sort-order
-        bottom: inherit;
         left: 50%;
-        top: 100%;
-        -webkit-transform: translateX(-50%) translateY(13px);
-        transform: translateX(-50%) translateY(13px);
+        -webkit-transform: translateX(-50%);
+        transform: translateX(-50%);
         // sass-lint:enable no-vendor-prefixes property-sort-order
-
-        &::before {
-          // sass-lint:disable no-vendor-prefixes property-sort-order
-          left: 50%;
-          -webkit-transform: translateX(-50%);
-          transform: translateX(-50%);
-          // sass-lint:enable no-vendor-prefixes property-sort-order
-        }
       }
     }
+  }
 
-    // Bottom right tooltip
-    &--btm-right {
-      .p-tooltip__message {
-        // sass-lint:disable no-vendor-prefixes property-sort-order
-        bottom: inherit;
+  // Bottom right tooltip
+  .p-tooltip--btm-right {
+    .p-tooltip__message {
+      // sass-lint:disable no-vendor-prefixes property-sort-order
+      bottom: inherit;
+      left: initial;
+      right: -#{2 * $triangle-height};
+      top: 100%;
+      -webkit-transform: translateY(13px);
+      transform: translateY(13px);
+      // sass-lint:enable no-vendor-prefixes property-sort-order
+
+      &::before {
         left: initial;
-        right: -#{2 * $triangle-height};
-        top: 100%;
-        -webkit-transform: translateY(13px);
-        transform: translateY(13px);
-        // sass-lint:enable no-vendor-prefixes property-sort-order
-
-        &::before {
-          left: initial;
-          right: $sph-inner;
-        }
+        right: $sph-inner;
       }
     }
+  }
 
-    // Top left tooltip
-    &--top-left {
-      .p-tooltip__message {
-        // sass-lint:disable no-vendor-prefixes property-sort-order
-        bottom: 100%;
-        left: -#{2 * $triangle-height};
-        top: initial;
-        -webkit-transform: translateX(0%) translateY(-13px);
-        transform: translateX(0%) translateY(-13px);
-        // sass-lint:enable no-vendor-prefixes property-sort-order
+  // Top left tooltip
+  .p-tooltip--top-left {
+    .p-tooltip__message {
+      // sass-lint:disable no-vendor-prefixes property-sort-order
+      bottom: 100%;
+      left: -#{2 * $triangle-height};
+      top: initial;
+      -webkit-transform: translateX(0%) translateY(-13px);
+      transform: translateX(0%) translateY(-13px);
+      // sass-lint:enable no-vendor-prefixes property-sort-order
 
-        &::before {
-          border: {
-            bottom: $triangle-height solid transparent;
-            left: $triangle-height solid transparent;
-            right: $triangle-height solid transparent;
-            top: $triangle-height solid $color-dark;
-          }
-          bottom: -#{2 * $triangle-height};
-          left: $sph-inner;
+      &::before {
+        border: {
+          bottom: $triangle-height solid transparent;
+          left: $triangle-height solid transparent;
+          right: $triangle-height solid transparent;
+          top: $triangle-height solid $color-dark;
         }
+        bottom: -#{2 * $triangle-height};
+        left: $sph-inner;
       }
     }
+  }
 
-    // Top center tooltip
-    &--top-center {
-      .p-tooltip__message {
-        // sass-lint:disable no-vendor-prefixes property-sort-order
-        bottom: 100%;
+  // Top center tooltip
+  .p-tooltip--top-center {
+    .p-tooltip__message {
+      // sass-lint:disable no-vendor-prefixes property-sort-order
+      bottom: 100%;
+      left: 50%;
+      top: initial;
+      -webkit-transform: translateX(-50%) translateY(-13px);
+      transform: translateX(-50%) translateY(-13px);
+
+      &::before {
+        border: {
+          bottom: $triangle-height solid transparent;
+          left: $triangle-height solid transparent;
+          right: $triangle-height solid transparent;
+          top: $triangle-height solid $color-dark;
+        }
+        bottom: -#{2 * $triangle-height};
         left: 50%;
-        top: initial;
-        -webkit-transform: translateX(-50%) translateY(-13px);
-        transform: translateX(-50%) translateY(-13px);
+        -webkit-transform: translateX(-50%);
+        transform: translateX(-50%);
+      }
+      // sass-lint:enable no-vendor-prefixes property-sort-order
+    }
+  }
 
-        &::before {
-          border: {
-            bottom: $triangle-height solid transparent;
-            left: $triangle-height solid transparent;
-            right: $triangle-height solid transparent;
-            top: $triangle-height solid $color-dark;
-          }
-          bottom: -#{2 * $triangle-height};
-          left: 50%;
-          -webkit-transform: translateX(-50%);
-          transform: translateX(-50%);
+  // Top right tooltip
+  .p-tooltip--top-right {
+    .p-tooltip__message {
+      // sass-lint:disable no-vendor-prefixes property-sort-order
+      bottom: 100%;
+      left: initial;
+      right: -#{2 * $triangle-height};
+      top: initial;
+      -webkit-transform: translateX(0%) translateY(-13px);
+      transform: translateX(0%) translateY(-13px);
+      // sass-lint:enabled no-vendor-prefixes property-sort-order
+
+      &::before {
+        border: {
+          bottom: $triangle-height solid transparent;
+          left: $triangle-height solid transparent;
+          right: $triangle-height solid transparent;
+          top: $triangle-height solid $color-dark;
         }
+        bottom: -#{2 * $triangle-height};
+        left: initial;
+        right: $sph-inner;
+      }
+    }
+  }
+
+  // Right tooltip
+  .p-tooltip--right {
+    .p-tooltip__message {
+      bottom: inherit;
+      left: 100%;
+      top: 50%;
+      // sass-lint:disable no-vendor-prefixes property-sort-order
+      -webkit-transform: translateX(14px) translateY(-50%);
+      transform: translateX(14px) translateY(-50%);
+      // sass-lint:enable no-vendor-prefixes property-sort-order
+
+      &::before {
+        // sass-lint:disable no-vendor-prefixes property-sort-order
+        border: {
+          bottom: $triangle-height solid transparent;
+          left: $triangle-height solid transparent;
+          right: $triangle-height solid $color-dark;
+          top: $triangle-height solid transparent;
+        }
+        bottom: inherit;
+        left: 0;
+        top: 50%;
+        -webkit-transform: translateX(-16px) translateY(-50%);
+        transform: translateX(-16px) translateY(-50%);
         // sass-lint:enable no-vendor-prefixes property-sort-order
       }
     }
+  }
 
-    // Top right tooltip
-    &--top-right {
-      .p-tooltip__message {
+  // Left tooltip
+  .p-tooltip--left {
+    .p-tooltip__message {
+      // sass-lint:disable no-vendor-prefixes property-sort-order
+      bottom: inherit;
+      left: -16px;
+      top: 50%;
+      -webkit-transform: translateX(-100%) translateY(-50%);
+      transform: translateX(-100%) translateY(-50%);
+      // sass-lint:enable no-vendor-prefixes property-sort-order
+
+      &::before {
         // sass-lint:disable no-vendor-prefixes property-sort-order
-        bottom: 100%;
-        left: initial;
-        right: -#{2 * $triangle-height};
-        top: initial;
-        -webkit-transform: translateX(0%) translateY(-13px);
-        transform: translateX(0%) translateY(-13px);
-        // sass-lint:enabled no-vendor-prefixes property-sort-order
-
-        &::before {
-          border: {
-            bottom: $triangle-height solid transparent;
-            left: $triangle-height solid transparent;
-            right: $triangle-height solid transparent;
-            top: $triangle-height solid $color-dark;
-          }
-          bottom: -#{2 * $triangle-height};
-          left: initial;
-          right: $sph-inner;
+        border: {
+          bottom: $triangle-height solid transparent;
+          left: $triangle-height solid $color-dark;
+          right: $triangle-height solid transparent;
+          top: $triangle-height solid transparent;
         }
-      }
-    }
-
-    // Right tooltip
-    &--right {
-      .p-tooltip__message {
         bottom: inherit;
         left: 100%;
         top: 50%;
-        // sass-lint:disable no-vendor-prefixes property-sort-order
-        -webkit-transform: translateX(14px) translateY(-50%);
-        transform: translateX(14px) translateY(-50%);
+        -webkit-transform: translateX(0) translateY(-50%);
+        transform: translateX(0) translateY(-50%);
         // sass-lint:enable no-vendor-prefixes property-sort-order
-
-        &::before {
-          // sass-lint:disable no-vendor-prefixes property-sort-order
-          border: {
-            bottom: $triangle-height solid transparent;
-            left: $triangle-height solid transparent;
-            right: $triangle-height solid $color-dark;
-            top: $triangle-height solid transparent;
-          }
-          bottom: inherit;
-          left: 0;
-          top: 50%;
-          -webkit-transform: translateX(-16px) translateY(-50%);
-          transform: translateX(-16px) translateY(-50%);
-          // sass-lint:enable no-vendor-prefixes property-sort-order
-        }
-      }
-    }
-
-    // Left tooltip
-    &--left {
-      .p-tooltip__message {
-        // sass-lint:disable no-vendor-prefixes property-sort-order
-        bottom: inherit;
-        left: -16px;
-        top: 50%;
-        -webkit-transform: translateX(-100%) translateY(-50%);
-        transform: translateX(-100%) translateY(-50%);
-        // sass-lint:enable no-vendor-prefixes property-sort-order
-
-        &::before {
-          // sass-lint:disable no-vendor-prefixes property-sort-order
-          border: {
-            bottom: $triangle-height solid transparent;
-            left: $triangle-height solid $color-dark;
-            right: $triangle-height solid transparent;
-            top: $triangle-height solid transparent;
-          }
-          bottom: inherit;
-          left: 100%;
-          top: 50%;
-          -webkit-transform: translateX(0) translateY(-50%);
-          transform: translateX(0) translateY(-50%);
-          // sass-lint:enable no-vendor-prefixes property-sort-order
-        }
       }
     }
   }


### PR DESCRIPTION
## Done

Unnested sass used solely to generate classnames.

e.g.:
```
.foo {
  color: #990000;

  &__bar {
    padding: 0;
  }
}
```
becomes:
```
.foo {
  color: #990000;
}

.foo__bar {
  padding: 0;
}
```

This was a decision taken following discussion in a developer catch up. Key benefits include:
- Full classnames are now searchable in files
- Nesting depths are reduced
- Generated CSS is closer to the source SASS, allowing more mindful CSS generation
  

Also fixed some class names that weren't proper BEM.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- See no visual differences

## Details

Fixes #2091 