### PR TITLE
Add a highlight to inline code elements

### DIFF
--- a/examples/base/code.html
+++ b/examples/base/code.html
@@ -8,3 +8,5 @@ category: _base
 Settings:
 maas_url=http://192.168.122.1:5240/MAAS</code>
 </pre>
+
+<p>The quick brown <code>fox&nbsp;jumps</code> over the lazy dog</p>

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -5,8 +5,12 @@
   code,
   samp,
   kbd {
+    background-color: $color-mid-x-light;
+    box-shadow: 0 0 0 0.25rem $color-mid-x-light;
     font-family: unquote($font-monospace);
     font-weight: 300;
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
     text-align: left;
   }
 
@@ -46,5 +50,12 @@
     text-align: left;
     text-shadow: none;
     white-space: pre;
+  }
+
+  pre code {
+    background: none;
+    box-shadow: none;
+    margin-left: 0;
+    margin-right: 0;
   }
 }


### PR DESCRIPTION
## Done

Added a highlight to inline code elements

## QA

- Pull code
- Run `./run serve --watch`
- http://0.0.0.0:8101/vanilla-framework/examples/base/code/
- See that the lower example matches the [spec](https://github.com/ubuntudesign/design-vanilla-framework/blob/master/Code/code.md)

## Details

Fixes #2040 