### PR TITLE
Swap the icons in accordions to the left

### DIFF
--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -24,14 +24,14 @@
 
     $calculated-height: $multi * $spv-inner--x-small * 2 + map-get($line-heights, default-text);
     background: {
-      position: top 50% right $sph-inner;
+      position: top 50% left $sph-inner;
       repeat: no-repeat;
     }
     background-color: inherit;
     border: 0;
     border-radius: 0;
     margin-bottom: 0;
-    padding-left: $sph-inner;
+    padding-left: $sph-inner--x-large;
     padding-right: $sph-inner;
     text-align: left;
     transition-duration: 0s;
@@ -54,7 +54,7 @@
     border-bottom: 1px solid $color-mid-light;
     margin: 0;
     overflow: auto; // include child margins into its height
-    padding-left: $sph-inner * 2;
+    padding-left: $sph-inner * 4;
 
     // Hides panel content
     &[aria-hidden='true'] {


### PR DESCRIPTION
## Done

Moved the icons to the left of the accordion pattern and modified padding to match

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/accordion/
- See that the icons are on the left and that padding looks good when expanded

## Details

Fixes #2008 
