### PR TITLE
Fix the docs sidebar width

### DIFF
--- a/docs/sass/styles.scss
+++ b/docs/sass/styles.scss
@@ -80,7 +80,7 @@ hr {
 .p-sidebar {
   background-color: $color-light;
   border-right: $border;
-  flex: 0 0 $sidebar-width;
+  flex: 0 0 18rem;
 
   @supports (position: sticky) {
     height: 100vh;


### PR DESCRIPTION
## Done
Fixed the docs sidebar width by swapping for a raw value instead of a setting which is used in the code numbered pattern. This is the only use of this variable so lets keep it simple. 

## QA
- Pull code
- Run `cd docs/`
- Run `./run serve --watch`
- Open http://0.0.0.0:8104/en/
- Check that the navigation has a decent width
- Check that the navigation continues to work on small screens

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/2258

## Screenshots
Before:
![Screenshot_2019-04-04 Home Vanilla framework](https://user-images.githubusercontent.com/1413534/55538770-17371300-56b7-11e9-9dea-87d387c6cbdb.png)

After:
![Screenshot_2019-04-04 Home Vanilla framework(1)](https://user-images.githubusercontent.com/1413534/55538792-20c07b00-56b7-11e9-927a-80420bb2c87c.png)

