### PR TITLE
Add override to remove motion when the user has set prefer-reduced-motion

### DIFF
--- a/docs/en/settings/animation-settings.md
+++ b/docs/en/settings/animation-settings.md
@@ -46,6 +46,12 @@ include animation by including the animation mixin.
 @include animation(property: all, duration: brisk, easing: out);
 ```
 
+### Reduced motion
+
+Vanilla implements the [prefers-reduced-motion CSS media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) so that - in supported browsers and operating systems - users with an accessibility need or preference see reduced animation applied to page elements.
+
+Currently, Vanilla's implementation of this feature is a simple media query where both animations and transitions are set to `none !important` for all HTML elements. Nothing needs to be done to use this feature in your pages but we encourage using animations and transitions in a progressive manner so that your web sites and applications are usable without animations being present.
+
 ### Design
 
 For more information view the [animations design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Animations) which includes the specification in markdown format and a PNG image.

--- a/scss/_utilities_animations.scss
+++ b/scss/_utilities_animations.scss
@@ -1,5 +1,12 @@
 /// Animations
 @mixin vf-u-animations {
+  @media (prefers-reduced-motion: reduce) {
+    * {
+      animation: none !important;
+      transition: none !important;
+    }
+  }
+
   .u-animation--spin {
     // sass-lint:disable no-vendor-prefixes property-sort-order
     -webkit-animation: spin map-get($animation-duration, sleepy) infinite linear;


### PR DESCRIPTION
## Done

Added overrides to stop animations if the user has set the prefer-reduced-motion flag.

## QA

- Set the setting in your operating system - [Mac OS instructions](http://osxdaily.com/2018/12/17/how-reduce-motion-mac-disable-animations/)
- Check that you are using a [supported browser](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#Browser_compatibility)
- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/icons/icons-light/

## Details

Fixes #2116 