### PR TITLE
Reverted the TOC classes

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "node-sass": "^4.5.3",
-    "vanilla-framework": "1.8.0",
+    "vanilla-framework": "1.8.1",
     "watch-cli": "^0.2.2"
   }
 }

--- a/docs/template.html
+++ b/docs/template.html
@@ -139,11 +139,11 @@
         </footer>
       </main>
       {% if toc_items %}
-      <aside id="side-content" class="p-table-of-contents">
+      <aside id="side-content" class="p-aside">
         {% if toc_items %}
-        <div class="p-table-of-contents__section">
-          <h4 class="p-table-of-contents__header">Contents</h4>
-          <nav class="p-table-of-contents__nav">
+        <div class="p-aside__section">
+          <h4 class="p-aside__header">Contents</h4>
+          <nav class="p-aside__nav">
             <ul class="p-list">
               {{ toc_items }}
             </ul>

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1223,9 +1223,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.8.0.tgz#b5aacc3ce60a521b8de8f160cb505807aadc7869"
+vanilla-framework@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.8.1.tgz#0d7f5885cdbd1355a9f9d42d7596f9a1258b27ea"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done
Reverted the TOC classes and bumped the version of Vanilla to v1.8.1

## QA
- Pull code
- Run `cd docs/`
- Run `./run serve --watch`
- Open http://0.0.0.0:8104/en/base/forms
- Check that the TOC is styled nicely and matched the screenshots in the issue.

## Details
Fixes https://github.com/vanilla-framework/vanilla-framework/issues/2260

